### PR TITLE
Fix local ElasticSearch

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -8,6 +8,9 @@ syncdb:
 syncdb-populate:
 	docker compose exec backend python manage.py syncdb --populate
 
+syncdb-dangerously-force:
+	docker compose exec backend python manage.py syncdb --dangerouslyforce
+
 # Pytest
 # i.e. make pytest FILE=xfd_api/tests/test_domain.py
 pytest:

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -8,9 +8,6 @@ syncdb:
 syncdb-populate:
 	docker compose exec backend python manage.py syncdb --populate
 
-syncdb-dangerously-force:
-	docker compose exec backend python manage.py syncdb --dangerouslyforce
-
 # Pytest
 # i.e. make pytest FILE=xfd_api/tests/test_domain.py
 pytest:

--- a/backend/src/xfd_django/xfd_api/management/commands/syncdb.py
+++ b/backend/src/xfd_django/xfd_api/management/commands/syncdb.py
@@ -8,6 +8,7 @@ from xfd_api.tasks.syncdb_helpers import (
     sync_es_organizations,
     synchronize,
 )
+from xfd_api.tasks.searchSync import handler as sync_es_domains
 
 
 class Command(BaseCommand):
@@ -53,5 +54,8 @@ class Command(BaseCommand):
             populate_sample_data()
             self.stdout.write("Sample data population complete.")
 
-        # Step 4: Sync organizations in ES
-        sync_es_organizations()
+            # Step 4: Sync organizations in ES
+            sync_es_organizations()
+
+            # Step 5: Sync domains in ES
+            sync_es_domains({})

--- a/backend/src/xfd_django/xfd_api/management/commands/syncdb.py
+++ b/backend/src/xfd_django/xfd_api/management/commands/syncdb.py
@@ -1,6 +1,7 @@
 """Populate command."""
 # Third-Party Libraries
 from django.core.management.base import BaseCommand
