### PR TITLE
Removes filter counts in UI dashboard to make search experience less confusing

### DIFF
--- a/frontend/src/components/FacetFilter.tsx
+++ b/frontend/src/components/FacetFilter.tsx
@@ -52,7 +52,7 @@ export const FacetFilter: React.FC<Props> = (props) => {
               label={
                 <>
                   <span>{opt.value}</span>
-                  <OptionTotal count={opt.count} />
+                  {/* <OptionTotal count={opt.count} /> */}
                 </>
               }
             />

--- a/frontend/src/components/FacetFilter.tsx
+++ b/frontend/src/components/FacetFilter.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { FormGroup, FormControlLabel, Checkbox } from '@mui/material';
 import { styled } from '@mui/material/styles';
 

--- a/frontend/src/components/FacetFilter.tsx
+++ b/frontend/src/components/FacetFilter.tsx
@@ -24,10 +24,6 @@ export const FacetFilter: React.FC<Props> = (props) => {
     }
   };
 
-  const OptionTotal = memo(({ count }: { count: number }) => {
-    return <span className={classes.count}>{count}</span>;
-  });
-
   const fixedOptions = useMemo(() => {
     return options;
     // NOTE: Desired functionality is to calculate on mount - Update deps and remove the below rule if this changes
@@ -52,7 +48,6 @@ export const FacetFilter: React.FC<Props> = (props) => {
               label={
                 <>
                   <span>{opt.value}</span>
-                  {/* <OptionTotal count={opt.count} /> */}
                 </>
               }
             />


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

- Removed the count for each filter within the Inventory/Search UI

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

Resolves [CRASM-330](https://maestro.dhs.gov/jira/browse/CRASM-330)

Justification for solution

After updating the filters to not change as of [PR-447](https://github.com/cisagov/XFD/pull/447) which resolved [CRASM-329](https://maestro.dhs.gov/jira/browse/CRASM-329). I looked into how our search works, and believe that this part of the UI seems unintuitive due to the following:
- The user may expect the sum of the numbers next to the active filters to equal the total number of results shown at the bottom of the page. 
- The numbers shown for each filter is a representation of how many results match that filter, but this is not strictly inclusive. (ie selecting ports 22 and 80 will return results for any records containing only port 22, only port 80 and results with both port 22 and 80).
- We could update the search process to return results that match exactly the search filters. (ie return results that only have port 22 and port 80. This however seems less intuitive as the user may expect to see any combination.

Based on this and after looking into our search implementation, it seemed that the best solution at this time is to remove the counts shown next to each filter. Below I have snips displaying before and after





## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


## 📷 Screenshots (if appropriate) ##

Before change
<img width="1282" alt="Screenshot 2024-07-17 at 10 25 06 AM" src="https://github.com/user-attachments/assets/0b700d73-5358-4b4e-ba85-6bbe6b1bd577">

After change
<img width="1286" alt="Screenshot 2024-07-17 at 10 27 33 AM" src="https://github.com/user-attachments/assets/3955376a-6e9f-4b4d-9a26-bf2238fb13ea">




## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
