### PR TITLE
Update port scan summary table to include counts of risky service groups: CRASM-2490

### DIFF
--- a/backend/src/xfd_django/xfd_api/schema_models/stat_schema.py
+++ b/backend/src/xfd_django/xfd_api/schema_models/stat_schema.py
@@ -226,6 +226,7 @@ class PortScanSummaryResponse(BaseModel):
     nmi_service_count: Optional[int] = 0
     unique_ip_count: Optional[int] = 0
     unique_service_count: Optional[int] = 0
+    risky_service_group_counts: Optional[dict] = {}
 
 
 class PortScanServiceSummaryResponse(BaseModel):

--- a/backend/src/xfd_django/xfd_api/tasks/syncdb_helpers.py
+++ b/backend/src/xfd_django/xfd_api/tasks/syncdb_helpers.py
@@ -267,6 +267,10 @@ def build_fake_port_scan(org):
         "method": random.choice(["probed", "banner", "snmp", "ssl-cert"]),
         "name": random.choice(["http", "ssh", "tcpwrapped", "ftp", "mysql"]),
     }
+    risky_service_group = random.choice(
+        ["rdp", "telnet","smb","ldap","netbios","ftp","rpc","sql", "irc", "kerberos", None, None, None]
+    )
+    nmi_group = risky_service_group if risky_service_group in ["smb", "telnet","rdp"] else None
 
     return PortScan(
         id=str(uuid.uuid4()),
@@ -286,10 +290,8 @@ def build_fake_port_scan(org):
         time_scanned=timezone.make_aware(
             fake.date_time_between(start_date="-1y", end_date="now")
         ),
-        nmi_service_group="NMI",
-        risky_service_group=random.choice(
-            ["Potentially Risky Service", "Known Exploited Service"]
-        ),
+        nmi_service_group=nmi_group,
+        risky_service_group = risky_service_group
     )
 
 

--- a/backend/src/xfd_django/xfd_api/tasks/syncdb_helpers.py
+++ b/backend/src/xfd_django/xfd_api/tasks/syncdb_helpers.py
@@ -55,7 +55,7 @@ SAMPLE_STATES = ["Virginia", "California", "Colorado"]
 SAMPLE_REGION_IDS = ["1", "2", "3"]
 ORGANIZATION_CHUNK_SIZE = 50
 FAKE_VULN_SCAN_COUNT = 2
-FAKE_PORT_SCAN_COUNT = 2
+FAKE_PORT_SCAN_COUNT = 20
 FAKE_HOST_COUNT = 2
 FAKE_TICKET_COUNT = 2
 # Load sample data files
@@ -277,7 +277,7 @@ def build_fake_port_scan(org):
         ip=ip_record,
         ip_string=ip_string,
         organization=org,
-        latest=random.choice([True, False]),
+        latest=random.choice([True, True, True, True, False]),
         port=random.choice([22, 80, 443, 8080, 33542]),
         protocol=random.choice(["tcp", "udp"]),
         reason=random.choice(["syn-ack", "response", "reset", "none"]),
@@ -286,7 +286,7 @@ def build_fake_port_scan(org):
         service_confidence=int(service_info["conf"]),
         service_method=service_info["method"],
         source="nmap",
-        state=random.choice(["open", "closed", "filtered", "silent"]),
+        state=random.choice(["open", "open", "open", "open", "closed", "filtered", "silent"]),
         time_scanned=timezone.make_aware(
             fake.date_time_between(start_date="-1y", end_date="now")
         ),

--- a/backend/src/xfd_django/xfd_api/tasks/syncdb_helpers.py
+++ b/backend/src/xfd_django/xfd_api/tasks/syncdb_helpers.py
@@ -268,9 +268,25 @@ def build_fake_port_scan(org):
         "name": random.choice(["http", "ssh", "tcpwrapped", "ftp", "mysql"]),
     }
     risky_service_group = random.choice(
-        ["rdp", "telnet","smb","ldap","netbios","ftp","rpc","sql", "irc", "kerberos", None, None, None]
+        [
+            "rdp",
+            "telnet",
+            "smb",
+            "ldap",
+            "netbios",
+            "ftp",
+            "rpc",
+            "sql",
+            "irc",
+            "kerberos",
+            None,
+            None,
+            None,
+        ]
     )
