### PR TITLE
Fix local build-worker for M2 machines

### DIFF
--- a/backend/tools/build-worker.sh
+++ b/backend/tools/build-worker.sh
@@ -6,6 +6,6 @@
 
 set -e
 
-docker build -t crossfeed-worker -f Dockerfile.worker .
+docker build --platform linux/amd64 -t crossfeed-worker -f Dockerfile.worker .
 
-docker build -t pe-worker -f Dockerfile.pe .
+docker build --platform linux/amd64 -t pe-worker -f Dockerfile.pe .


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Specify the platform when building the worker containers.

"When we run a docker image on an Apple laptop with a silicon chip (like M1, M2 or M3), by default it'll use the [ARM64 architecture](https://en.wikipedia.org/wiki/ARM_architecture_family) instead of [x86_64](https://en.wikipedia.org/wiki/X86-64) architecture.

This will cause issues when you try to run a docker image that is built for x86_64 architecture or on a platform that is not ARM64."

https://nesin.io/blog/x86-x86-amd64-docker-mac

## 💭 Motivation and context ##

The M2 macbooks are failing to build the worker images `npm run build-worker`

## 🧪 Testing ##

Tested npm run build-worker on the Intel and M2 Macbooks

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Revert dependencies to default branches.
- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release.
