### PR TITLE
Convert org id to uuid when comparing to list of org ids

### DIFF
--- a/backend/src/xfd_django/xfd_api/api_methods/stats.py
+++ b/backend/src/xfd_django/xfd_api/api_methods/stats.py
@@ -457,7 +457,7 @@ def get_vs_condensed_trending_data(filters, current_user):
         and not current_user.user_type == "regionalAdmin"
     ):
         org_ids = get_org_memberships(current_user)
-        if organization_id not in org_ids:
+        if uuid.UUID(organization_id) not in org_ids:
             raise HTTPException(
                 status_code=404, detail="Access denied to requested organization."
             )
@@ -541,7 +541,7 @@ def get_vs_trending_data(filters, current_user):
         and not current_user.user_type == "regionalAdmin"
     ):
         org_ids = get_org_memberships(current_user)
-        if organization_id not in org_ids:
+        if uuid.UUID(organization_id) not in org_ids:
             raise HTTPException(
                 status_code=404, detail="Access denied to requested organization."
             )  # User has no accessible organizations


### PR DESCRIPTION
Convert org id to uuid when comparing to list of org ids

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
When a standard user uses this endpoint the passed org id needs to be converted to a UUID before comparing to the list of orgs associated with the user
## 💭 Motivation and context ##
Standard users weren't being served data
## 🧪 Testing ##
tested locally


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
