### PR TITLE
Add command to clone repository into AWS Playwright Container

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -45,33 +45,43 @@ jobs:
           PW_XFD_PASSWORD: ${{ secrets.PW_XFD_PASSWORD }}
           PW_XFD_USERNAME: ${{ secrets.PW_XFD_USERNAME }}
         run: |
-          aws ecs run-task \
-          --cluster crossfeed-playwright-staging-cd-ecs-cluster \
-          --task-definition crossfeed-staging-cd-playwright-worker \
-          --launch-type FARGATE \
-          --network-configuration \
-          "awsvpcConfiguration={subnets=[\"${{ secrets.AWS_SUBNET }}\"], \
-          securityGroups=[\"${{ secrets.AWS_SECURITY_GROUP }}\"], \
-          assignPublicIp=\"ENABLED\"}" \
-          --region ${{ secrets.AWS_REGION }} \
-          --overrides '{
-            "containerOverrides": [
-            {
-              "name": "main",
-              "command": [
-                "sh",
-                "-c",
-                "echo 'Cloning Playwright tests from GitHub...'; \
-                git clone https://github.com/cisagov/xfd.git /app/xfd; \
-                cd /app/xfd/playwright && \
-                echo 'Running Playwright tests'; \
-                npx playwright test"
+          # Start the ECS task and capture the task ARN
+          TASK_ARN=$(aws ecs run-task \
+            --cluster crossfeed-playwright-staging-cd-ecs-cluster \
+            --task-definition crossfeed-staging-cd-playwright-worker \
+            --launch-type FARGATE \
+            --network-configuration 'awsvpcConfiguration={
+              "subnets": ["${{ secrets.AWS_SUBNET }}"],
+              "securityGroups": ["${{ secrets.AWS_SECURITY_GROUP }}"],
+              "assignPublicIp": "ENABLED"
+            }' \
+            --region ${{ secrets.AWS_REGION }} \
+            --overrides '{
+              "containerOverrides": [
+              {
+                "name": "main",
+                "command": [
+                  "sh",
+                  "-c",
+                  "echo 'Cloning Playwright tests from GitHub...'; \
+                  git clone https://github.com/cisagov/xfd.git /app/xfd; \
+                  cd /app/xfd/playwright && \
+                  echo 'Running Playwright tests'; \
+                  npx playwright test"
+                ]
+              }
+            ]
+            }' \
+            --query 'tasks[0].taskArn' --output text)
 
-              ]
-            }
-          ]
-          }'
+          echo "Started ECS Task with ARN: $TASK_ARN"
 
+          # Wait for the ECS task to complete
+          aws ecs wait tasks-stopped \
+          --cluster crossfeed-playwright-staging-cd-ecs-cluster\
+          --tasks $TASK_ARN --region ${{ secrets.AWS_REGION }}
+
+          echo "ECS task completed. Continuing with the next steps."
 
         continue-on-error: false  # Ensure it stops if the ECS task fails
 
@@ -122,32 +132,44 @@ jobs:
           PW_XFD_PASSWORD: ${{ secrets.PW_XFD_PASSWORD }}
           PW_XFD_USERNAME: ${{ secrets.PW_XFD_USERNAME }}
         run: |
-          aws ecs run-task \
-            --cluster crossfeed-playwright-integration-ecs-cluster \
-            --task-definition crossfeed-integration-playwright-worker \
+          # Start the ECS task and capture the task ARN
+          TASK_ARN=$(aws ecs run-task \
+            --cluster crossfeed-playwright-staging-cd-ecs-cluster \
+            --task-definition crossfeed-staging-cd-playwright-worker \
             --launch-type FARGATE \
-            --network-configuration \
-            "awsvpcConfiguration={subnets=[\"${{ secrets.AWS_SUBNET }}\"], \
-            securityGroups=[\"${{ secrets.AWS_SECURITY_GROUP }}\"], \
-            assignPublicIp=\"ENABLED\"}" \
+            --network-configuration 'awsvpcConfiguration={
+              "subnets": ["${{ secrets.AWS_SUBNET }}"],
+              "securityGroups": ["${{ secrets.AWS_SECURITY_GROUP }}"],
+              "assignPublicIp": "ENABLED"
+            }' \
             --region ${{ secrets.AWS_REGION }} \
             --overrides '{
-            "containerOverrides": [
-            {
-              "name": "main",
-              "command": [
+              "containerOverrides": [
               {
                 "name": "main",
                 "command": [
                   "sh",
                   "-c",
-                  "cd /app/xfd/playwright && \
+                  "echo 'Cloning Playwright tests from GitHub...'; \
+                  git clone https://github.com/cisagov/xfd.git /app/xfd; \
+                  cd /app/xfd/playwright && \
                   echo 'Running Playwright tests'; \
                   npx playwright test"
                 ]
               }
             ]
-          }'
+            }' \
+            --query 'tasks[0].taskArn' --output text)
+
+          echo "Started ECS Task with ARN: $TASK_ARN"
+
+          # Wait for the ECS task to complete
+          aws ecs wait tasks-stopped \
+          --cluster crossfeed-playwright-staging-cd-ecs-cluster\
+          --tasks $TASK_ARN --region ${{ secrets.AWS_REGION }}
+
+          echo "ECS task completed. Continuing with the next steps."
+
         continue-on-error: false  # Ensure it stops if the ECS task fails
 
       - name: Upload test results as artifact

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -26,6 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: staging
     timeout-minutes: 60
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -102,6 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: integration
     timeout-minutes: 60
+    if: github.event_name == 'push' && github.ref == 'refs/heads/integration'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -139,9 +141,7 @@ jobs:
                 "command": [
                   "sh",
                   "-c",
-                  "echo 'Cloning Playwright tests from GitHub...'; \
-                  git clone https://github.com/cisagov/xfd.git /app/xfd; \
-                  cd /app/xfd/playwright && \
+                  "cd /app/xfd/playwright && \
                   echo 'Running Playwright tests'; \
                   npx playwright test"
                 ]

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -60,7 +60,14 @@ jobs:
               "command": [
                 "sh",
                 "-c",
-                "npx playwright install && npx playwright test"
+                "echo 'Cloning Playwright tests from GitHub...'; \
+                git clone --single-branch --depth 1 \
+                --branch $(echo ${GITHUB_REF} | sed 's|refs/heads/||') \
+                https://github.com/cisagov/xfd.git /app/xfd; \
+                cd /app/xfd/playwright && \
+                echo 'Running Playwright tests'; \
+                npx playwright test"
+
               ]
             }
           ]
