### PR TITLE
Fix Last Logged In column sort in Users page (CRASM-1130)

### DIFF
--- a/frontend/src/pages/Users/Users.tsx
+++ b/frontend/src/pages/Users/Users.tsx
@@ -26,7 +26,7 @@ import {
   UserFormValues
 } from 'types';
 import { useAuthContext } from 'context';
-import { parseISO, format } from 'date-fns';
+import { format } from 'date-fns';
 import UserForm from './UserForm';
 
 type ApiErrorStates = {
@@ -78,10 +78,10 @@ export const Users: React.FC = () => {
       const rows = await apiGet<UserType[]>(`/users`);
       rows.forEach((row) => {
         row.lastLoggedInString = row.lastLoggedIn
-          ? format(parseISO(row.lastLoggedIn), 'MM-dd-yyyy hh:mm a')
+          ? format(new Date(row.lastLoggedIn), 'MM-dd-yyyy hh:mm a')
           : 'None';
         row.dateToUSigned = row.dateAcceptedTerms
-          ? format(parseISO(row.dateAcceptedTerms), 'MM-dd-yyyy hh:mm a')
+          ? format(new Date(row.dateAcceptedTerms), 'MM-dd-yyyy hh:mm a')
           : 'None';
         row.orgs = row.roles
           ? row.roles
@@ -132,7 +132,16 @@ export const Users: React.FC = () => {
       field: 'lastLoggedInString',
       headerName: 'Last Logged In',
       minWidth: 100,
-      flex: 1
+      flex: 1,
+      sortComparator: (v1, v2) => {
+        if (v1 === 'None') return -1;
+        if (v2 === 'None') return 1;
+
+        const date1 = new Date(v1);
+        const date2 = new Date(v2);
+
+        return date1.getTime() - date2.getTime();
+      }
     },
     {
       field: 'edit',

--- a/frontend/src/pages/Users/Users.tsx
+++ b/frontend/src/pages/Users/Users.tsx
@@ -26,7 +26,7 @@ import {
   UserFormValues
 } from 'types';
 import { useAuthContext } from 'context';
-import { format } from 'date-fns';
+import { format, parseISO } from 'date-fns';
 import UserForm from './UserForm';
 
 type ApiErrorStates = {
@@ -81,7 +81,7 @@ export const Users: React.FC = () => {
           ? format(new Date(row.lastLoggedIn), 'MM-dd-yyyy hh:mm a')
           : 'None';
         row.dateToUSigned = row.dateAcceptedTerms
-          ? format(new Date(row.dateAcceptedTerms), 'MM-dd-yyyy hh:mm a')
+          ? format(parseISO(row.dateAcceptedTerms), 'MM-dd-yyyy hh:mm a')
           : 'None';
         row.orgs = row.roles
           ? row.roles
@@ -92,6 +92,7 @@ export const Users: React.FC = () => {
         row.fullName = `${row.firstName} ${row.lastName}`;
       });
       setUsers(rows);
+      console.log('rows', rows);
       setApiErrorStates((prev) => ({ ...prev, getUsersError: '' }));
     } catch (e: any) {
       setLoadingError(true);
@@ -117,7 +118,7 @@ export const Users: React.FC = () => {
     },
     { field: 'userType', headerName: 'User Type', minWidth: 100, flex: 0.75 },
     {
-      field: 'dateToUSigned',
+      field: 'dateAcceptedTerms',
       headerName: 'Date ToU Signed',
       minWidth: 100,
       flex: 1


### PR DESCRIPTION
- Last Logged In column is sorting off the numerical value of the Month due to the "MM-dd-yyyy hh:mm a" format.

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
- converted lastLoggedIn to Date object before sorting.
- added sort comparator for lastLoggedIn column based of newDate object and getTime() method.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
- Ensures natural sorting of dates.
- Closes CRASM-1130
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
- Seeded local db with various last logged in dates across multiple users.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


## 📷 Screenshots (if appropriate) ##
<img width="2032" alt="Screenshot 2025-02-03 at 10 42 19 AM" src="https://github.com/user-attachments/assets/372a8881-312d-4088-a8ec-c480a76f53ce" />
<img width="2032" alt="Screenshot 2025-02-03 at 10 42 43 AM" src="https://github.com/user-attachments/assets/f3a047e2-48f0-4f60-a86e-78613039fe5d" />
<img width="2032" alt="Screenshot 2025-02-03 at 10 42 49 AM" src="https://github.com/user-attachments/assets/daa1c1de-a910-4e3f-8956-b97cbc9b7010" />


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