-    nmi_group = risky_service_group if risky_service_group in ["smb", "telnet","rdp"] else None
+    nmi_group = (
+        risky_service_group if risky_service_group in ["smb", "telnet", "rdp"] else None
+    )
 
     return PortScan(
         id=str(uuid.uuid4()),
@@ -286,12 +302,14 @@ def build_fake_port_scan(org):
         service_confidence=int(service_info["conf"]),
         service_method=service_info["method"],
         source="nmap",
-        state=random.choice(["open", "open", "open", "open", "closed", "filtered", "silent"]),
+        state=random.choice(
+            ["open", "open", "open", "open", "closed", "filtered", "silent"]
+        ),
         time_scanned=timezone.make_aware(
             fake.date_time_between(start_date="-1y", end_date="now")
         ),
         nmi_service_group=nmi_group,
-        risky_service_group = risky_service_group
+        risky_service_group=risky_service_group,
     )
 
 

--- a/backend/src/xfd_django/xfd_api/tasks/syncdb_helpers.py
+++ b/backend/src/xfd_django/xfd_api/tasks/syncdb_helpers.py
@@ -302,9 +302,7 @@ def build_fake_port_scan(org):
         service_confidence=int(service_info["conf"]),
         service_method=service_info["method"],
         source="nmap",
-        state=random.choice(
-            ["open", "open", "open", "open", "closed", "filtered", "silent"]
-        ),
+        state=random.choice(["open", "open", "open", "open", "silent"]),
         time_scanned=timezone.make_aware(
             fake.date_time_between(start_date="-1y", end_date="now")
         ),

--- a/backend/src/xfd_django/xfd_api/tasks/vulnScanningSync.py
+++ b/backend/src/xfd_django/xfd_api/tasks/vulnScanningSync.py
@@ -522,6 +522,7 @@ def create_port_scan_summary(summary_date=None):
                 organization=org,
                 latest=True,  # only latest scans
                 time_scanned__isnull=False,
+                state="open",
             )
 
             if not scans.exists():
@@ -530,7 +531,7 @@ def create_port_scan_summary(summary_date=None):
             aggregated = scans.aggregate(
                 start_date=Min("time_scanned"),
                 end_date=Max("time_scanned"),
-                open_port_count=Count("id", filter=Q(state="open")),
+                open_port_count=Count("id"),
                 risky_port_count=Count(
                     "id", filter=Q(risky_service_group__isnull=False)
                 ),
@@ -801,7 +802,7 @@ def create_vuln_scan_summary(summary_date=None):
             included.filter(~Q(cve_string__isnull=True), ~Q(cve_string=""))
             .values("cve_string")
             .annotate(
-                count=Count("id"),
+                count=Count("ip_string"),
                 cvss_base_score=Max(
                     "cvss_base_score"
                 ),  # or Avg if you want to average across tickets
@@ -834,7 +835,7 @@ def create_vuln_scan_summary(summary_date=None):
             .filter(~Q(cve_string__isnull=True), ~Q(cve_string=""))
             .values("cve_string")
             .annotate(
-                count=Count("id"),
+                count=Count("ip_string"),
                 cvss_base_score=Max("cvss_base_score"),
                 severity=Max("cvss_severity"),
                 vuln_name=Max("vuln_name"),

--- a/backend/src/xfd_django/xfd_api/tasks/vulnScanningSync.py
+++ b/backend/src/xfd_django/xfd_api/tasks/vulnScanningSync.py
@@ -541,6 +541,18 @@ def create_port_scan_summary(summary_date=None):
                 unique_service_count=Count("service_name", distinct=True),
             )
 
+            risky_group_data = (
+                scans
+                .filter(risky_service_group__isnull=False)
+                .values("risky_service_group")
+                .annotate(count=Count("id"))
+            )
+
+            # Convert to dict: {group: count}
+            risky_service_group_counts = {
+                item["risky_service_group"]: item["count"] for item in risky_group_data
+            }
+
             PortScanSummary.objects.update_or_create(
                 organization=org,
                 summary_date=summary_date,
@@ -552,8 +564,10 @@ def create_port_scan_summary(summary_date=None):
                     "nmi_service_count": aggregated["nmi_service_count"],
                     "unique_ip_count": aggregated["unique_ip_count"],
                     "unique_service_count": aggregated["unique_service_count"],
+                    "risky_service_group_counts": risky_service_group_counts, 
                 },
             )
+
     except Exception as e:
         print("Error creating port scan summary: {}".format(e))
 

--- a/backend/src/xfd_django/xfd_api/tasks/vulnScanningSync.py
+++ b/backend/src/xfd_django/xfd_api/tasks/vulnScanningSync.py
@@ -863,7 +863,7 @@ def create_vuln_scan_summary(summary_date=None):
             is_open=True,
             cvss_base_score__isnull=False,
             ip_string__isnull=False,
-            source="nessus",
+            vuln_source="nessus",
             false_positive__in=[False, None],
         )
 

