### PR TITLE
Update state selection form to use local storage to avoid prompting on logout

### DIFF
--- a/frontend/src/components/Register/UpdateUserStateForm.tsx
+++ b/frontend/src/components/Register/UpdateUserStateForm.tsx
@@ -72,6 +72,7 @@ export const UpdateStateForm: React.FC<{
       }
 
       setIsLoading(false);
+      localStorage.setItem('user_state', values.state); // ✅ Save it
       onClose(); // Only close after handling
     } catch (error) {
       setErrorRequestMessage(

--- a/frontend/src/components/Register/UpdateUserStateForm.tsx
+++ b/frontend/src/components/Register/UpdateUserStateForm.tsx
@@ -72,7 +72,8 @@ export const UpdateStateForm: React.FC<{
       }
 
       setIsLoading(false);
-      localStorage.setItem('user_state', values.state); // ✅ Save it
+      // Save state selection to local storage to avoid logout re-trigger
+      localStorage.setItem('user_state', values.state);
       onClose(); // Only close after handling
     } catch (error) {
       setErrorRequestMessage(

--- a/frontend/src/pages/Risk/Risk.tsx
+++ b/frontend/src/pages/Risk/Risk.tsx
@@ -379,7 +379,7 @@ const Risk: React.FC<ContextType> = ({
                 new Date(n.start_datetime) <= new Date() &&
                 new Date(n.end_datetime) >= new Date()
             );
-            if (active) {
+            if (active && user && user.user_type !== 'globalAdmin') {
               setMaintenanceNotification(active);
               setIsLoginBlockedDialogOpen(true);
             }

--- a/frontend/src/pages/Risk/Risk.tsx
+++ b/frontend/src/pages/Risk/Risk.tsx
@@ -167,7 +167,10 @@ const Risk: React.FC<ContextType> = ({
 
   useEffect(() => {
     if (!isLoggingOut && user) {
-      if (!user.state || user.state === '') {
+      if (
+        (!user.state || user.state === '') &&
+        !localStorage.getItem('user_state')
+      ) {
         setIsUpdateStateFormOpen(true);
       }
     }
@@ -365,8 +368,9 @@ const Risk: React.FC<ContextType> = ({
         onClose={async () => {
           setIsUpdateStateFormOpen(false);
 
-          // Re-fetch user data or just check if state now exists
-          if (user && user.state) {
+          // Re-fetch updated user to prevent false popup
+          const updatedUser = await apiGet('/users/me');
+          if (updatedUser?.state && user?.user_type !== 'globalAdmin') {
             const notifications = await apiGet('/notifications');
             const active = notifications.find(
               (n: any) =>
@@ -375,7 +379,7 @@ const Risk: React.FC<ContextType> = ({
                 new Date(n.start_datetime) <= new Date() &&
                 new Date(n.end_datetime) >= new Date()
             );
-            if (active && user.user_type !== 'globalAdmin') {
+            if (active) {
               setMaintenanceNotification(active);
               setIsLoginBlockedDialogOpen(true);
             }

--- a/frontend/src/pages/Risk/Risk.tsx
+++ b/frontend/src/pages/Risk/Risk.tsx
@@ -379,7 +379,7 @@ const Risk: React.FC<ContextType> = ({
                 new Date(n.start_datetime) <= new Date() &&
                 new Date(n.end_datetime) >= new Date()
             );
-            if (active && user && user.user_type !== 'globalAdmin') {
+            if (active && updatedUser.user_type !== 'globalAdmin') {
               setMaintenanceNotification(active);
               setIsLoginBlockedDialogOpen(true);
             }


### PR DESCRIPTION
closes: [CRASM-2663](https://maestro.dhs.gov/jira/browse/CRASM-2663)

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
Fix bug that triggers state selection when clicking inventory.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
Bug was triggering state selection when clicking inventory.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
After creating a new user, agree to terms, select state, and then try to click on "inventory" link (as an unapproved user) the state selection popup should not be seen. It also should not show on logout.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


