### PR TITLE
Modified the last-logged-in feature to indicate accurate date and time. (CRASM-391)

### DIFF
--- a/frontend/src/pages/Users/Users.tsx
+++ b/frontend/src/pages/Users/Users.tsx
@@ -117,7 +117,6 @@ export const Users: React.FC = () => {
           : 'None';
         row.fullName = `${row.firstName} ${row.lastName}`;
       });
-      console.log(rows);
       if (user?.userType === 'globalAdmin') {
         setUsers(rows);
       } else if (user?.userType === 'regionalAdmin' && user?.regionId) {

--- a/frontend/src/pages/Users/Users.tsx
+++ b/frontend/src/pages/Users/Users.tsx
@@ -27,7 +27,7 @@ import { ImportExport } from 'components';
 import { initializeUser, Organization, User } from 'types';
 import { useAuthContext } from 'context';
 import { STATE_OPTIONS } from '../../constants/constants';
-import { formatDistanceToNow, parseISO } from 'date-fns';
+import { parseISO, format } from 'date-fns';
 
 type ErrorStates = {
   getUsersError: string;
@@ -104,10 +104,10 @@ export const Users: React.FC = () => {
       const rows = await apiGet<UserType[]>(`/users/`);
       rows.forEach((row) => {
         row.lastLoggedInString = row.lastLoggedIn
-          ? `${formatDistanceToNow(parseISO(row.lastLoggedIn))} ago`
+          ? format(parseISO(row.lastLoggedIn), "MM-dd-yyyy 'at' hh:mm a")
           : 'None';
         row.dateToUSigned = row.dateAcceptedTerms
-          ? `${formatDistanceToNow(parseISO(row.dateAcceptedTerms))} ago`
+          ? format(parseISO(row.dateAcceptedTerms), "MM-dd-yyyy 'at' hh:mm a")
           : 'None';
         row.orgs = row.roles
           ? row.roles
@@ -117,6 +117,7 @@ export const Users: React.FC = () => {
           : 'None';
         row.fullName = `${row.firstName} ${row.lastName}`;
       });
+      console.log(rows);
       if (user?.userType === 'globalAdmin') {
         setUsers(rows);
       } else if (user?.userType === 'regionalAdmin' && user?.regionId) {
@@ -199,7 +200,7 @@ export const Users: React.FC = () => {
       field: 'lastLoggedInString',
       headerName: 'Last Logged In',
       minWidth: 100,
-      flex: 0.75
+      flex: 1
     },
     {
       field: 'edit',


### PR DESCRIPTION
## 🗣 Description ##

Last-logged-in showed estimated "ago" time, In order to display accurate date and time, "formatDistanceToNow" was replaced with "parseISO" format.

## 💭 Motivation and context ##

closes #471 
closes CRASM-391

## 🧪 Testing ##
Local

## 📷 Screenshots (if appropriate) ##
![Screenshot 2024-07-23 at 2 19 55 PM](https://github.com/user-attachments/assets/41b39ad0-1bb2-43f7-9580-07dcb3ca052b)


## Prior to implementation ##
![Screenshot 2024-07-23 at 9 02 09 AM](https://github.com/user-attachments/assets/8a19094e-7eac-405c-97d1-ac57af69e078)

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
