### PR TITLE
Increased contrast of Save Search in Search Results (CRASM- 373)

### DIFF
--- a/frontend/src/pages/Search/Styling/sortBarStyle.ts
+++ b/frontend/src/pages/Search/Styling/sortBarStyle.ts
@@ -31,7 +31,7 @@ export const Root = styled('div')(({ theme }) => ({
     alignItems: 'center',
     justifyContent: 'space-between',
     padding: '0.2rem 1rem 0.5rem 1rem',
-    color: '#71767A',
+    color: '#4e4e4e',
     margin: '0.5rem 0',
     boxShadow: ({ isFixed }: Props) =>
       isFixed ? '0px 1px 2px rgba(0, 0, 0, 0.15)' : 'none',
@@ -39,7 +39,7 @@ export const Root = styled('div')(({ theme }) => ({
     '& button': {
       outline: 'none',
       border: 'none',
-      color: '#71767A',
+      color: '#4e4e4e',
       background: 'none',
       cursor: 'pointer',
       textDecoration: 'underline'
@@ -64,7 +64,7 @@ export const Root = styled('div')(({ theme }) => ({
       display: 'block',
       fontSize: '1rem',
       fontWeight: 600,
-      color: '#71767A'
+      color: '#4e4e4e'
     }
   },
 
@@ -80,12 +80,12 @@ export const Root = styled('div')(({ theme }) => ({
     fontWeight: 600,
     fontSize: 14,
     padding: 0,
-    color: '#71767A'
+    color: '#4e4e4e'
   },
 
   [`& .${classes.option}`]: {
     fontWeight: 600,
     fontSize: 14,
-    color: '#71767A'
+    color: '#4e4e4e'
   }
 }));


### PR DESCRIPTION
Increased contrast of Save Search, Sort Menu, and Sort Arrow in Sort Bar above Search Results.
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
- Changed color of text and icons to #4E4E4E to achieve a contrast ration of 7.35:1 against the background color of #EFF1F5

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
- 508 Compliance
- Achieve a contrast ration of 4.5:1 or higher.
- Closes #342 
- Closes CRASM-373
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


## 📷 Screenshots (if appropriate) ##

![Screenshot 2024-06-26 at 2 09 22 PM](https://github.com/cisagov/XFD/assets/123108455/9b4c99cd-de3f-444c-aff6-deca4c7a31a2)
![Screenshot 2024-06-26 at 2 11 18 PM](https://github.com/cisagov/XFD/assets/123108455/317f7f4b-cf92-4b2f-b52f-f339ab825a26)




## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