+from xfd_api.tasks.searchSync import handler as sync_es_domains
 from xfd_api.tasks.syncdb_helpers import (
     drop_all_tables,
     manage_elasticsearch_indices,
@@ -8,7 +9,6 @@ from xfd_api.tasks.syncdb_helpers import (
     sync_es_organizations,
     synchronize,
 )
-from xfd_api.tasks.searchSync import handler as sync_es_domains
 
 
 class Command(BaseCommand):

--- a/backend/src/xfd_django/xfd_api/tasks/es_client.py
+++ b/backend/src/xfd_django/xfd_api/tasks/es_client.py
@@ -10,9 +10,6 @@ from elasticsearch import Elasticsearch, helpers
 DOMAINS_INDEX = "domains-5"
 ORGANIZATIONS_INDEX = "organizations-1"
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
-
 # Define mappings
 organization_mapping = {
     "properties": {"name": {"type": "text"}, "suggest": {"type": "completion"}}
@@ -41,7 +38,7 @@ class ESClient:
         """Create or updates the organizations index with mappings."""
         try:
             if not self.client.indices.exists(index=ORGANIZATIONS_INDEX):
-                logging.info(f"Creating index {ORGANIZATIONS_INDEX}...")
+                print(f"Creating index {ORGANIZATIONS_INDEX}...")
                 self.client.indices.create(
                     index=ORGANIZATIONS_INDEX,
                     body={
@@ -50,19 +47,19 @@ class ESClient:
                     },
                 )
             else:
-                logging.info(f"Updating index {ORGANIZATIONS_INDEX}...")
+                print(f"Updating index {ORGANIZATIONS_INDEX}...")
                 self.client.indices.put_mapping(
                     index=ORGANIZATIONS_INDEX, body=organization_mapping
                 )
         except Exception as e:
-            logging.error(f"Error syncing organizations index: {e}")
+            print(f"Error syncing organizations index: {e}")
             raise e
 
     def sync_domains_index(self):
         """Create or updates the domains index with mappings."""
         try:
             if not self.client.indices.exists(index=DOMAINS_INDEX):
-                logging.info(f"Creating index {DOMAINS_INDEX}...")
+                print(f"Creating index {DOMAINS_INDEX}...")
                 self.client.indices.create(
                     index=DOMAINS_INDEX,
                     body={
@@ -71,7 +68,7 @@ class ESClient:
                     },
                 )
             else:
-                logging.info(f"Updating index {DOMAINS_INDEX}...")
+                print(f"Updating index {DOMAINS_INDEX}...")
                 self.client.indices.put_mapping(
                     index=DOMAINS_INDEX, body=domain_mapping
                 )
@@ -80,7 +77,7 @@ class ESClient:
                 index=DOMAINS_INDEX, body={"settings": {"refresh_interval": "1800s"}}
             )
         except Exception as e:
-            logging.error(f"Error syncing domains index: {e}")
+            print(f"Error syncing domains index: {e}")
             raise e
 
     def update_organizations(self, organizations):
@@ -140,10 +137,10 @@ class ESClient:
     def delete_all(self):
         """Delete all indices in Elasticsearch."""
         try:
-            logging.info("Deleting all indices...")
+            print("Deleting all indices...")
             self.client.indices.delete(index="*")
         except Exception as e:
-            logging.error(f"Error deleting all indices: {e}")
+            print(f"Error deleting all indices: {e}")
             raise e
 
     def search_domains(self, body):
@@ -157,8 +154,17 @@ class ESClient:
     def _bulk_update(self, actions):
         """Update to Elasticsearch."""
         try:
-            helpers.bulk(self.client, actions, raise_on_error=True)
-            logging.info("Bulk update completed successfully.")
+            success_count, response = helpers.bulk(self.client, actions, raise_on_error=False)
+            print(f"Bulk operation success count: {success_count}")
+            
+            for idx, item in enumerate(response):
+                if 'update' in item and item['update'].get('error'):
+                    print(f"Error indexing document {idx}: {item['update']['error']}")
+                else:
+                    print(f"Successfully indexed document {idx}: {item}")
+            
+            self.client.indices.refresh(index='domains-5')
         except Exception as e:
-            logging.error(f"Bulk operation error: {e}")
+            print(f"Bulk operation error: {e}")
             raise e
+        

--- a/backend/src/xfd_django/xfd_api/tasks/es_client.py
+++ b/backend/src/xfd_django/xfd_api/tasks/es_client.py
@@ -154,17 +154,18 @@ class ESClient:
     def _bulk_update(self, actions):
         """Update to Elasticsearch."""
         try:
-            success_count, response = helpers.bulk(self.client, actions, raise_on_error=False)
+            success_count, response = helpers.bulk(
+                self.client, actions, raise_on_error=False
+            )
             print(f"Bulk operation success count: {success_count}")
-            
+
             for idx, item in enumerate(response):
-                if 'update' in item and item['update'].get('error'):
+                if "update" in item and item["update"].get("error"):
                     print(f"Error indexing document {idx}: {item['update']['error']}")
                 else:
                     print(f"Successfully indexed document {idx}: {item}")
-            
-            self.client.indices.refresh(index='domains-5')
+
+            self.client.indices.refresh(index="domains-5")
         except Exception as e:
             print(f"Bulk operation error: {e}")
             raise e
-        

--- a/backend/src/xfd_django/xfd_api/tasks/es_client.py
+++ b/backend/src/xfd_django/xfd_api/tasks/es_client.py
@@ -1,6 +1,5 @@
 """ES client."""
 # Standard Python Libraries
-import logging
 import os
 
 # Third-Party Libraries

--- a/backend/src/xfd_django/xfd_api/tasks/searchSync.py
+++ b/backend/src/xfd_django/xfd_api/tasks/searchSync.py
@@ -21,7 +21,7 @@ def chunked_queryset(queryset, chunk_size):
         yield [first] + list(islice(it, chunk_size - 1))
 
 
-async def handler(command_options):
+def handler(command_options):
     """Handle the synchronization of domains with Elasticsearch."""
     organization_id = command_options.get("organizationId")
     domain_id = command_options.get("domainId")

--- a/backend/worker/worker.py
+++ b/backend/worker/worker.py
@@ -40,11 +40,11 @@ async def main():
 
     # Execute the task
     if getattr(scan_schema, "global_scan", False):
-        await scan_fn(command_options)
+        scan_fn(command_options)
     else:
         # Non-global task: execute per organization
         for org in organizations:
-            await scan_fn(
+            scan_fn(
                 {
                     **command_options,
                     "organizationId": org["id"],


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

- Adds searchSync to the syncdb-populate process.
- Ensures all domains are added to ElasticSearch container by adding the refresh after every update. (Local refresh is every 30 min)
- Ensures /search has results.

## 💭 Motivation and context ##

ElasticSearch is not populating correctly when running locally causing the /search endpoint to fail.

## 🧪 Testing ##

Passes pytest and pre-commit checks. 

Tested a full build locally and running of the searchSync scan.

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Revert dependencies to default branches.
- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release.
