### PR TITLE
Filter Organizations for RegionalAdmin User Type

### DIFF
--- a/frontend/src/components/OrganizationList/OrganizationList.tsx
+++ b/frontend/src/components/OrganizationList/OrganizationList.tsx
@@ -26,7 +26,7 @@ export const OrganizationList: React.FC<{
     }
   };
 
-  const orgsUrl = getOrgsUrl() as String;
+  const orgsUrl = getOrgsUrl() as string;
 
   const orgCols: GridColDef[] = [
     { field: 'name', headerName: 'Organization', minWidth: 100, flex: 2 },

--- a/frontend/src/components/OrganizationList/OrganizationList.tsx
+++ b/frontend/src/components/OrganizationList/OrganizationList.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import EditNoteOutlinedIcon from '@mui/icons-material/EditNoteOutlined';
 import { Organization } from 'types';
 import { Alert, Box, Button, IconButton, Grid } from '@mui/material';
@@ -17,13 +17,16 @@ export const OrganizationList: React.FC<{
   const [dialogOpen, setDialogOpen] = useState(false);
   const history = useHistory();
   const regionId = user?.regionId;
-  let getOrgsURL: any;
 
-  if (user?.userType == 'regionalAdmin') {
-    getOrgsURL = `/organizations/regionId/${regionId}`;
-  } else {
-    getOrgsURL = `/v2/organizations/`;
-  }
+  const getOrgsUrl = () => {
+    if (user?.userType == 'regionalAdmin') {
+      return `/organizations/regionId/${regionId}`;
+    } else {
+      return `/v2/organizations/`;
+    }
+  };
+
+  const orgsUrl = getOrgsUrl() as String;
 
   const orgCols: GridColDef[] = [
     { field: 'name', headerName: 'Organization', minWidth: 100, flex: 2 },
@@ -69,7 +72,7 @@ export const OrganizationList: React.FC<{
 
   const fetchOrganizations = useCallback(async () => {
     try {
-      const rows = await apiGet<Organization[]>(getOrgsURL);
+      const rows = await apiGet<Organization[]>(orgsURL);
       // rows.forEach((obj) => {
       //   // obj.userCount = obj.userRoles.length;
       //   obj.tagNames = obj.tags.map((tag) => tag.name);
@@ -78,9 +81,9 @@ export const OrganizationList: React.FC<{
     } catch (e) {
       console.error(e);
     }
-  }, [apiGet, getOrgsURL]);
+  }, [apiGet, orgsURL]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!parent) fetchOrganizations();
     else {
       setOrganizations(parent.children);

--- a/frontend/src/components/OrganizationList/OrganizationList.tsx
+++ b/frontend/src/components/OrganizationList/OrganizationList.tsx
@@ -16,7 +16,14 @@ export const OrganizationList: React.FC<{
   const [organizations, setOrganizations] = useState<Organization[]>([]);
   const [dialogOpen, setDialogOpen] = useState(false);
   const history = useHistory();
-  const getOrgsURL = `/v2/organizations/`;
+  const regionId = user?.regionId;
+  let getOrgsURL: any;
+
+  if (user?.userType == 'regionalAdmin') {
+    getOrgsURL = `/organizations/regionId/${regionId}`;
+  } else {
+    getOrgsURL = `/v2/organizations/`;
+  }
 
   const orgCols: GridColDef[] = [
     { field: 'name', headerName: 'Organization', minWidth: 100, flex: 2 },

--- a/frontend/src/components/OrganizationList/OrganizationList.tsx
+++ b/frontend/src/components/OrganizationList/OrganizationList.tsx
@@ -72,7 +72,7 @@ export const OrganizationList: React.FC<{
 
   const fetchOrganizations = useCallback(async () => {
     try {
-      const rows = await apiGet<Organization[]>(orgsURL);
+      const rows = await apiGet<Organization[]>(orgsUrl);
       // rows.forEach((obj) => {
       //   // obj.userCount = obj.userRoles.length;
       //   obj.tagNames = obj.tags.map((tag) => tag.name);
@@ -81,7 +81,7 @@ export const OrganizationList: React.FC<{
     } catch (e) {
       console.error(e);
     }
-  }, [apiGet, orgsURL]);
+  }, [apiGet, orgsUrl]);
 
   useEffect(() => {
     if (!parent) fetchOrganizations();

--- a/frontend/src/components/OrganizationList/OrganizationList.tsx
+++ b/frontend/src/components/OrganizationList/OrganizationList.tsx
@@ -19,7 +19,7 @@ export const OrganizationList: React.FC<{
   const regionId = user?.regionId;
 
   const getOrgsUrl = () => {
-    if (user?.userType == 'regionalAdmin') {
+    if (user?.userType === 'regionalAdmin') {
       return `/organizations/regionId/${regionId}`;
     } else {
       return `/v2/organizations/`;


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #
Filter Organizations for RegionalAdmin User Type
## 🗣 Description ##
Closes #23 Filter Organizations for RegionalAdmin User Type in UI to make sure that regionalAdmin user types don't see all organizations.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
Leadership requests that regionalAdmin users shouldn't be able to see all organizations, but rather only organizations in their specific region.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
Confirm that regionalAdmin user types don't see all organizations, but rather only orgs in their region?
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
