### PR TITLE
BUG: Update Matomo user permissions

### DIFF
--- a/backend/src/xfd_django/xfd_api/helpers/infra_helpers.py
+++ b/backend/src/xfd_django/xfd_api/helpers/infra_helpers.py
@@ -98,33 +98,20 @@ def create_matomo_scan_user():
                 cursor.execute(
                     "CREATE USER %s@'%%' IDENTIFIED BY %s;", [scan_user, scan_password]
                 )
-                print(
-                    "User '{}' created successfully in Matomo database.".format(
-                        scan_user
-                    )
-                )
+                print("User '{}' created successfully in Matomo database.".format(scan_user))
             else:
-                print("User '{}' already exists. Skipping creation.".format(scan_user))
+                print("User '{}' already exists in Matomo database. Skipping creation.".format(scan_user))
 
-            # Grant privileges (aligned with PostgreSQL version)
-            cursor.execute(
-                "GRANT CONNECT ON DATABASE {} TO %s@'%%';".format(db_name), [scan_user]
-            )
-            cursor.execute("GRANT USAGE ON SCHEMA public TO %s@'%%';", [scan_user])
-            cursor.execute(
-                "GRANT SELECT ON {}.* TO %s@'%%';".format(db_name), [scan_user]
-            )
-            cursor.execute(
-                "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO %s@'%%';",
-                [scan_user],
-            )  # ✅ ADDED
-            cursor.execute("FLUSH PRIVILEGES;")  # MariaDB-specific, but necessary
+            cursor.execute("GRANT USAGE ON *.* TO %s@'%%';", [scan_user])
+            cursor.execute("GRANT SELECT ON matomo.* TO %s@'%%';", [scan_user])
 
-            print(
-                "User '{}' configured successfully in Matomo database.".format(
-                    scan_user
-                )
-            )
+            # Additional permissions to allow access to system tables
+            cursor.execute("GRANT SHOW DATABASES ON *.* TO %s@'%%';", [scan_user])
+            cursor.execute("GRANT PROCESS ON *.* TO %s@'%%';", [scan_user]) 
+
+            cursor.execute("FLUSH PRIVILEGES;")
+
+            print("User '{}' configured successfully in Matomo database.".format(scan_user))
 
         conn.commit()
         conn.close()

--- a/backend/src/xfd_django/xfd_api/helpers/infra_helpers.py
+++ b/backend/src/xfd_django/xfd_api/helpers/infra_helpers.py
@@ -98,20 +98,32 @@ def create_matomo_scan_user():
                 cursor.execute(
                     "CREATE USER %s@'%%' IDENTIFIED BY %s;", [scan_user, scan_password]
                 )
-                print("User '{}' created successfully in Matomo database.".format(scan_user))
+                print(
+                    "User '{}' created successfully in Matomo database.".format(
+                        scan_user
+                    )
+                )
             else:
-                print("User '{}' already exists in Matomo database. Skipping creation.".format(scan_user))
+                print(
+                    "User '{}' already exists in Matomo database. Skipping creation.".format(
+                        scan_user
+                    )
+                )
 
             cursor.execute("GRANT USAGE ON *.* TO %s@'%%';", [scan_user])
             cursor.execute("GRANT SELECT ON matomo.* TO %s@'%%';", [scan_user])
 
             # Additional permissions to allow access to system tables
             cursor.execute("GRANT SHOW DATABASES ON *.* TO %s@'%%';", [scan_user])
-            cursor.execute("GRANT PROCESS ON *.* TO %s@'%%';", [scan_user]) 
+            cursor.execute("GRANT PROCESS ON *.* TO %s@'%%';", [scan_user])
 
             cursor.execute("FLUSH PRIVILEGES;")
 
-            print("User '{}' configured successfully in Matomo database.".format(scan_user))
+            print(
+                "User '{}' configured successfully in Matomo database.".format(
+                    scan_user
+                )
+            )
 
         conn.commit()
         conn.close()


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Purpose: The VMAT team needs the ability to select tables in the Matomo database in order to fully run their scans.

Steps to Reproduce: VMAT team runs their scans.

Expected Behavior: VMAT user can select on user table.

Current Behavior: VMAT user is denied access to select user table.

Updates make sure:
- Full Read Access on matomo Tables
- Can See Databases
- Can Use the Database (Equivalent to GRANT USAGE in PostgreSQL)
- Can View Running Queries (Optional, Debugging)

## 🧪 Testing ##

Passes pre-commit and pytests.

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Revert dependencies to default branches.
- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