--- a/backend/src/xfd_django/xfd_api/tasks/vulnScanningSync.py
+++ b/backend/src/xfd_django/xfd_api/tasks/vulnScanningSync.py
@@ -542,8 +542,7 @@ def create_port_scan_summary(summary_date=None):
             )
 
             risky_group_data = (
-                scans
-                .filter(risky_service_group__isnull=False)
+                scans.filter(risky_service_group__isnull=False)
                 .values("risky_service_group")
                 .annotate(count=Count("id"))
             )
@@ -564,7 +563,7 @@ def create_port_scan_summary(summary_date=None):
                     "nmi_service_count": aggregated["nmi_service_count"],
                     "unique_ip_count": aggregated["unique_ip_count"],
                     "unique_service_count": aggregated["unique_service_count"],
-                    "risky_service_group_counts": risky_service_group_counts, 
+                    "risky_service_group_counts": risky_service_group_counts,
                 },
             )
 

--- a/backend/src/xfd_django/xfd_api/utils/scan_utils/vuln_scanning_sync_utils.py
+++ b/backend/src/xfd_django/xfd_api/utils/scan_utils/vuln_scanning_sync_utils.py
@@ -660,6 +660,7 @@ def enforce_latest_flag_port_scan():
                 id
             FROM port_scan
             WHERE time_scanned IS NOT NULL
+            AND time_scanned > NOW() - INTERVAL '90 days'
             ORDER BY organization_id, ip_string, port, time_scanned DESC
         )
         UPDATE port_scan

--- a/backend/src/xfd_django/xfd_mini_dl/models.py
+++ b/backend/src/xfd_django/xfd_mini_dl/models.py
@@ -2979,6 +2979,11 @@ class PortScanSummary(models.Model):
     unique_service_count = models.IntegerField(
         null=True, blank=True, help_text="Number of unique services."
     )
+    risky_service_group_counts = models.JSONField(
+        null=True,
+        blank=True,
+        help_text="Dictionary of risky_service_group values and their counts",
+    )
 
     class Meta:
         """The Meta class for PortScanSummary."""


### PR DESCRIPTION

## 🗣 Description ##
This PR adds a new field to the Port Scan Summary that holds a dictionary containing counts of ports running a risky services grouped by those risky services.

This PR also updates the dummy data generation to better mimic how the data will show up with real data, helping the frontend better design their widgets.
## 💭 Motivation and context ##
This update is necessary to populate a port service level widget in the VS dashboard
## 🧪 Testing ##
Tested locally and all previously written tests still pass


## ✅ Pre-approval checklist ##

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - *eschew scope creep!*
- [X] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [X] All relevant type-of-change labels have been added.
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
