### PR TITLE
CRASM-2285 Create Playwright Container for AWS Fargate

### DIFF
--- a/infrastructure/database.tf
+++ b/infrastructure/database.tf
@@ -297,7 +297,7 @@ resource "aws_ssm_parameter" "crossfeed_send_db_host" {
 resource "aws_ssm_parameter" "crossfeed_send_db_name" {
   name      = var.ssm_db_name
   type      = "SecureString"
-  value     = aws_db_instance.db.name
+  value     = aws_db_instance.db.identifier
   overwrite = true
 
   tags = {

--- a/infrastructure/playwright.tf
+++ b/infrastructure/playwright.tf
@@ -1,0 +1,108 @@
+resource "aws_iam_role" "playwright_worker_task_execution_role" {
+  name = "playwright-worker-task-execution-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+        Effect = "Allow"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "playwright_ecs_task_policy" {
+  name = "playwright-ecs-task-policy"
+  role = aws_iam_role.worker_task_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = ["s3:ListBucket", "s3:GetObject", "s3:PutObject"]
+        Effect = "Allow"
+        Resource = [
+          "arn:aws:s3:::my-bucket",  # ListBucket on the bucket itself
+          "arn:aws:s3:::my-bucket/*" # GetObject and PutObject on all objects within the bucket
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "playwright_ecs_execution_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+  role       = aws_iam_role.playwright_worker_task_execution_role.name
+}
+
+resource "aws_ecr_repository" "playwright" {
+  name = "playwright-ui-testing"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  image_tag_mutability = "MUTABLE"
+
+  encryption_configuration {
+    encryption_type = "KMS"
+    kms_key         = aws_kms_key.key.arn
+  }
+
+  tags = {
+    Project = var.project
+    Stage   = var.stage
+    Owner   = "Crossfeed managed resource"
+  }
+}
+
+resource "aws_ecs_task_definition" "playwright_worker" {
+  family                   = var.worker_ecs_task_definition_family
+  container_definitions    = <<EOF
+[
+  {
+    "name": "playwright",
+    "image": "${aws_ecr_repository.playwright.repository_url}:${var.image_tag}",
+    "essential": true,
+    "mountPoints": [],
+    "portMappings": [],
+    "volumesFrom": [],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${var.worker_ecs_log_group_name}",
+        "awslogs-region": "${var.aws_region}",
+        "awslogs-stream-prefix": "playwright"
+      }
+    },
+    "environment": [
+      {
+        "name": "BROWSER_TYPE",
+        "value": "chromium"
+      },
+      {
+        "name": "TEST_URL",
+        "value": "${var.frontend_domain}"
+      }
+    ]
+  }
+]
+EOF
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  execution_role_arn       = aws_iam_role.playwright_worker_task_execution_role.arn
+  task_role_arn            = aws_iam_role.worker_task_role.arn
+
+  cpu    = 256 # .25 vCPU
+  memory = 512 # 512 MB
+
+  tags = {
+    Project = var.project
+    Stage   = var.stage
+    Owner   = "Crossfeed managed resource"
+  }
+}

--- a/infrastructure/playwright.tf
+++ b/infrastructure/playwright.tf
@@ -26,8 +26,8 @@ resource "aws_iam_role_policy" "playwright_ecs_task_policy" {
         Action = ["s3:ListBucket", "s3:GetObject", "s3:PutObject"]
         Effect = "Allow"
         Resource = [
-          "arn:aws:s3:::cisa-crossfeed-staging-auto-test-reports",  # ListBucket on the bucket itself
-          "arn:aws:s3:::cisa-crossfeed-staging-auto-test-reports/*" # GetObject and PutObject on all objects within the bucket
+          "arn:aws:s3:::${var.automated_test_report_bucket_name}",  # ListBucket on the bucket itself
+          "arn:aws:s3:::${var.automated_test_report_bucket_name}/*" # GetObject and PutObject on all objects within the bucket
         ]
       }
     ]

--- a/infrastructure/playwright.tf
+++ b/infrastructure/playwright.tf
@@ -26,8 +26,8 @@ resource "aws_iam_role_policy" "playwright_ecs_task_policy" {
         Action = ["s3:ListBucket", "s3:GetObject", "s3:PutObject"]
         Effect = "Allow"
         Resource = [
-          "arn:aws:s3:::my-bucket",  # ListBucket on the bucket itself
-          "arn:aws:s3:::my-bucket/*" # GetObject and PutObject on all objects within the bucket
+          "arn:aws:s3:::cisa-crossfeed-staging-auto-test-reports",  # ListBucket on the bucket itself
+          "arn:aws:s3:::cisa-crossfeed-staging-auto-test-reports/*" # GetObject and PutObject on all objects within the bucket
         ]
       }
     ]

--- a/infrastructure/vars.tf
+++ b/infrastructure/vars.tf
@@ -848,3 +848,9 @@ variable "crossfeed-lz-sync_name" {
   description = "The name of the S3 bucket for Crossfeed LZ sync"
   default     = "crossfeed-lz-sync"
 }
+
+variable "image_tag" {
+  description = "The tag for the image in ECR"
+  type        = string
+  default     = "latest"
+}

--- a/infrastructure/vars.tf
+++ b/infrastructure/vars.tf
@@ -854,3 +854,9 @@ variable "image_tag" {
   type        = string
   default     = "latest"
 }
+
+variable "automated_test_report_bucket_name" {
+  description = "S3 bucket where test reports will be stored"
+  type        = string
+  default     = "cisa-crossfeed-staging-auto-test-reports"
+}


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This adds the playwright.tf file to the repo, to create a Playwright container for AWS Fargate.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This change is needed to build up our regression testing infrastructure.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Code was validated by Terraform validate.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

