### PR TITLE
Fix PE_API_URL usage in SQS dockerfile

### DIFF
--- a/backend/worker/generate_config.sh
+++ b/backend/worker/generate_config.sh
@@ -14,7 +14,7 @@ key1=${PE_SHODAN_API_KEYS}
 
 [pe_api]
 pe_api_key=${PE_API_KEY}
-pe_api_url=${PE_API_URL}
+pe_api_url=${PE_API_URL}/apiv1/
 cf_api_key=${CF_API_KEY}
 
 [staging]


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Add /apiv1/ to the PE_API_URL used by the SQS container.

The generate_config.sh file sets the environment variables that the ATC framework needs to run. ATC-framework expects the /apiv1/ prefix on all endpoint calls so is needed here.


## 💭 Motivation and context ##

SQS container is failing to hit the ATC API.

## 🧪 Testing ##

Tested the Fargates have access to the EC2 private IP  and tested the scans in ATC-Framework.

Passes pre-commits and github checks.

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Revert dependencies to default branches.
- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
