### PR TITLE
Include domain id in Top 5 risky hosts:CRASM-2455

### DIFF
--- a/backend/src/xfd_django/xfd_api/schema_models/stat_schema.py
+++ b/backend/src/xfd_django/xfd_api/schema_models/stat_schema.py
@@ -153,6 +153,7 @@ class RiskyHostStats(BaseModel):
     high: int
     critical: int
     total: int
+    domain_id: str
 
 
 class VulnScanSummaryResponse(BaseModel):
@@ -166,7 +167,6 @@ class VulnScanSummaryResponse(BaseModel):
     assets_owned_count: Optional[int] = None
     false_positive_count: Optional[int] = None
     vulnerable_host_count: Optional[int] = None
-    scanned_asset_count: Optional[int] = None
     unique_service_count: Optional[int] = None
     unique_low_severity_count: Optional[int] = None
     unique_medium_severity_count: Optional[int] = None
@@ -210,6 +210,7 @@ class HostScanSummaryResponse(BaseModel):
     host_ready_count: Optional[int] = 0
     up_host_count: Optional[int] = 0
     down_host_count: Optional[int] = 0
+    scanned_asset_count: Optional[int] = 0
 
 
 class PortScanSummaryResponse(BaseModel):
@@ -267,6 +268,7 @@ class VsTrendCondensedResponse(BaseModel):
     host_summary_host_ready_count: Optional[List[int]] = []
     host_summary_up_host_count: Optional[List[int]] = []
     host_summary_down_host_count: Optional[List[int]] = []
+    host_summary_scanned_asset_count: Optional[List[int]] = []
 
     port_scan_summary_id: Optional[List[int]] = []
     port_scan_summary_start_date: Optional[List[datetime]] = []
@@ -296,7 +298,6 @@ class VsTrendCondensedResponse(BaseModel):
     vuln_scan_summary_asset_count: Optional[List[int]] = []
     vuln_scan_summary_false_positive_count: Optional[List[int]] = []
     vuln_scan_summary_vulnerable_host_count: Optional[List[int]] = []
-    vuln_scan_summary_scanned_asset_count: Optional[List[int]] = []
     vuln_scan_summary_unique_service_count: Optional[List[int]] = []
     vuln_scan_summary_unique_none_severity_count: Optional[List[int]] = []
     vuln_scan_summary_unique_low_severity_count: Optional[List[int]] = []

--- a/backend/src/xfd_django/xfd_api/tasks/syncdb_helpers.py
+++ b/backend/src/xfd_django/xfd_api/tasks/syncdb_helpers.py
@@ -378,6 +378,7 @@ def build_fake_host_summaries():
                     "host_ready_count": host_ready_count,
                     "up_host_count": up_host_count,
                     "down_host_count": down_host_count,
+                    "scanned_asset_count": total_count,
                 },
             )
         except Exception as e:

--- a/backend/src/xfd_django/xfd_api/tasks/vulnScanningSync.py
+++ b/backend/src/xfd_django/xfd_api/tasks/vulnScanningSync.py
@@ -456,7 +456,7 @@ def create_daily_host_summary(org_id_dict, summary_date=None):
             SUM(CASE WHEN status = 'READY' THEN 1 ELSE 0 END) AS host_ready_count,
             SUM(CASE WHEN json_extract_path_text(state, 'up') = 'true' THEN 1 ELSE 0 END) AS up_host_count,
             SUM(CASE WHEN json_extract_path_text(state, 'up') = 'false' THEN 1 ELSE 0 END) AS down_host_count,
-            COUNT(*) AS scanned_asset_count,
+            COUNT(ip) AS scanned_asset_count,
         FROM vmtableau.hosts
         WHERE last_change >= GETDATE() - INTERVAL '100 days'
         GROUP BY owner;

--- a/backend/src/xfd_django/xfd_api/tasks/vulnScanningSync.py
+++ b/backend/src/xfd_django/xfd_api/tasks/vulnScanningSync.py
@@ -46,7 +46,6 @@ from xfd_api.utils.scan_utils.vuln_scanning_sync_utils import (
 )
 from xfd_mini_dl.models import (
     Cidr,
-    Host,
     HostSummary,
     NMIServiceGroup,
     Organization,
@@ -56,6 +55,7 @@ from xfd_mini_dl.models import (
     RiskyServiceGroup,
     Sector,
     Ticket,
+    Vulnerability,
     VulnScanSummary,
 )
 
@@ -455,7 +455,8 @@ def create_daily_host_summary(org_id_dict, summary_date=None):
             SUM(CASE WHEN status = 'RUNNING' THEN 1 ELSE 0 END) AS host_running_count,
             SUM(CASE WHEN status = 'READY' THEN 1 ELSE 0 END) AS host_ready_count,
             SUM(CASE WHEN json_extract_path_text(state, 'up') = 'true' THEN 1 ELSE 0 END) AS up_host_count,
-            SUM(CASE WHEN json_extract_path_text(state, 'up') = 'false' THEN 1 ELSE 0 END) AS down_host_count
+            SUM(CASE WHEN json_extract_path_text(state, 'up') = 'false' THEN 1 ELSE 0 END) AS down_host_count,
+            COUNT(*) AS scanned_asset_count,
         FROM vmtableau.hosts
         WHERE last_change >= GETDATE() - INTERVAL '100 days'
         GROUP BY owner;
@@ -881,10 +882,20 @@ def create_vuln_scan_summary(summary_date=None):
                 high=Count("id", filter=Q(cvss_severity=3)),
                 critical=Count("id", filter=Q(cvss_severity=4)),
                 weighted=Sum(weighted_expr),
+                sample_ticket_id=Min("id"),
             )
             .order_by("-weighted")[:5]
         )
 
