### PR TITLE
Remove outdated export functionality

### DIFF
--- a/frontend/src/components/ImportExport/ImportExport.tsx
+++ b/frontend/src/components/ImportExport/ImportExport.tsx
@@ -12,6 +12,8 @@ interface ImportProps<T> {
 
   // Callback that handles data on import (usually saves the data).
   onImport: (e: T[]) => void;
+
+  fieldsToImport: string[];
 }
 
 export interface ExportProps<T> {
@@ -25,11 +27,11 @@ export interface ExportProps<T> {
   getDataToExport: () => Partial<T>[] | Promise<Partial<T>[]> | Promise<string>;
 }
 
-interface ImportExportProps<T> extends ImportProps<T>, ExportProps<T> {}
+// interface ImportExportProps<T> extends ImportProps<T>, ExportProps<T> {}
 
 export const Import = <T extends object>(props: ImportProps<T>) => {
   const { setLoading } = useAuthContext();
-  const { name, onImport } = props;
+  const { name, onImport, fieldsToImport } = props;
   const [selectedFile, setSelectedFile] = React.useState<File | null>(null);
   const [results, setResults] = React.useState<T[] | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -83,8 +85,8 @@ export const Import = <T extends object>(props: ImportProps<T>) => {
       <h2>Import {name}</h2>
       <FormGroup>
         <Label htmlFor="import">
-          File must be in a CSV format, with the same header as the exported
-          file.
+          File must be in a CSV format, header must include the following
+          fields: <br /> {fieldsToImport.join(', ')}
         </Label>
         <FileInput
           key={key}
@@ -141,32 +143,11 @@ export const exportCSV = async <T extends object>(
   setLoading((l) => l - 1);
 };
 
-export const Export = <T extends object>(props: ExportProps<T>) => {
-  const { setLoading } = useAuthContext();
-  return (
-    <form>
-      <h2>Export {props.name}</h2>
-      <Button
-        type="button"
-        outline
-        onClick={() => exportCSV(props, setLoading)}
-      >
-        Export as CSV
-      </Button>
-    </form>
-  );
-};
-
-export const ImportExport = <T extends object>(props: ImportExportProps<T>) => {
-  const { name, onImport, getDataToExport, fieldsToExport } = props;
+export const ImportExport = <T extends object>(props: ImportProps<T>) => {
+  const { name, onImport, fieldsToImport } = props;
   return (
     <>
-      <Import name={name} onImport={onImport} />
-      <Export
-        name={name}
-        fieldsToExport={fieldsToExport}
-        getDataToExport={getDataToExport}
-      />
+      <Import name={name} onImport={onImport} fieldsToImport={fieldsToImport} />
     </>
   );
 };

--- a/frontend/src/pages/Organizations/Organizations.tsx
+++ b/frontend/src/pages/Organizations/Organizations.tsx
@@ -59,7 +59,7 @@ export const Organizations: React.FC = () => {
           <>
             <ImportExport<Organization>
               name="organizations"
-              fieldsToExport={[
+              fieldsToImport={[
                 'name',
                 'acronym',
                 'rootDomains',
@@ -105,15 +105,6 @@ export const Organizations: React.FC = () => {
                 setOrganizations(organizations.concat(...createdOrganizations));
                 window.location.reload();
               }}
-              getDataToExport={() =>
-                organizations.map(
-                  (org) =>
-                    ({
-                      ...org,
-                      tags: org.tags.map((tag) => tag.name)
-                    }) as any
-                )
-              }
             />
           </>
         )}

--- a/frontend/src/pages/Scans/ScansView.tsx
+++ b/frontend/src/pages/Scans/ScansView.tsx
@@ -298,7 +298,7 @@ const ScansView: React.FC = () => {
       ></ScanForm>
       <ImportExport<Scan>
         name="scans"
-        fieldsToExport={['name', 'arguments', 'frequency']}
+        fieldsToImport={['name', 'arguments', 'frequency']}
         onImport={async (results) => {
           // TODO: use a batch call here instead.
           const createdScans = [];
@@ -318,12 +318,6 @@ const ScansView: React.FC = () => {
           }
           setScans(scans.concat(...createdScans));
         }}
-        getDataToExport={() =>
-          scans.map((scan) => ({
-            ...scan,
-            arguments: JSON.stringify(scan.arguments)
-          }))
-        }
       />
 
       <Modal ref={deleteModalRef} id="deleteModal">

--- a/frontend/src/pages/Users/Users.tsx
+++ b/frontend/src/pages/Users/Users.tsx
@@ -571,7 +571,7 @@ export const Users: React.FC = () => {
               }
           >
             name="users"
-            fieldsToExport={[
+            fieldsToImport={[
               'firstName',
               'lastName',
               'email',
@@ -603,17 +603,6 @@ export const Users: React.FC = () => {
               }
               setUsers(users.concat(...createdUsers));
             }}
-            getDataToExport={() =>
-              users.map((user) => ({
-                ...user,
-                roles: JSON.stringify(
-                  user.roles.map((role) => ({
-                    organization: role.organization.id,
-                    role: role.role
-                  }))
-                )
-              }))
-            }
           />
         </>
       )}


### PR DESCRIPTION
Remove outdated export functionality

## 🗣 Description ##
This PR removes the outdated export functionality from Organizations, Scans and Users management pages
## 💭 Motivation and context ##
Old export functionality was not functioning correctly for all pages and has been replaced by the new paginated displays, which has its own export capabilities. We want to remove this functionality while maintaining the import capabilities

## 🧪 Testing ##
Tested locally
## 📷 Screenshots (if appropriate) ##
<img width="1572" alt="image" src="https://github.com/cisagov/XFD/assets/79864006/5ff6a6f3-3326-4896-816d-2dcc2e44aba7">

## ✅ Pre-approval checklist ##

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - *eschew scope creep!*
- [X] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [X] All relevant type-of-change labels have been added.
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [X] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.

