### PR TITLE
Added Open/All status toggle to All Vulns table

### DIFF
--- a/backend/src/xfd_django/xfd_api/api_methods/vulnerability.py
+++ b/backend/src/xfd_django/xfd_api/api_methods/vulnerability.py
@@ -152,6 +152,10 @@ def search_vulnerabilities(vulnerability_search: VulnerabilitySearch, current_us
                 domain__organization__regionId=current_user.regionId
             )
 
+        # Apply Open Status only filters by default unless showAll is set to True
+        if not vulnerability_search.showAll:
+            vulnerabilities = vulnerabilities.filter(Q(state="open"))
+
         # Apply custom FCEB and CIDR filter
         vulnerabilities = vulnerabilities.filter(
             Q(domain__isFceb=True) | Q(domain__isFceb=False, domain__fromCidr=True)

--- a/backend/src/xfd_django/xfd_api/schema_models/vulnerability.py
+++ b/backend/src/xfd_django/xfd_api/schema_models/vulnerability.py
@@ -65,6 +65,7 @@ class VulnerabilitySearch(BaseModel):
     filters: Optional[VulnerabilityFilters] = None
     pageSize: Optional[int] = 25
     groupBy: Optional[str] = None
+    showAll: Optional[bool] = False
 
     model_config = {"from_attributes": True}
 

--- a/backend/src/xfd_django/xfd_api/tasks/syncdb_helpers.py
+++ b/backend/src/xfd_django/xfd_api/tasks/syncdb_helpers.py
@@ -167,6 +167,7 @@ def create_sample_services_and_vulnerabilities(domain):
 
     # Add random vulnerabilities
     if random.random() < PROB_SAMPLE_VULNERABILITIES:
+        state = random.choice(["open", "closed"])
         Vulnerability.objects.create(
             title="Sample Vulnerability "
             + "".join(random.choices("ABCDEFGHIJKLMNOPQRSTUVWXYZ", k=3)),
@@ -210,8 +211,10 @@ def create_sample_services_and_vulnerabilities(domain):
                 ]
             ),
             needsPopulation=True,
-            state="open",
-            substate="unconfirmed",
+            state=state,
+            substate=random.choice(["unconfirmed", "exploitable"])
+            if state == "open"
+            else random.choice(["false-positive", "accepted-risk", "remediated"]),
             source="sample_source",
             actions=[],
             structuredData={},

--- a/frontend/src/pages/Vulnerabilities/Vulnerabilities.tsx
+++ b/frontend/src/pages/Vulnerabilities/Vulnerabilities.tsx
@@ -28,7 +28,7 @@ import { getSeverityColor } from 'pages/Risk/utils';
 import { differenceInCalendarDays, parseISO } from 'date-fns';
 import { truncateString } from 'utils/dataTransformUtils';
 import { ORGANIZATION_EXCLUSIONS } from 'hooks/useUserTypeFilters';
