### PR TITLE
Add and Update SQS Versions of PE Report Scans

### DIFF
--- a/backend/Dockerfile.pe
+++ b/backend/Dockerfile.pe
@@ -28,7 +28,7 @@ RUN ./aws/install
 # Sync the latest from cf-staging branch
 RUN git clone -b crossfeed-SQS https://github.com/cisagov/ATC-Framework.git && \
     cd ATC-Framework && \
-    git checkout 563f59e8b67ca153ab5564d697433ca0d8db451a && \
+    git checkout 4dc934cb07d50111a80459206f7bf27389e08e9e && \
     pip install .
 
 RUN python -m spacy download en_core_web_lg

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -266,7 +266,7 @@ resources:
         VisibilityTimeout: 18000  # 5 hours
         MaximumMessageSize: 262144  # 256 KB
         MessageRetentionPeriod: 604800  # 7 days
-    
+
 functions:
   - ${file(./src/tasks/functions.yml)}
   - ${file(./src/api/functions.yml)}

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -181,11 +181,50 @@ resources:
             - ${self:provider.stage}
             - integration
   Resources:
-    ShodanQueue:
+    ASMSyncQueue:
+      Type: AWS::SQS::Queue
+      Properties:
+        QueueName: ${self:provider.stage}-asmSync-queue
+        VisibilityTimeout: 18000  # 5 hours
+        MaximumMessageSize: 262144  # 256 KB
+        MessageRetentionPeriod: 604800  # 7 days
+    CybersixgillAlertsQueue:
       Type: AWS::SQS::Queue
       Condition: IsDMZ
       Properties:
-        QueueName: ${self:provider.stage}-shodan-queue
+        QueueName: ${self:provider.stage}-cybersixgill-alerts-queue
+        VisibilityTimeout: 18000  # 5 hours
+        MaximumMessageSize: 262144  # 256 KB
+        MessageRetentionPeriod: 604800  # 7 days
+    CybersixgillCredentialsQueue:
+      Type: AWS::SQS::Queue
+      Condition: IsDMZ
+      Properties:
+        QueueName: ${self:provider.stage}-cybersixgill-credentials-queue
+        VisibilityTimeout: 18000  # 5 hours
+        MaximumMessageSize: 262144  # 256 KB
+        MessageRetentionPeriod: 604800  # 7 days
+    CybersixgillMentionsQueue:
+      Type: AWS::SQS::Queue
+      Condition: IsDMZ
+      Properties:
+        QueueName: ${self:provider.stage}-cybersixgill-mentions-queue
+        VisibilityTimeout: 18000  # 5 hours
+        MaximumMessageSize: 262144  # 256 KB
+        MessageRetentionPeriod: 604800  # 7 days
+    CybersixgillTopcvesQueue:
+      Type: AWS::SQS::Queue
+      Condition: IsDMZ
+      Properties:
+        QueueName: ${self:provider.stage}-cybersixgill-topcves-queue
+        VisibilityTimeout: 18000  # 5 hours
+        MaximumMessageSize: 262144  # 256 KB
+        MessageRetentionPeriod: 604800  # 7 days
+    DnsmonitorQueue:
+      Type: AWS::SQS::Queue
+      Condition: IsDMZ
+      Properties:
+        QueueName: ${self:provider.stage}-dnsmonitor-queue
         VisibilityTimeout: 18000  # 5 hours
         MaximumMessageSize: 262144  # 256 KB
         MessageRetentionPeriod: 604800  # 7 days
@@ -205,11 +244,18 @@ resources:
         VisibilityTimeout: 18000  # 5 hours
         MaximumMessageSize: 262144  # 256 KB
         MessageRetentionPeriod: 604800  # 7 days
-    CybersixgillQueue:
+    QualysQueue:
+      Type: AWS::SQS::Queue
+      Properties:
+        QueueName: ${self:provider.stage}-qualys-queue
+        VisibilityTimeout: 18000  # 5 hours
+        MaximumMessageSize: 262144  # 256 KB
+        MessageRetentionPeriod: 604800  # 7 days
+    ShodanQueue:
       Type: AWS::SQS::Queue
       Condition: IsDMZ
       Properties:
