### PR TITLE
RegionAdmin Manage Users Bugfix

### DIFF
--- a/backend/src/xfd_django/xfd_api/api_methods/user.py
+++ b/backend/src/xfd_django/xfd_api/api_methods/user.py
@@ -183,9 +183,15 @@ def get_users(current_user):
     """Retrieve a list of all users."""
     try:
         # Check if user is a regional admin or global admin
-        if not is_global_view_admin(current_user):
+        can_access_users = False
+
+        if is_global_view_admin(current_user) or is_regional_admin(current_user):
+            can_access_users = True
+
+        if not can_access_users:
             raise HTTPException(status_code=401, detail="Unauthorized")
 
+        # Get Users
         users = User.objects.all().prefetch_related("roles__organization")
 
         # Return the updated user details


### PR DESCRIPTION
…user.py)
resolves CRASM-1059. Bugfix to remove 401 error on manage users as a regionalAdmin user type.

## 🗣 Description ##
Fix users backend endpoint so regionalAdmin user type can access the manage users page.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
As a regionalAdmin user, you should now be able to get the "Manage Users" Screen without seeing any errors.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->
