### PR TITLE
Add static 508 banner text for local dev builds and cleanup logging

### DIFF
--- a/backend/src/api/app.ts
+++ b/backend/src/api/app.ts
@@ -179,9 +179,6 @@ app.post('/auth/okta-callback', async (req, res) => {
   const clientId = process.env.REACT_APP_COGNITO_CLIENT_ID;
   const callbackUrl = process.env.REACT_APP_COGNITO_CALLBACK_URL;
   const domain = process.env.REACT_APP_COGNITO_DOMAIN;
-  console.log('Okta ClientID: ', clientId);
-  console.log('Okta CallbackURL: ', callbackUrl);
-  console.log('Okta Domain: ', domain);
 
   if (!code) {
     return res.status(400).json({ message: 'Missing authorization code' });
@@ -202,7 +199,6 @@ app.post('/auth/okta-callback', async (req, res) => {
       },
       body: tokenData
     });
-    console.log('Okta token response: ', response);
     const { id_token, access_token, refresh_token } = await response.json();
 
     if (!id_token) {
@@ -216,12 +212,6 @@ app.post('/auth/okta-callback', async (req, res) => {
 
     const cognitoUsername = decodedToken['cognito:username'];
     const oktaId = decodedToken['custom:OKTA_ID'];
-    console.log('Cognito Username:', cognitoUsername);
-    console.log('Cognito OKTA_ID:', oktaId);
-
-    console.log('ID Token:', id_token);
-    console.log('Decoded Token:', decodedToken);
-
     jwt.verify(
       id_token,
       auth.getOktaKey,

--- a/backend/src/api/auth.ts
+++ b/backend/src/api/auth.ts
@@ -166,7 +166,6 @@ export const callback = async (event, context) => {
     user.loginBlockedByMaintenance = loginBlocked;
     user.save();
   }
-  console.log(user);
 
   // If user does not exist, create it
   if (!user) {

--- a/backend/src/api/helpers.ts
+++ b/backend/src/api/helpers.ts
@@ -313,7 +313,6 @@ export const sendRegistrationApprovedEmail = async (
  */
 async function isMajorActiveMaintenance(): Promise<boolean> {
   const now = new Date();
-  console.log(now);
   try {
     // DB connection
     await connectToDatabase();

--- a/backend/src/api/notifications.ts
+++ b/backend/src/api/notifications.ts
@@ -111,8 +111,6 @@ export const list = wrapHandler(async (event) => {
     }
   });
 
-  console.log('Notification.find result: ', result);
-
   return {
     statusCode: 200,
     body: JSON.stringify(result)

--- a/backend/src/api/notifications.ts
+++ b/backend/src/api/notifications.ts
@@ -4,6 +4,18 @@ import { validateBody, wrapHandler, NotFound, Unauthorized } from './helpers';
 import { isGlobalWriteAdmin } from './auth';
 import S3Client from '../tasks/s3-client';
 
+// 508 Warning Banner S3 filename
+const bannerFileName = '508warningtext.txt';
+
+// Default 508 Warning Banner for local dev
+const default508Banner =
+  'CISA is committed to providing access for all individuals with disabilities, \
+  including members of the public and all employees. While this website is not \
+  yet fully accessible to users with disabilities as required by Section \
+  [508](https://cisa.gov/accessibility) federal law, CISA is working diligently \
+  to resolve those issues. If you experience accessibility issues, please email \
+  [TOC@mail.cisa.dhs.gov](mailto:TOC@mail.cisa.dhs.gov) for assistance.';
+
 class NewNotification {
   @IsDateString()
   startDatetime?: string;
@@ -161,16 +173,28 @@ export const update = wrapHandler(async (event) => {
  *    - Notifications
  */
 export const get508Banner = wrapHandler(async () => {
-  const bannerFileName = '508warningtext.txt';
+  // Return hardcoded banner for local builds
+  if (process.env.IS_LOCAL) {
+    console.log('Using default banner for 508 warning: ', default508Banner);
+    // API Response
+    return {
+      statusCode: 200,
+      body: JSON.stringify(default508Banner)
+    };
+  }
+
+  // Handle normal S3 logic
   try {
     const client = new S3Client();
     const bannerResult = await client.getEmailAsset(bannerFileName);
+    // API Response
     return {
       statusCode: 200,
       body: JSON.stringify(bannerResult)
     };
   } catch (error) {
     console.log('S3 Banner Error: ', error);
+    // API Error Response
     return {
       statusCode: 500,
       body: 'Error retrieving file from S3. See details in logs.'


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #
Return a hardcoded 508 compliance warning banner for local dev builds instead of pulling from s3 bucket. Cleanup old console.logs that were no longer needed.

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
It was decided to use this solution over providing individual AWS access keys.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
Make sure local .env file includes:

`IS_LOCAL=1`


Login to localhost as usual and you should see the banner without access keys setup. To confirm that it's using the hardcoded value, check the backend container log output to be sure that` 

`Using default banner for 508 warning: ` 

is displayed.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
