### PR TITLE
Update CPE Field type to use textfield: CRASM-2467

### DIFF
--- a/backend/src/xfd_django/xfd_mini_dl/models.py
+++ b/backend/src/xfd_django/xfd_mini_dl/models.py
@@ -104,7 +104,7 @@ class Cpe(AutoLengthCheckModel):
         default=uuid.uuid4,
         help_text="PK: Unique identifier for a CPE Product object.",
     )
-    name = models.CharField(max_length=255, help_text="Name of the product.")
+    name = models.TextField(help_text="Name of the product.")
     version = models.CharField(max_length=255, help_text="Version of the product.")
     vendor = models.CharField(
         max_length=255, help_text="Vendor who created the product."
@@ -2858,8 +2858,7 @@ class PortScan(AutoLengthCheckModel):
         blank=True,
         help_text="The method that was used to identify the service on the port.",
     )
-    service_cpe = models.CharField(
-        max_length=255,
+    service_cpe = models.TextField(
         null=True,
         blank=True,
         help_text="The cpe of the product associated with the service on the port.",

--- a/backend/src/xfd_django/xfd_mini_dl/models.py
+++ b/backend/src/xfd_django/xfd_mini_dl/models.py
@@ -1496,8 +1496,7 @@ class VulnScan(AutoLengthCheckModel):
         null=True,
         help_text="Id to look up a vulnerability int the CERT Vulnerability Notes Database. https://www.kb.cert.org/vuls/",
     )
-    cpe = models.CharField(
-        max_length=255,
+    cpe = models.TextField(
         blank=True,
         null=True,
         help_text="Common Platform Enumeration (CPE) id for the product the vulnerability was found on.",


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
Update CPE Field type to use TextField instead of Charfield.
## 💭 Motivation and context ##
This will avoid overflow issues, when a large CPE is entered. We have seen these large CPE names in the VulnScan Import
## 🧪 Testing ##
Tested Locally
## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - *eschew scope creep!*
- [X] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [X] All relevant type-of-change labels have been added.
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
