### PR TITLE
Fixed Title sorting in All Vulns table (CRASM-1019)

### DIFF
--- a/frontend/src/pages/Vulnerabilities/Vulnerabilities.tsx
+++ b/frontend/src/pages/Vulnerabilities/Vulnerabilities.tsx
@@ -376,6 +376,13 @@ export const Vulnerabilities: React.FC<{ groupBy?: string }> = ({
       headerName: 'Vulnerability',
       minWidth: 100,
       flex: 1.2,
+      sortComparator: (v1, v2, cellParams1, cellParams2) => {
+        const collator = new Intl.Collator(undefined, {
+          numeric: true,
+          sensitivity: 'base'
+        });
+        return collator.compare(cellParams1.value, cellParams2.value);
+      },
       renderCell: (cellValues: GridRenderCellParams) => {
         if (cellValues.row.title.startsWith('CVE')) {
           return (


### PR DESCRIPTION
- Edited the title column in the All Vulnerabilities table to allow for natural sorting.
- For example, - "2" comes before "10" in the sorted list if sorted in ascending order.

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
- Added a sort comparator property with an Intl.Collator instance for the title column.
- It runs a localeCompare method on the title strings to compare them and sort them naturally.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
- Provides natural sorting of Vulnerability titles in the All Vulnerabilities table.
- Closes CRASM-1019
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
- Tested locally with vulnerability titles to match bug.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate) ##

<img width="2032" alt="Screenshot 2025-01-30 at 10 22 24 AM" src="https://github.com/user-attachments/assets/7e668e74-1d52-4233-a3d7-6edd28eac913" />
<img width="2032" alt="Screenshot 2025-01-30 at 10 22 36 AM" src="https://github.com/user-attachments/assets/b68e0a9f-5712-48af-a099-92645e001f86" />
<img width="2032" alt="Screenshot 2025-01-30 at 10 22 44 AM" src="https://github.com/user-attachments/assets/43987666-ba19-4b0e-8571-1a5f6ac9a5bf" />


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
