### PR TITLE
Resolved keyboard navigation of Responsive Bar graphs in Overview (CRASM-416)

### DIFF
--- a/frontend/src/pages/Risk/TopVulnerableDomains.tsx
+++ b/frontend/src/pages/Risk/TopVulnerableDomains.tsx
@@ -51,11 +51,11 @@ const TopVulnerableDomains = (props: { data: Point[] }) => {
   const dataVal = Object.keys(domainToSevMap)
     .map((key) => ({
       label: key,
-      total: domainTotals[key],
+      Total: domainTotals[key],
       ...domainToSevMap[key]
     }))
     .sort((a, b) => {
-      let diff = b.total - a.total;
+      let diff = b.Total - a.Total;
       if (diff === 0) {
         for (const label of sevLabels) {
           diff += (label in b ? b[label] : 0) - (label in a ? a[label] : 0);
@@ -83,16 +83,17 @@ const TopVulnerableDomains = (props: { data: Point[] }) => {
           fill={bar.color}
           tabIndex={0}
           aria-label={`Port - ${bar.data.indexValue}: ${bar.data.value}`}
-          onClick={(e) => {
+          onClick={() => {
             console.log('clicked label value: ', bar);
             history.push(
-              `/inventory?filters[0][field]=services.port&filters[0][values][0]=n_${bar.data.indexValue}_n&filters[0][type]=any`
+              `/inventory/vulnerabilities?domain=${bar.data.label}&severity=${bar.data.id}`
             );
-            window.location.reload();
           }}
         />
         <title>
-          Port - {bar.data.indexValue}: {bar.data.value}
+          {bar.data.value} {bar.data.id}{' '}
+          {bar.data.value > 1 ? 'vulnerabilites' : 'vulnerability'} in domain{' '}
+          {bar.data.indexValue}
         </title>
       </g>
     ));
@@ -136,7 +137,7 @@ const TopVulnerableDomains = (props: { data: Point[] }) => {
               tabIndex={0}
               data={dataVal as any}
               //If all vuln is selected, only show total vulns
-              keys={allVuln ? ['total'] : keys}
+              keys={allVuln ? ['Total'] : keys}
               layers={['grid', 'axes', CustomBarLayer, 'markers', 'legends']}
               indexBy="label"
               margin={{
@@ -155,11 +156,11 @@ const TopVulnerableDomains = (props: { data: Point[] }) => {
                   }
                 }
               }}
-              onClick={(event) => {
-                history.push(
-                  `/inventory/vulnerabilities?domain=${event.data.label}&severity=${event.id}`
-                );
-              }}
+              // onClick={(event) => {
+              //   history.push(
+              //     `/inventory/vulnerabilities?domain=${event.data.label}&severity=${event.id}`
+              //   );
+              // }}
               padding={0.5}
               //If all vuln is selected, only show color for total vulns
               colors={allVuln ? getAllVulnColor : (getSeverityColor as any)}

--- a/frontend/src/pages/Risk/TopVulnerableDomains.tsx
+++ b/frontend/src/pages/Risk/TopVulnerableDomains.tsx
@@ -84,7 +84,6 @@ const TopVulnerableDomains = (props: { data: Point[] }) => {
           tabIndex={0}
           aria-label={`Port - ${bar.data.indexValue}: ${bar.data.value}`}
           onClick={() => {
-            console.log('clicked label value: ', bar);
             history.push(
               `/inventory/vulnerabilities?domain=${bar.data.label}&severity=${bar.data.id}`
             );
@@ -156,11 +155,6 @@ const TopVulnerableDomains = (props: { data: Point[] }) => {
                   }
                 }
               }}
-              // onClick={(event) => {
-              //   history.push(
-              //     `/inventory/vulnerabilities?domain=${event.data.label}&severity=${event.id}`
-              //   );
-              // }}
               padding={0.5}
               //If all vuln is selected, only show color for total vulns
               colors={allVuln ? getAllVulnColor : (getSeverityColor as any)}

--- a/frontend/src/pages/Risk/TopVulnerableDomains.tsx
+++ b/frontend/src/pages/Risk/TopVulnerableDomains.tsx
@@ -8,7 +8,8 @@ import {
   sevLabels,
   resultsPerPage,
   getSeverityColor,
-  severities
+  severities,
+  getAllVulnColor
 } from './utils';
 import * as RiskStyles from './style';
 import { Pagination } from '@mui/lab';
@@ -31,7 +32,9 @@ const TopVulnerableDomains = (props: { data: Point[] }) => {
   const [labels, setLabels] = useState(sevLabels);
   const keys = sevLabels;
   const pageStart = (current - 1) * resultsPerPage;
-  // Separate count by severity
+  // Store for count by total vulns
+  const domainTotals: { [key: string]: number } = {};
+  // Separate count by severity but also store total vulns
   const domainToSevMap: any = {};
   for (const point of data) {
     const split = point.id.split('|');
@@ -39,24 +42,61 @@ const TopVulnerableDomains = (props: { data: Point[] }) => {
     const severity = split[1];
     if (labels.includes(severity)) {
       if (!(domain in domainToSevMap)) domainToSevMap[domain] = {};
+      if (!(domain in domainTotals)) domainTotals[domain] = 0;
       domainToSevMap[domain][severity] = point.value;
+      domainTotals[domain] += point.value;
     }
   }
   const domainsWithVulns = Object.keys(domainToSevMap).length;
   const dataVal = Object.keys(domainToSevMap)
     .map((key) => ({
       label: key,
+      total: domainTotals[key],
       ...domainToSevMap[key]
     }))
     .sort((a, b) => {
-      let diff = 0;
-      for (const label of sevLabels) {
-        diff += (label in b ? b[label] : 0) - (label in a ? a[label] : 0);
+      let diff = b.total - a.total;
+      if (diff === 0) {
+        for (const label of sevLabels) {
+          diff += (label in b ? b[label] : 0) - (label in a ? a[label] : 0);
+          if (diff !== 0) break;
+        }
       }
       return diff;
     })
     .slice(pageStart, Math.min(pageStart + 30, domainsWithVulns))
     .reverse();
+  // Check if all vuln labels are selected
+  const allVuln = labels.length === 5;
+  //Custom Bar Layer to allow for top to bottom tab navigation
+  const CustomBarLayer = ({ bars }: { bars: any[]; [key: string]: any }) => {
+    const reversedBars = [...bars].reverse();
+    return reversedBars.map((bar) => (
+      <g key={bar.key}>
+        <rect
+          role="button"
+          key={bar.key}
+          x={bar.x}
+          y={bar.y}
+          width={bar.width}
+          height={bar.height}
+          fill={bar.color}
+          tabIndex={0}
+          aria-label={`Port - ${bar.data.indexValue}: ${bar.data.value}`}
+          onClick={(e) => {
+            console.log('clicked label value: ', bar);
+            history.push(
+              `/inventory?filters[0][field]=services.port&filters[0][values][0]=n_${bar.data.indexValue}_n&filters[0][type]=any`
+            );
+            window.location.reload();
+          }}
+        />
+        <title>
+          Port - {bar.data.indexValue}: {bar.data.value}
+        </title>
+      </g>
+    ));
+  };
   // create the total vuln labels for each domain
   return (
     <div className={cardBig}>
@@ -93,9 +133,11 @@ const TopVulnerableDomains = (props: { data: Point[] }) => {
               <h5 style={{ textAlign: 'right', paddingLeft: 0 }}>Total</h5>
             </div>
             <ResponsiveBar
+              tabIndex={0}
               data={dataVal as any}
-              keys={keys}
-              layers={['grid', 'axes', 'bars', 'markers', 'legends']}
+              //If all vuln is selected, only show total vulns
+              keys={allVuln ? ['total'] : keys}
+              layers={['grid', 'axes', CustomBarLayer, 'markers', 'legends']}
               indexBy="label"
               margin={{
                 top: 10,
@@ -119,7 +161,8 @@ const TopVulnerableDomains = (props: { data: Point[] }) => {
                 );
               }}
               padding={0.5}
-              colors={getSeverityColor as any}
+              //If all vuln is selected, only show color for total vulns
+              colors={allVuln ? getAllVulnColor : (getSeverityColor as any)}
               borderColor={{ from: 'color', modifiers: [['darker', 1.6]] }}
               axisTop={null}
               axisRight={null}
@@ -153,6 +196,7 @@ const TopVulnerableDomains = (props: { data: Point[] }) => {
               enableLabel={false}
               isFocusable={true}
               layout={'horizontal'}
+              // reverse={true}
               motionDamping={15}
               {...({ motionStiffness: 90 } as any)}
             />

--- a/frontend/src/pages/Risk/TopVulnerableDomains.tsx
+++ b/frontend/src/pages/Risk/TopVulnerableDomains.tsx
@@ -66,7 +66,7 @@ const TopVulnerableDomains = (props: { data: Point[] }) => {
     })
     .slice(pageStart, Math.min(pageStart + 30, domainsWithVulns))
     .reverse();
-  // Check if all vuln labels are selected
+  // Repurposes the "All" chip to show total vulns vs aggregate
   const allVuln = labels.length === 5;
   //Custom Bar Layer to allow for top to bottom tab navigation
   const CustomBarLayer = ({ bars }: { bars: any[]; [key: string]: any }) => {
@@ -82,7 +82,11 @@ const TopVulnerableDomains = (props: { data: Point[] }) => {
           height={bar.height}
           fill={bar.color}
           tabIndex={0}
-          aria-label={`Port - ${bar.data.indexValue}: ${bar.data.value}`}
+          aria-label={` ${bar.data.value} ${bar.data.id}${' '}
+          ${
+            bar.data.value > 1 ? 'vulnerabilites' : 'vulnerability'
+          } in domain${' '}
+          ${bar.data.indexValue}`}
           onClick={() => {
             history.push(
               `/inventory/vulnerabilities?domain=${bar.data.label}&severity=${bar.data.id}`

--- a/frontend/src/pages/Risk/TopVulnerablePorts.tsx
+++ b/frontend/src/pages/Risk/TopVulnerablePorts.tsx
@@ -5,11 +5,43 @@ import { useHistory } from 'react-router-dom';
 import { getSingleColor } from './utils';
 import * as RiskStyles from './style';
 import { Paper } from '@mui/material';
+
 const TopVulnerablePorts = (props: { data: Point[] }) => {
+  const CustomBarLayer = ({ bars }: { bars: any[]; [key: string]: any }) => {
+    const reversedBars = [...bars].reverse();
+    return reversedBars.map((bar) => (
+      <g key={bar.key}>
+        <rect
+          role="button"
+          key={bar.key}
+          x={bar.x}
+          y={bar.y}
+          width={bar.width}
+          height={bar.height}
+          fill={bar.color}
+          tabIndex={0}
+          aria-label={`Port - ${bar.data.indexValue}: ${bar.data.value}`}
+          onClick={(e) => {
+            console.log('clicked label value: ', bar);
+            history.push(
+              `/inventory?filters[0][field]=services.port&filters[0][values][0]=n_${bar.data.indexValue}_n&filters[0][type]=any`
+            );
+            window.location.reload();
+          }}
+        />
+        <title>
+          Port - {bar.data.indexValue}: {bar.data.value}
+        </title>
+      </g>
+    ));
+  };
   const history = useHistory();
   const { data } = props;
   const { cardRoot, cardSmall, header, chartSmall } = RiskStyles.classesRisk;
-  const dataVal = data.map((e) => ({ ...e, [['Port'][0]]: e.value })) as any;
+  const reversedData = [...data].reverse();
+  const dataVal = data
+    .reverse()
+    .map((e) => ({ ...e, [['Port'][0]]: e.value })) as any;
   return (
     <Paper elevation={0} className={cardRoot}>
       <div className={cardSmall}>
@@ -20,7 +52,7 @@ const TopVulnerablePorts = (props: { data: Point[] }) => {
           <ResponsiveBar
             data={dataVal as any}
             keys={['Port']}
-            layers={['grid', 'axes', 'bars']}
+            layers={['grid', 'axes', CustomBarLayer]}
             indexBy="label"
             margin={{ top: 30, right: 40, bottom: 75, left: 100 }}
             theme={{
@@ -34,6 +66,7 @@ const TopVulnerablePorts = (props: { data: Point[] }) => {
               }
             }}
             onClick={(event) => {
+              console.log('clicked label value: ', event.data.label);
               history.push(
                 `/inventory?filters[0][field]=services.port&filters[0][values][0]=n_${event.data.label}_n&filters[0][type]=any`
               );

--- a/frontend/src/pages/Risk/TopVulnerablePorts.tsx
+++ b/frontend/src/pages/Risk/TopVulnerablePorts.tsx
@@ -38,7 +38,6 @@ const TopVulnerablePorts = (props: { data: Point[] }) => {
   const history = useHistory();
   const { data } = props;
   const { cardRoot, cardSmall, header, chartSmall } = RiskStyles.classesRisk;
-  const reversedData = [...data].reverse();
   const dataVal = data
     .reverse()
     .map((e) => ({ ...e, [['Port'][0]]: e.value })) as any;

--- a/frontend/src/pages/Risk/utils.ts
+++ b/frontend/src/pages/Risk/utils.ts
@@ -4,6 +4,9 @@ export const resultsPerPage = 30;
 export const getSingleColor = () => {
   return '#F23AB8';
 };
+export const getAllVulnColor = () => {
+  return '#ce80ed';
+};
 export const getSeverityColor = ({ id }: { id: string }) => {
   if (id === 'null' || id === '') return '#EFF1F5';
   else if (id === 'Low') return '#ffe100';


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #
- Refactored Top Vulnerable Domains' responsive bar graph to display a simple total vulnerability count vs the more elaborate pre-existing aggregate count.
- This combined with a custom bar layer resolved issues where a keyboard user could not tab through the respective graphs in a uniform top to bottom manner.
- The custom bar layer was also applied to the Top Vulnerable Ports' bar graph as well.
## 🗣 Description ##
- Refactored domainToSev map to include a store for total vulnerabilities count in Top Domains
- Refactored dataVal to include a key for the total vulnerabilities count in Top Domains
- Created Custom Bar Layer to allow top to bottom keyboard navigation on Top Domains.
- Created Custom Bar Layer to allow top to bottom keyboard navigation in Top Ports
- Created getAllVulnColor function to return color for bars based on the total vulnerabilities count.
- Edited responsive bar keys to be based off total vulnerabilities count if labels were set to All.
- Created custom tooltips to display bar info for mouse users.
- Added appropriate aria-labels

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
- 508 Compliance
- Closes #436 
- Closes CRASM-416
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->


## 📷 Screenshots (if appropriate) ##


![Screenshot 2024-07-15 at 6 39 11 PM](https://github.com/user-attachments/assets/cb80995d-d580-4355-a158-c194e6fcbe40)
![Screenshot 2024-07-15 at 6 40 02 PM](https://github.com/user-attachments/assets/9d86ac62-0daa-4b55-b329-48dc9c636701)
![Screenshot 2024-07-15 at 6 40 45 PM](https://github.com/user-attachments/assets/f60f0269-5d2a-4f14-b511-6dd9bcb2ba0d)



## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