-        QueueName: ${self:provider.stage}-cybersixgill-queue
+        QueueName: ${self:provider.stage}-shodan-queue
         VisibilityTimeout: 18000  # 5 hours
         MaximumMessageSize: 262144  # 256 KB
         MessageRetentionPeriod: 604800  # 7 days
@@ -220,21 +266,7 @@ resources:
         VisibilityTimeout: 18000  # 5 hours
         MaximumMessageSize: 262144  # 256 KB
         MessageRetentionPeriod: 604800  # 7 days
-    ASMSyncQueue:
-      Type: AWS::SQS::Queue
-      Properties:
-        QueueName: ${self:provider.stage}-asmSync-queue
-        VisibilityTimeout: 18000  # 5 hours
-        MaximumMessageSize: 262144  # 256 KB
-        MessageRetentionPeriod: 604800  # 7 days
-    QualysQueue:
-      Type: AWS::SQS::Queue
-      Properties:
-        QueueName: ${self:provider.stage}-qualys-queue
-        VisibilityTimeout: 18000  # 5 hours
-        MaximumMessageSize: 262144  # 256 KB
-        MessageRetentionPeriod: 604800  # 7 days
-
+    
 functions:
   - ${file(./src/tasks/functions.yml)}
   - ${file(./src/api/functions.yml)}

--- a/backend/src/xfd_django/xfd_api/tasks/scanExecution.py
+++ b/backend/src/xfd_django/xfd_api/tasks/scanExecution.py
@@ -20,13 +20,17 @@ django.setup()
 # Initialize AWS clients
 
 SCAN_LIST = [
+    "asmSync",
+    "cybersixgill-alerts",
+    "cybersixgill-credentials",
+    "cybersixgill-mentions",
+    "cybersixgill-topcves",
+    "dnsmonitor",
     "dnstwist",
     "intelx",
-    "cybersixgill",
+    "qualys",
     "shodan",
     "xpanse",
-    "asmSync",
-    "qualys",
 ]
 QUEUE_URL = os.getenv("QUEUE_URL")
 

--- a/backend/src/xfd_django/xfd_api/tasks/scanExecution.py
+++ b/backend/src/xfd_django/xfd_api/tasks/scanExecution.py
@@ -51,7 +51,7 @@ def start_desired_tasks(scan_type, desired_count, shodan_api_keys=None):
     shodan_api_keys = shodan_api_keys or []
     queue_url = "{}{}-queue".format(QUEUE_URL, scan_type)
 
-    batch_size = 1 if scan_type == "shodan" else 10
+    batch_size = 1 if scan_type in ["shodan", "asmSync"] else 10
     remaining_count = desired_count
 
     while remaining_count > 0:
@@ -151,7 +151,7 @@ def handler(event, context):
             print("scanType must be provided.")
             return {"statusCode": 400, "body": "Failed: no scanType provided."}
 
