### PR TITLE
Update ATC-Framework Commit ID to be the Most Recent

### DIFF
--- a/backend/Dockerfile.pe
+++ b/backend/Dockerfile.pe
@@ -28,7 +28,7 @@ RUN ./aws/install
 # Sync the latest from cf-staging branch
 RUN git clone -b crossfeed-SQS https://github.com/cisagov/ATC-Framework.git && \
     cd ATC-Framework && \
-    git checkout 5ed8cf41e6a661aa202990889d21c55022627e57 && \
+    git checkout 3c78bba8125ee4322f4f8f727af62bd962105807 && \
     pip install .
 
 RUN python -m spacy download en_core_web_lg


### PR DESCRIPTION
## 🗣 Description ##

Updated the commit ID in /backend/Dockerfile.pe to be the most up-to-date version of the crossfeed-sqs branch of the ATC-Framework repo.

## 💭 Motivation and context ##

The previous crossfeed-sqs commit removed the Pshtt library/code which ended up breaking some SQS scripts. This is because the SQS scripts tried importing the now non-existent Pshtt code. I've commented out that import in crossfeed-sqs which fixes the problem. I just need XFD to use the right version of crossfeed-sqs now.

## 🧪 Testing ##

Observed the pshtt import error locally.
Commented out that import and the error went away and the script ran as intended.

## ✅ Pre-approval checklist ##

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - *eschew scope creep!*
- [X] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [X] All relevant type-of-change labels have been added.
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [X] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [X] Tests have been added and/or modified to cover the changes in this PR.
- [X] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [X] Revert dependencies to default branches.
- [X] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
