### PR TITLE
Remove default values to trigger state selection

### DIFF
--- a/backend/src/api/app.ts
+++ b/backend/src/api/app.ts
@@ -234,10 +234,7 @@ app.post('/auth/okta-callback', async (req, res) => {
             oktaId: oktaId,
             firstName: decodedToken.given_name,
             lastName: decodedToken.family_name,
-            invitePending: true,
-            // TODO: Replace these default Region/State values with user selection
-            state: 'Virginia',
-            regionId: '3'
+            invitePending: true
           });
           await user.save();
         } else {


### PR DESCRIPTION
Resolves CRASM-558 Allows state selection on new user creation if one does not exist.

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
Removes default state values to prompt the state selection screen on login if a user doesn't have the value populated.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
CRASM-558
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
Register for a new user in login.gov or remove existing users state/region value and you should be prompted with the screenshot on login if the state/region values are missing. After state is selected, the region will automatically be set as well in the database.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) #

Uncomment this section if a screenshot is needed.

-->
![Screenshot 2024-09-04 at 10 44 43 AM](https://github.com/user-attachments/assets/adbde7c9-6883-4835-87e8-e8bbff7dbdd1)

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