-import ListAltIcon from '@mui/icons-material/ListAlt';
+import ChecklistIcon from '@mui/icons-material/Checklist';
 import DynamicFeedIcon from '@mui/icons-material/DynamicFeed';
 
 export interface ApiResponse {
@@ -341,7 +341,7 @@ export const Vulnerabilities: React.FC<{ groupBy?: string }> = ({
     <Button
       size="small"
       sx={{ '& .MuiButton-startIcon': { mr: '2px', mb: '2px' } }}
-      startIcon={<ListAltIcon />}
+      startIcon={<ChecklistIcon />}
       onClick={() => {
         fetchVulnerabilities({
           page: 1,

--- a/frontend/src/pages/Vulnerabilities/Vulnerabilities.tsx
+++ b/frontend/src/pages/Vulnerabilities/Vulnerabilities.tsx
@@ -28,6 +28,7 @@ import { getSeverityColor } from 'pages/Risk/utils';
 import { differenceInCalendarDays, parseISO } from 'date-fns';
 import { truncateString } from 'utils/dataTransformUtils';
 import { ORGANIZATION_EXCLUSIONS } from 'hooks/useUserTypeFilters';
+import ListAltIcon from '@mui/icons-material/ListAlt';
 
 export interface ApiResponse {
   result: Vulnerability[];
@@ -112,13 +113,15 @@ export const Vulnerabilities: React.FC<{ groupBy?: string }> = ({
       page,
       pageSize = PAGE_SIZE,
       doExport = false,
-      groupBy = undefined
+      groupBy = undefined,
+      showAll = false
     }: {
       filters: GridFilterItem[];
       page: number;
       pageSize?: number;
       doExport?: boolean;
       groupBy?: string;
+      showAll?: boolean;
     }): Promise<ApiResponse | undefined> => {
       try {
         const tableFilters: {
@@ -169,7 +172,8 @@ export const Vulnerabilities: React.FC<{ groupBy?: string }> = ({
               page,
               filters: tableFilters,
               pageSize,
-              groupBy
+              groupBy,
+              showAll
             }
           }
         );
@@ -189,7 +193,8 @@ export const Vulnerabilities: React.FC<{ groupBy?: string }> = ({
           filters: query.filters,
           page: query.page,
           pageSize: query.pageSize ?? PAGE_SIZE,
-          groupBy
+          groupBy,
+          showAll: query.showAll
         });
         if (!resp) return;
         const { result, count } = resp;
@@ -216,6 +221,7 @@ export const Vulnerabilities: React.FC<{ groupBy?: string }> = ({
   const history = useHistory();
   const location = useLocation();
   const state = location.state as LocationState;
+  const [onlyOpenVulns, setOnlyOpenVulns] = useState(true);
   const [initialFilters, setInitialFilters] = useState<GridFilterItem[]>(
     state?.title
       ? [
@@ -311,6 +317,43 @@ export const Vulnerabilities: React.FC<{ groupBy?: string }> = ({
     });
   }, [fetchVulnerabilities, initialFilters]);
 
+  const showAllVulnsButton = (
+    <Button
+      size="small"
+      sx={{ '& .MuiButton-startIcon': { mr: '2px', mb: '2px' } }}
+      startIcon={<ListAltIcon />}
+      onClick={() => {
+        fetchVulnerabilities({
+          page: 1,
+          pageSize: 100,
+          filters: [...filters],
+          showAll: true
+        });
+        setOnlyOpenVulns(false);
+      }}
+    >
+      Show All Vulnerabilities
+    </Button>
+  );
+
+  const showOpenVulnsButton = (
+    <Button
+      size="small"
+      sx={{ '& .MuiButton-startIcon': { mr: '2px', mb: '2px' } }}
+      startIcon={<ListAltIcon />}
+      onClick={() => {
+        fetchVulnerabilities({
+          page: 1,
+          pageSize: 100,
+          filters: [...filters],
+          showAll: false
+        });
+        setOnlyOpenVulns(true);
+      }}
+    >
+      Show Open Vulnerabilities
+    </Button>
+  );
   const vulRows: VulnerabilityRow[] = vulnerabilities.map((vuln) => {
     //The following logic is to format irregular severity levels to match those used in VulnerabilityBarChart.tsx
 
@@ -613,6 +656,13 @@ export const Vulnerabilities: React.FC<{ groupBy?: string }> = ({
               rowCount={totalResults}
               columns={vulCols}
               slots={{ toolbar: CustomToolbar }}
+              slotProps={{
+                toolbar: {
+                  children: onlyOpenVulns
+                    ? showAllVulnsButton
+                    : showOpenVulnsButton
+                }
+              }}
               paginationMode="server"
               paginationModel={paginationModel}
               onPaginationModelChange={(model) => {

--- a/frontend/src/pages/Vulnerabilities/Vulnerabilities.tsx
+++ b/frontend/src/pages/Vulnerabilities/Vulnerabilities.tsx
@@ -29,6 +29,7 @@ import { differenceInCalendarDays, parseISO } from 'date-fns';
 import { truncateString } from 'utils/dataTransformUtils';
 import { ORGANIZATION_EXCLUSIONS } from 'hooks/useUserTypeFilters';
 import ListAltIcon from '@mui/icons-material/ListAlt';
+import DynamicFeedIcon from '@mui/icons-material/DynamicFeed';
 
 export interface ApiResponse {
   result: Vulnerability[];
@@ -321,7 +322,7 @@ export const Vulnerabilities: React.FC<{ groupBy?: string }> = ({
     <Button
       size="small"
       sx={{ '& .MuiButton-startIcon': { mr: '2px', mb: '2px' } }}
-      startIcon={<ListAltIcon />}
+      startIcon={<DynamicFeedIcon />}
       onClick={() => {
         fetchVulnerabilities({
           page: 1,

--- a/frontend/src/pages/Vulnerabilities/Vulnerabilities.tsx
+++ b/frontend/src/pages/Vulnerabilities/Vulnerabilities.tsx
@@ -345,7 +345,7 @@ export const Vulnerabilities: React.FC<{ groupBy?: string }> = ({
       onClick={() => {
         fetchVulnerabilities({
           page: 1,
-          pageSize: 100,
+          pageSize: PAGE_SIZE,
           filters: [...filters],
           showAll: false
         });

--- a/frontend/src/types/query.ts
+++ b/frontend/src/types/query.ts
@@ -8,4 +8,5 @@ export interface Query<T extends object> {
   page: number;
   filters: CustomGridFilterItem<T>[];
   pageSize?: number;
+  showAll?: boolean;
 }


### PR DESCRIPTION
- Display the same type of vulnerabilities in the All Vulns tables as the stats based info graphics in Overview by default but also allow the User to see every vulnerability related to their org when needed.

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
- Added showAll boolean to VulnerabilitySearch base model.
- Added showAll boolean to the Query type in query.ts.
- Edited vulnerability.py to add status=open filter to search_vulnerabilities unless showAll is true.
- Edited fetchVulnerabilities to handle the new boolean.
- Added a ternary based button to the All Vulns table to switch between Open and All statuses.
- Only open vulnerabilities are now shown by default.
- User can then toggle to see all vulnerabilities regardless of status.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
- Closes CRASM-2222
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
- tested locally
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate) ##
<img width="2032" alt="Screenshot 2025-02-14 at 5 13 24 PM" src="https://github.com/user-attachments/assets/e8a5af75-4909-45c8-abf6-66a164b6151d" />
<img width="2032" alt="Screenshot 2025-02-14 at 5 13 33 PM" src="https://github.com/user-attachments/assets/3461eab3-bdd9-4e9e-a170-35bb025bd9fe" />
<img width="2032" alt="Screenshot 2025-02-14 at 5 13 53 PM" src="https://github.com/user-attachments/assets/4c58fcc5-d619-4f5f-9d2d-9abdcd3ae790" />
<img width="2032" alt="Screenshot 2025-02-14 at 5 13 44 PM" src="https://github.com/user-attachments/assets/05b36563-442c-4c48-8b67-a35d7a5608f2" />



## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