@@ -129,12 +136,21 @@ jobs:
             {
               "name": "main",
               "command": [
-                "sh",
-                "-c",
-                "npx playwright install && npx playwright test"
-              ]
-            }
-          ]
+              {
+                "name": "main",
+                "command": [
+                  "sh",
+                  "-c",
+                  "echo 'Cloning Playwright tests from GitHub...'; \
+                  git clone --single-branch --depth 1 \
+                  --branch $(echo ${GITHUB_REF} | sed 's|refs/heads/||') \
+                  https://github.com/cisagov/xfd.git /app/xfd; \
+                  cd /app/xfd/playwright && \
+                  echo 'Running Playwright tests'; \
+                  npx playwright test"
+                ]
+              }
+            ]
           }'
         continue-on-error: false  # Ensure it stops if the ECS task fails
 
@@ -146,7 +162,7 @@ jobs:
 
       - name: Upload HTML report to S3
         run: |
-          aws s3 cp ./playwright-report/html \
+          aws s3 cp ./playwright-report/ \
             s3://${{ vars.AUTOMATED_TEST_REPORT_BUCKET_NAME }}/\
             playwright-reports/html/ --recursive || \
           { echo "HTML report upload failed"; exit 1; }

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -61,9 +61,7 @@ jobs:
                 "sh",
                 "-c",
                 "echo 'Cloning Playwright tests from GitHub...'; \
-                git clone --single-branch --depth 1 \
-                --branch $(echo ${GITHUB_REF} | sed 's|refs/heads/||') \
-                https://github.com/cisagov/xfd.git /app/xfd; \
+                git clone https://github.com/cisagov/xfd.git /app/xfd; \
                 cd /app/xfd/playwright && \
                 echo 'Running Playwright tests'; \
                 npx playwright test"
@@ -142,9 +140,7 @@ jobs:
                   "sh",
                   "-c",
                   "echo 'Cloning Playwright tests from GitHub...'; \
-                  git clone --single-branch --depth 1 \
-                  --branch $(echo ${GITHUB_REF} | sed 's|refs/heads/||') \
-                  https://github.com/cisagov/xfd.git /app/xfd; \
+                  git clone https://github.com/cisagov/xfd.git /app/xfd; \
                   cd /app/xfd/playwright && \
                   echo 'Running Playwright tests'; \
                   npx playwright test"

--- a/infrastructure/playwright.tf
+++ b/infrastructure/playwright.tf
@@ -83,6 +83,11 @@ resource "aws_ecs_task_definition" "playwright_worker" {
         "name": "TEST_URL",
         "value": "${var.frontend_domain}"
       }
+    ],
+    "command": [
+      "sh",
+      "-c",
+      "echo 'Installing Playwright...'; npx playwright install"
     ]
   }
 ]

--- a/infrastructure/playwright.tf
+++ b/infrastructure/playwright.tf
@@ -87,7 +87,7 @@ resource "aws_ecs_task_definition" "playwright_worker" {
     "command": [
       "sh",
       "-c",
-      "echo 'Installing Playwright...'; npx playwright install"
+      "echo 'Installing Playwright...'; npx playwright install --with-deps"
     ]
   }
 ]

--- a/infrastructure/playwright.tf
+++ b/infrastructure/playwright.tf
@@ -87,7 +87,9 @@ resource "aws_ecs_task_definition" "playwright_worker" {
     "command": [
       "sh",
       "-c",
-      "echo 'Installing Playwright...'; npx playwright install --with-deps"
+      "echo 'Installing Playwright...'; npx playwright install --with-deps; \
+      echo 'Cloning Playwright tests from GitHub...'; \
+      git clone https://github.com/cisagov/xfd.git /app/xfd; "
     ]
   }
 ]

--- a/infrastructure/playwright.tf
+++ b/infrastructure/playwright.tf
@@ -87,9 +87,7 @@ resource "aws_ecs_task_definition" "playwright_worker" {
     "command": [
       "sh",
       "-c",
-      "echo 'Installing Playwright...'; npx playwright install --with-deps; \
-      echo 'Cloning Playwright tests from GitHub...'; \
-      git clone https://github.com/cisagov/xfd.git /app/xfd; "
+      "echo 'Installing Playwright...'; npx playwright install --with-deps; echo 'Cloning Playwright tests from GitHub...'; git clone https://github.com/cisagov/xfd.git /app/xfd; "
     ]
   }
 ]


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Modify the Terraform and Regression Test Actions to clone the XFD repository into the AWS Playwright Container.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Github Actions can now run the AWS Playwright Container, but it does not have any test cases. This change should bring the repository into the container so it can access the test cases.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

It is being tested in this PR. 
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

