### PR TITLE
Update content security policy to display NTAS iframe

### DIFF
--- a/backend/src/api/app.ts
+++ b/backend/src/api/app.ts
@@ -92,6 +92,9 @@ app.use(
           'https://api.staging-cd.crossfeed.cyber.dhs.gov'
           // Add any other allowed script sources here
         ],
+        frameSrc: [
+          'https://www.dhs.gov' // Add the URL for the iframe here
+        ],
         frameAncestors: ["'none'"]
         // Add other directives as needed
       }

--- a/backend/src/api/app.ts
+++ b/backend/src/api/app.ts
@@ -93,7 +93,7 @@ app.use(
           // Add any other allowed script sources here
         ],
         frameSrc: [
-          'https://www.dhs.gov' // Add the URL for the iframe here
+          'https://www.dhs.gov' // This allows iframes to load content from dhs.gov
         ],
         frameAncestors: ["'none'"]
         // Add other directives as needed

--- a/frontend/scripts/api.js
+++ b/frontend/scripts/api.js
@@ -34,6 +34,9 @@ app.use(
           'https://api.staging-cd.crossfeed.cyber.dhs.gov'
           // Add any other allowed script sources here
         ],
+        frameSrc: [
+          'https://www.dhs.gov' // Add the URL for the iframe here
+        ],
         frameAncestors: ["'none'"]
         // Add other directives as needed
       }

--- a/frontend/scripts/api.js
+++ b/frontend/scripts/api.js
@@ -35,7 +35,7 @@ app.use(
           // Add any other allowed script sources here
         ],
         frameSrc: [
-          'https://www.dhs.gov' // Add the URL for the iframe here
+          'https://www.dhs.gov' // This allows iframes to load content from dhs.gov
         ],
         frameAncestors: ["'none'"]
         // Add other directives as needed


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

- Added www.dhs.gov to the Content Security Policy 

## 💭 Motivation and context ##

Within the ReadySetCyber Dashboard footer, an Iframe has been added to display the National Terrorism Advisory System (NTAS) widget. This widget is displayed within a local environment, but once in staging it is prevented from loading by the content security policy.

This closes issue #242 
<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
