### PR TITLE
Fix pydantic model return assets_owned_count

### DIFF
--- a/backend/src/xfd_django/xfd_api/schema_models/stat_schema.py
+++ b/backend/src/xfd_django/xfd_api/schema_models/stat_schema.py
@@ -163,7 +163,7 @@ class VulnScanSummaryResponse(BaseModel):
     start_date: Optional[datetime] = None
     end_date: Optional[datetime] = None
     organization: Optional[UUID] = None
-    asset_count: Optional[int] = None
+    assets_owned_count: Optional[int] = None
     false_positive_count: Optional[int] = None
     vulnerable_host_count: Optional[int] = None
     scanned_asset_count: Optional[int] = None


### PR DESCRIPTION
Update pydantic model

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
Update pydantic model to match vulnScanSummary and return all fields correctly
## 💭 Motivation and context ##
The value is currently not returning because it is using an outdated name in the pydantic model. This one line change will fix the issue