-        if scan_type == "shodan":
+        if scan_type in ["shodan", "asmSync"]:
             api_key_list = event.get("apiKeyList", "")
             shodan_api_keys = (
                 [key.strip() for key in api_key_list.split(",")] if api_key_list else []

--- a/backend/worker/pe-worker-entry.sh
+++ b/backend/worker/pe-worker-entry.sh
@@ -52,21 +52,29 @@ while true; do
     ORG=$(echo "$MESSAGE" | jq -r '.Messages[0].Body | fromjson | .org')
   fi
 
-  if [[ "$SERVICE_TYPE" = *"shodan"* ]]; then
-    COMMAND="pe-source shodan --soc_med_included --org=$ORG"
+  # Run command for the specified script
+  if [[ "$SERVICE_TYPE" = *"asmSync"* ]]; then
+    COMMAND="pe-asm-sync asm-sqs --orgs=$ORG"
+  elif [[ "$SERVICE_TYPE" = *"cybersixgill-alerts"* ]]; then
+    COMMAND="pe-source cybersixgill --cybersix-methods=alerts --soc_med_included --orgs=$ORG"
+  elif [[ "$SERVICE_TYPE" = *"cybersixgill-credentials"* ]]; then
+    COMMAND="pe-source cybersixgill --cybersix-methods=credentials --soc_med_included --orgs=$ORG"
+  elif [[ "$SERVICE_TYPE" = *"cybersixgill-mentions"* ]]; then
+    COMMAND="pe-source cybersixgill --cybersix-methods=mentions --soc_med_included --orgs=$ORG"
+  elif [[ "$SERVICE_TYPE" = *"cybersixgill-topcves"* ]]; then
+    COMMAND="pe-source cybersixgill --cybersix-methods=topCVEs --soc_med_included"
+  elif [[ "$SERVICE_TYPE" = *"dnsmonitor"* ]]; then
+    COMMAND="pe-source dnsmonitor --orgs=$ORG"
   elif [[ "$SERVICE_TYPE" = *"dnstwist"* ]]; then
-    COMMAND="pe-source dnstwist --org=$ORG"
+    COMMAND="pe-source dnstwist --orgs=$ORG"
   elif [[ "$SERVICE_TYPE" = *"intelx"* ]]; then
-    COMMAND="pe-source intelx --org=$ORG --soc_med_included"
-  elif [[ "$SERVICE_TYPE" = *"cybersixgill"* ]]; then
-    COMMAND="pe-source cybersixgill --org=$ORG --soc_med_included"
-  elif [[ "$SERVICE_TYPE" = *"xpanse"* ]]; then
-    COMMAND="pe-source xpanse --org='$ORG'"
-  elif [[ "$SERVICE_TYPE" = *"asmSync"* ]]; then
-    COMMAND="pe-asm-sync asm-sqs --org='$ORG'"
+    COMMAND="pe-source intelx --orgs=$ORG"
   elif [[ "$SERVICE_TYPE" = *"qualys"* ]]; then
     COMMAND="pe-source was-report-pull --org='$ORG' && pe-source was-findings-sync --org='$ORG'"
-
+  elif [[ "$SERVICE_TYPE" = *"shodan"* ]]; then
+    COMMAND="pe-source shodan --soc_med_included --orgs=$ORG"
+  elif [[ "$SERVICE_TYPE" = *"xpanse"* ]]; then
+    COMMAND="pe-source xpanse --org='$ORG'"
   else
     echo "Unsupported SERVICE_TYPE: $SERVICE_TYPE"
     break


### PR DESCRIPTION
## 🗣 Description ##

Changes were made to update and add several SQS PE report scans:
- scanExecution.py was updated so that Shodan API keys would be passed in when the asmSync SQS scan runs
- All the other file changes were made in order to add the SQS versions of P&E Report scans (Cybersixgill alerts/credentials/mentions/topcves and dnsmonitor).

## 💭 Motivation and context ##

- The ASM Sync process needs Shodan API keys to function properly. As a result, small updates were made so that those Shodan keys would be passed into the fargate containers.
- The PE Report scans are currently running on the Accessor, which is not very scalable. As a result, these updates will add SQS versions of these scans that are more capable of scaling

## 🧪 Testing ##

The commands that were added to call the new SQS versions of the PE report scans have been tested and confirmed to be working. The code for the new SQS PE report scans are in the crossfeed-sqs branch of the ATC-Framework repo. Additionally, the scan code that was added to XFD follows a very similar pattern to existing SQS scans so not much new code was needed. These changes should only affect the SQS scans that P&E uses.

## 📷 Screenshots (if appropriate) ##


## ✅ Pre-approval checklist ##

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - *eschew scope creep!*
- [X] All relevant type-of-change labels have been added.
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [X] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [X] Tests have been added and/or modified to cover the changes in this PR.
- [X] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [X] Finalize version.

## ✅ Post-merge checklist ##

- [ ] Create a release.