### PR TITLE
Remove none counts from stats/trends endpoint

### DIFF
--- a/backend/src/xfd_django/xfd_api/schema_models/stat_schema.py
+++ b/backend/src/xfd_django/xfd_api/schema_models/stat_schema.py
@@ -148,7 +148,6 @@ class RiskyHostStats(BaseModel):
     """Risky Host Stats model."""
 
     rrs: float
-    none: int
     low: int
     medium: int
     high: int
@@ -169,7 +168,6 @@ class VulnScanSummaryResponse(BaseModel):
     vulnerable_host_count: Optional[int] = None
     scanned_asset_count: Optional[int] = None
     unique_service_count: Optional[int] = None
-    unique_none_severity_count: Optional[int] = None
     unique_low_severity_count: Optional[int] = None
     unique_medium_severity_count: Optional[int] = None
     unique_high_severity_count: Optional[int] = None
@@ -177,14 +175,12 @@ class VulnScanSummaryResponse(BaseModel):
     risky_services_count: Optional[int] = None
     unsupported_software_count: Optional[int] = None
     unique_os_count: Optional[int] = None
-    none_severity_count: Optional[int] = None
     low_severity_count: Optional[int] = None
     medium_severity_count: Optional[int] = None
     high_severity_count: Optional[int] = None
     critical_severity_count: Optional[int] = None
     critical_max_age: Optional[int] = None
     high_max_age: Optional[int] = None
-    none_kev_count: Optional[int] = None
     low_kev_count: Optional[int] = None
     medium_kev_count: Optional[int] = None
     high_kev_count: Optional[int] = None

--- a/backend/src/xfd_django/xfd_api/tasks/syncdb_helpers.py
+++ b/backend/src/xfd_django/xfd_api/tasks/syncdb_helpers.py
@@ -372,7 +372,7 @@ def build_fake_ticket(org):
     ip_record, ip_string = create_ip_within_org_cidr(org)
     cve = Cve.objects.order_by("?").first()
     port = random.choice([21, 22, 80, 443])
-    severity = random.choice(["0.0", "1.0", "2.0", "3.0", "4.0"])
+    severity = random.choice(["1.0", "2.0", "3.0", "4.0"])
     protocol = random.choice(["tcp", "udp"])
     opened_time = timezone.now() - timedelta(days=random.randint(300, 1000))
     # 70% chance of ticket being open (closed_timestamp = None)

--- a/backend/src/xfd_django/xfd_api/tasks/vulnScanningSync.py
+++ b/backend/src/xfd_django/xfd_api/tasks/vulnScanningSync.py
@@ -740,7 +740,7 @@ def create_vuln_scan_summary(summary_date=None):
         ]
 
         # Severity logic using cvss_severity
-        severity_map = {0: "none", 1: "low", 2: "medium", 3: "high", 4: "critical"}
+        severity_map = {1: "low", 2: "medium", 3: "high", 4: "critical"}
         severity_counts = {
             f"{name}_severity_count": included.filter(cvss_severity=level).count()
             for level, name in severity_map.items()
@@ -849,6 +849,8 @@ def create_vuln_scan_summary(summary_date=None):
             is_open=True,
             cvss_base_score__isnull=False,
             ip_string__isnull=False,
+            source="nessus",
+            false_positive__in=[False, None],
         )
 
         # Base RRS score expression: (cvss_base_score^7) / 1,000,000
@@ -860,7 +862,6 @@ def create_vuln_scan_summary(summary_date=None):
             tickets.values("ip_string")
             .annotate(
                 total=Count("id"),
-                none=Count("id", filter=Q(cvss_severity=0)),
                 low=Count("id", filter=Q(cvss_severity=1)),
                 medium=Count("id", filter=Q(cvss_severity=2)),
                 high=Count("id", filter=Q(cvss_severity=3)),
@@ -874,7 +875,6 @@ def create_vuln_scan_summary(summary_date=None):
         top_5_hosts = {
             item["ip_string"]: {
                 "total": item["total"],
-                "none": item["none"],
                 "low": item["low"],
                 "medium": item["medium"],
                 "high": item["high"],


### PR DESCRIPTION

## 🗣 Description ##
The stats_trends vuln_scans summary should not include any counts from nmap results. This PR removes these results which results in no tickets with a severity of none, so these counts need to be removed from the return.
## 💭 Motivation and context ##
These counts will always return 0 so they need to be removed to avoid confusion
## 🧪 Testing ##
Tested locally.

## ✅ Pre-approval checklist ##

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - *eschew scope creep!*
- [X] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [X] All relevant type-of-change labels have been added.
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
