### PR TITLE
Changed Text Alignment of Buttons in Orgs Autocomplete (CRASM-745)

### DIFF
--- a/frontend/src/components/RegionAndOrganizationFilters.tsx
+++ b/frontend/src/components/RegionAndOrganizationFilters.tsx
@@ -309,7 +309,7 @@ export const RegionAndOrganizationFilters: React.FC<
                         height: '100%',
                         width: '100%',
                         display: 'flex',
-                        justifyContent: 'start',
+                        justifyContent: 'left',
                         fontWeight: 400,
                         color: 'black',
                         textTransform: 'none'

--- a/frontend/src/components/RegionAndOrganizationFilters.tsx
+++ b/frontend/src/components/RegionAndOrganizationFilters.tsx
@@ -309,11 +309,13 @@ export const RegionAndOrganizationFilters: React.FC<
                         height: '100%',
                         width: '100%',
                         display: 'flex',
-                        justifyContent: 'left',
+                        textAlign: 'left',
+                        justifyContent: 'start',
                         fontWeight: 400,
                         color: 'black',
                         textTransform: 'none'
                       }}
+                      id="search-org-button"
                       onClick={() =>
                         setTimeout(() => {
                           handleAddOrganization(option);


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
- Added textAlign "left" to button elements inside of Autocomplete li.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
- Closes #669
- Closes CRASM-745 
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
- This bug does not show up in local unless you add a sufficiently long enough Org name to your local DB.
- Tested in DMZ Staging with developer console on Chrome.
- Screenshots below reflect DMZ and Local env.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


## 📷 Screenshots (if appropriate) ##

![Screenshot 2024-10-07 at 9 46 54 AM](https://github.com/user-attachments/assets/a21dc6ad-a6b7-42d4-836a-dd58fc63cbfb)
![Screenshot 2024-10-07 at 9 47 50 AM](https://github.com/user-attachments/assets/0f57024c-c28a-4707-8e60-525cba53e08d)
![Screenshot 2024-10-07 at 11 25 02 AM](https://github.com/user-attachments/assets/5e93f7c6-831a-4e3c-bff6-0698603f4c17)
![Screenshot 2024-10-07 at 11 22 52 AM](https://github.com/user-attachments/assets/56a9ee1c-da52-4168-a743-8cf055187599)





## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
