### PR TITLE
Include a count of "none" severity in risky service dict: CRASM-2456

### DIFF
--- a/backend/src/xfd_django/xfd_api/schema_models/stat_schema.py
+++ b/backend/src/xfd_django/xfd_api/schema_models/stat_schema.py
@@ -147,12 +147,13 @@ class CVEItem(BaseModel):
 class RiskyHostStats(BaseModel):
     """Risky Host Stats model."""
 
-    low: int
     rrs: float
-    high: int
-    total: int
+    none: int
+    low: int
     medium: int
+    high: int
     critical: int
+    total: int
 
 
 class VulnScanSummaryResponse(BaseModel):

--- a/backend/src/xfd_django/xfd_api/tasks/vulnScanningSync.py
+++ b/backend/src/xfd_django/xfd_api/tasks/vulnScanningSync.py
@@ -860,6 +860,7 @@ def create_vuln_scan_summary(summary_date=None):
             tickets.values("ip_string")
             .annotate(
                 total=Count("id"),
+                none=Count("id", filter=Q(cvss_severity=0)),
                 low=Count("id", filter=Q(cvss_severity=1)),
                 medium=Count("id", filter=Q(cvss_severity=2)),
                 high=Count("id", filter=Q(cvss_severity=3)),
@@ -873,6 +874,7 @@ def create_vuln_scan_summary(summary_date=None):
         top_5_hosts = {
             item["ip_string"]: {
                 "total": item["total"],
+                "none": item["none"],
                 "low": item["low"],
                 "medium": item["medium"],
                 "high": item["high"],


### PR DESCRIPTION
## 🗣 Description ##
We want to include the count of vulnerabilities with a severity of 'None" so that the total count makes more sense.
## 💭 Motivation and context ##
Currently the total count is based off of all open tickets, but the severity level counts don't include vulns with a severity of 0, so adding this count will make all the severity level counts sum to the total value, making things more clear for the end user.

## ✅ Pre-approval checklist ##
ere to help! -->

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - *eschew scope creep!*
- [X] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [X] All relevant type-of-change labels have been added.
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).