+        ticket_ids = [str(item["sample_ticket_id"]) for item in risky_host_qs]
+
+        # Build a mapping from ticket_id → domain_id
+        vuln_domain_map = {
+            str(v.id): str(v.domain_id)
+            for v in Vulnerability.objects.filter(id__in=ticket_ids).only(
+                "id", "domain_id"
+            )
+        }
         # Convert to dictionary for JSONField
         top_5_hosts = {
             item["ip_string"]: {
@@ -896,6 +907,7 @@ def create_vuln_scan_summary(summary_date=None):
                 "rrs": round(item["weighted"], 2)
                 if item["weighted"] is not None
                 else 0,
+                "domain_id": vuln_domain_map.get(str(item["sample_ticket_id"])),
             }
             for item in risky_host_qs
         }
@@ -913,12 +925,6 @@ def create_vuln_scan_summary(summary_date=None):
                     vuln_source="nessus",
                 ).count(),
                 "vulnerable_host_count": included.values("ip_string")
-                .distinct()
-                .count(),
-                "scanned_asset_count": Host.objects.filter(
-                    organization=org, latest_vulnscan_timestamp__isnull=False
-                )
-                .values("ip_string")
                 .distinct()
                 .count(),
                 "unique_service_count": open_tickets.filter(vuln_source="nmap")

--- a/backend/src/xfd_django/xfd_api/tests/test_stats.py
+++ b/backend/src/xfd_django/xfd_api/tests/test_stats.py
@@ -534,6 +534,7 @@ def test_vs_trends_success():
         host_ready_count=7,
         up_host_count=8,
         down_host_count=3,
+        scanned_asset_count=11,
     )
 
     PortScanSummary.objects.create(
@@ -556,7 +557,6 @@ def test_vs_trends_success():
         assets_owned_count=100,
         false_positive_count=5,
         vulnerable_host_count=50,
-        scanned_asset_count=80,
         unique_service_count=12,
         unique_none_severity_count=1,
         unique_low_severity_count=2,
@@ -640,6 +640,7 @@ def test_vs_condensed_trends_success():
         host_ready_count=9,
         up_host_count=10,
         down_host_count=2,
+        scanned_asset_count=12,
     )
 
     PortScanSummary.objects.create(
@@ -662,7 +663,6 @@ def test_vs_condensed_trends_success():
         assets_owned_count=200,
         false_positive_count=0,
         vulnerable_host_count=100,
-        scanned_asset_count=150,
         unique_service_count=5,
         unique_none_severity_count=0,
         unique_low_severity_count=0,

--- a/backend/src/xfd_django/xfd_mini_dl/models.py
+++ b/backend/src/xfd_django/xfd_mini_dl/models.py
@@ -1826,11 +1826,6 @@ class VulnScanSummary(models.Model):
         blank=True,
         help_text="Count of Ip addresses that have an open ticket associated with them.",
     )
-    scanned_asset_count = models.IntegerField(
-        null=True,
-        blank=True,
-        help_text="Count of Ip addresses that have been scanned",
-    )
     unique_service_count = models.IntegerField(
         null=True,
         blank=True,
@@ -2376,6 +2371,11 @@ class HostSummary(models.Model):
         null=True,
         blank=True,
         help_text="Number of the hosts that were down in the last scan.",
+    )
+    scanned_asset_count = models.IntegerField(
+        null=True,
+        blank=True,
+        help_text="Count of Ip addresses that have been scanned",
     )
 
     class Meta:


### PR DESCRIPTION
Include domain id in Top 5 risky hosts vuln scan summary

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
This PR adds the domain_id related to the most risky hosts dictionary in the vuln scan summary return
## 💭 Motivation and context ##
This is necessary to navigate to the associated host/domain from the dashboard.
## 🧪 Testing ##
Tested locally

## ✅ Pre-approval checklist ##

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - *eschew scope creep!*
- [X] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [X] All relevant type-of-change labels have been added.
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
