### PR TITLE
CRASM-2662 Error Message Dialog for No Data

### DIFF
--- a/frontend/src/components/Dialog/NoDataErrorDialog.tsx
+++ b/frontend/src/components/Dialog/NoDataErrorDialog.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  Typography,
+  IconButton,
+  Box
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+
+export interface NoDataErrorDialogProps {
+  open?: boolean;
+  message?: string;
+  onClose?: () => void;
+}
+
+const defaultMessage = `No matching data available.\nPlease refine filters and retry the search.`;
+
+const NoDataErrorDialog: React.FC<NoDataErrorDialogProps> = ({
+  open = true,
+  message = defaultMessage,
+  onClose
+}) => {
+  const [internalOpen, setInternalOpen] = useState(open);
+
+  const handleClose = () => {
+    if (onClose) {
+      onClose();
+    } else {
+      setInternalOpen(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={internalOpen}
+      onClose={handleClose}
+      maxWidth="xs"
+      fullWidth
+      PaperProps={{
+        sx: {
+          textAlign: 'center',
+          padding: '2rem',
+          borderRadius: 2
+        }
+      }}
+    >
+      <IconButton
+        onClick={handleClose}
+        sx={{ position: 'absolute', top: 8, right: 8 }}
+        aria-label="Close dialog"
+      >
+        <CloseIcon />
+      </IconButton>
+
+      <DialogContent>
+        <Box display="flex" flexDirection="column" alignItems="center">
+          <ErrorOutlineIcon
+            color="primary"
+            sx={{ fontSize: 40, marginBottom: 2 }}
+          />
+          {message.split('\n').map((line, idx) => (
+            <Typography
+              key={idx}
+              variant="body1"
+              sx={{ mb: idx === 0 ? 1 : 0 }}
+            >
+              {line}
+            </Typography>
+          ))}
+        </Box>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default NoDataErrorDialog;

--- a/frontend/src/pages/VulnerabilityScanDash/TopVulnerabilities.tsx
+++ b/frontend/src/pages/VulnerabilityScanDash/TopVulnerabilities.tsx
@@ -130,18 +130,6 @@ export default function TopVulnerabilities({
         </Grid>
       </Grid>
       <Box sx={{ height: 'auto', mt: -1.5 }}>
-        {/* <RoundedTable
-          data={
-            activeLabel === 'KEV'
-              ? kevData
-              : activeLabel === 'All'
-              ? allData
-              : []
-          }
-          columns={topVulnerabilitiesColumns}
-          noDataMessage="There were no vulnerabilities found for this organization in the scan
-        results."
-        /> */}
         {tableData.length > 0 ? (
           <RoundedTable data={tableData} columns={topVulnerabilitiesColumns} />
         ) : (

--- a/frontend/src/pages/VulnerabilityScanDash/TopVulnerabilities.tsx
+++ b/frontend/src/pages/VulnerabilityScanDash/TopVulnerabilities.tsx
@@ -9,6 +9,7 @@ import TruncatedLink from 'components/Dashboard/TruncatedLink';
 import GraphChip from 'components/Dashboard/GraphChip';
 import InfoLabel from 'components/Dashboard/InfoLabel';
 import infoIconContent from './infoIconContent.json';
+import NoDataErrorDialog from 'components/Dialog/NoDataErrorDialog';
 
 const tooltipContentJson = infoIconContent.infoIconContent;
 
@@ -95,6 +96,7 @@ export default function TopVulnerabilities({
       )
     }
   ];
+  const tableData = activeLabel === 'KEV' ? kevData : allData;
 
   return (
     <Box
@@ -128,18 +130,23 @@ export default function TopVulnerabilities({
         </Grid>
       </Grid>
       <Box sx={{ height: 'auto', mt: -1.5 }}>
-        <RoundedTable
+        {/* <RoundedTable
           data={
             activeLabel === 'KEV'
               ? kevData
               : activeLabel === 'All'
-                ? allData
-                : []
+              ? allData
+              : []
           }
           columns={topVulnerabilitiesColumns}
           noDataMessage="There were no vulnerabilities found for this organization in the scan
         results."
-        />
+        /> */}
+        {tableData.length > 0 ? (
+          <RoundedTable data={tableData} columns={topVulnerabilitiesColumns} />
+        ) : (
+          <NoDataErrorDialog />
+        )}
       </Box>
     </Box>
   );

--- a/frontend/src/pages/VulnerabilityScanDash/VulnerabilityScan.tsx
+++ b/frontend/src/pages/VulnerabilityScanDash/VulnerabilityScan.tsx
@@ -371,59 +371,25 @@ export const VulnerabilityScan: React.FC<ContextType> = (props) => {
       </Stack>
     );
   }
-  // if (error) {
-  //   return (
-  //     <Stack
-  //       sx={{ maxWidth: '1152px', margin: 'auto', height: '100vh' }}
-  //       spacing={6}
-  //     >
-  //       {header}
-  //       <Alert severity="error">{error}</Alert>
-  //     </Stack>
-  //   );
-  // }
   if (error) {
     return (
-      // <>
-      //   {header}
-      //   <NoDataErrorDialog
-      //   // open={true}
-      //   // message={error}
-      //   // onClose={() => {
-      //   //   // Optional: you can route somewhere or trigger a refetch
-      //   //   window.location.reload(); // or just close and do nothing
-      //   // }}
-      //   />
-      // </>
       <Box
         sx={{
           maxWidth: '1152px',
           margin: 'auto',
-          height: '100vh',
-          px: { xs: 0, sm: 0.5, md: 1, lg: 1, xl: 0 }
+          px: {
+            xs: 0,
+            sm: 0.5,
+            md: 1,
+            lg: 1,
+            xl: 0
+          }
         }}
+        pb={6}
+        height={'100vh'}
       >
         {header}
         <NoDataErrorDialog />
-
-        <Box
-          sx={{
-            border: '1px solid',
-            borderRadius: '4px',
-            borderColor: 'neutrals.main',
-            backgroundColor: 'neutrals.white',
-            p: 8,
-            mt: 4,
-            textAlign: 'center'
-          }}
-        >
-          <Typography variant="subtitle1" color="textSecondary">
-            No matching data available.
-          </Typography>
-          <Typography variant="subtitle1" color="textSecondary">
-            Please refine filters and retry the search.
-          </Typography>
-        </Box>
       </Box>
     );
   }

--- a/frontend/src/pages/VulnerabilityScanDash/VulnerabilityScan.tsx
+++ b/frontend/src/pages/VulnerabilityScanDash/VulnerabilityScan.tsx
@@ -97,6 +97,21 @@ export const VulnerabilityScan: React.FC<ContextType> = (props) => {
   const [maintenanceNotification, setMaintenanceNotification] =
     useState<any>(null);
 
+  const FallbackMessage: React.FC<{ message?: string }> = ({
+    message = 'No matching data available.\nPlease refine filters and retry the search.'
+  }) => {
+    const lines = message.split('\n');
+    return (
+      <Box sx={{ p: 2, textAlign: 'center' }}>
+        {lines.map((line, idx) => (
+          <Typography key={idx} variant="body1" color="textSecondary">
+            {line}
+          </Typography>
+        ))}
+      </Box>
+    );
+  };
+
   useEffect(() => {
     if (!isLoggingOut && user) {
       if (
@@ -370,17 +385,47 @@ export const VulnerabilityScan: React.FC<ContextType> = (props) => {
   // }
   if (error) {
     return (
-      <>
+      // <>
+      //   {header}
+      //   <NoDataErrorDialog
+      //   // open={true}
+      //   // message={error}
+      //   // onClose={() => {
+      //   //   // Optional: you can route somewhere or trigger a refetch
+      //   //   window.location.reload(); // or just close and do nothing
+      //   // }}
+      //   />
+      // </>
+      <Box
+        sx={{
+          maxWidth: '1152px',
+          margin: 'auto',
+          height: '100vh',
+          px: { xs: 0, sm: 0.5, md: 1, lg: 1, xl: 0 }
+        }}
+      >
         {header}
-        <NoDataErrorDialog
-        // open={true}
-        // message={error}
-        // onClose={() => {
-        //   // Optional: you can route somewhere or trigger a refetch
-        //   window.location.reload(); // or just close and do nothing
-        // }}
-        />
-      </>
+        <NoDataErrorDialog />
+
+        <Box
+          sx={{
+            border: '1px solid',
+            borderRadius: '4px',
+            borderColor: 'neutrals.main',
+            backgroundColor: 'neutrals.white',
+            p: 8,
+            mt: 4,
+            textAlign: 'center'
+          }}
+        >
+          <Typography variant="subtitle1" color="textSecondary">
+            No matching data available.
+          </Typography>
+          <Typography variant="subtitle1" color="textSecondary">
+            Please refine filters and retry the search.
+          </Typography>
+        </Box>
+      </Box>
     );
   }
   return (
@@ -454,10 +499,19 @@ export const VulnerabilityScan: React.FC<ContextType> = (props) => {
             <SeverityByProminence data={vulnScanData.severityByProminence} />
           </Grid>
           <Grid size={{ xs: 12, lg: 6 }}>
-            <TopVulnerabilities
+            {/* <TopVulnerabilities
               allData={vulnScanData.topVulnerabilities}
               kevData={vulnScanData.topKevVulnerabilities}
-            />
+            /> */}
+            {vulnScanData.topVulnerabilities.length > 0 ||
+            vulnScanData.topKevVulnerabilities.length > 0 ? (
+              <TopVulnerabilities
+                allData={vulnScanData.topVulnerabilities}
+                kevData={vulnScanData.topKevVulnerabilities}
+              />
+            ) : (
+              <FallbackMessage />
+            )}
           </Grid>
         </Grid>
       </Box>

--- a/frontend/src/pages/VulnerabilityScanDash/VulnerabilityScan.tsx
+++ b/frontend/src/pages/VulnerabilityScanDash/VulnerabilityScan.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { withSearch } from '@elastic/react-search-ui';
 import {
-  Alert,
   Box,
   BoxProps,
   Grid,

--- a/frontend/src/pages/VulnerabilityScanDash/VulnerabilityScan.tsx
+++ b/frontend/src/pages/VulnerabilityScanDash/VulnerabilityScan.tsx
@@ -32,6 +32,7 @@ import TopVulnerableHosts from './TopVulnerableHosts';
 import TopVulnerabilities from './TopVulnerabilities';
 import SeverityByProminence from './SeverityByProminence';
 import infoIconContent from './infoIconContent.json';
+import NoDataErrorDialog from 'components/Dialog/NoDataErrorDialog';
 
 export interface VulnSeverities {
   label: string;
@@ -356,15 +357,30 @@ export const VulnerabilityScan: React.FC<ContextType> = (props) => {
       </Stack>
     );
   }
+  // if (error) {
+  //   return (
+  //     <Stack
+  //       sx={{ maxWidth: '1152px', margin: 'auto', height: '100vh' }}
+  //       spacing={6}
+  //     >
+  //       {header}
+  //       <Alert severity="error">{error}</Alert>
+  //     </Stack>
+  //   );
+  // }
   if (error) {
     return (
-      <Stack
-        sx={{ maxWidth: '1152px', margin: 'auto', height: '100vh' }}
-        spacing={6}
-      >
+      <>
         {header}
-        <Alert severity="error">{error}</Alert>
-      </Stack>
+        <NoDataErrorDialog
+        // open={true}
+        // message={error}
+        // onClose={() => {
+        //   // Optional: you can route somewhere or trigger a refetch
+        //   window.location.reload(); // or just close and do nothing
+        // }}
+        />
+      </>
     );
   }
   return (

--- a/frontend/src/pages/VulnerabilityScanDash/VulnerabilityScan.tsx
+++ b/frontend/src/pages/VulnerabilityScanDash/VulnerabilityScan.tsx
@@ -96,20 +96,21 @@ export const VulnerabilityScan: React.FC<ContextType> = (props) => {
   const [maintenanceNotification, setMaintenanceNotification] =
     useState<any>(null);
 
-  const FallbackMessage: React.FC<{ message?: string }> = ({
-    message = 'No matching data available.\nPlease refine filters and retry the search.'
-  }) => {
-    const lines = message.split('\n');
-    return (
-      <Box sx={{ p: 2, textAlign: 'center' }}>
-        {lines.map((line, idx) => (
-          <Typography key={idx} variant="body1" color="textSecondary">
-            {line}
-          </Typography>
-        ))}
-      </Box>
-    );
-  };
+  // Fallback message for displaying root page with message on noDataError.
+  // const FallbackMessage: React.FC<{ message?: string }> = ({
+  //   message = 'No matching data available.\nPlease refine filters and retry the search.'
+  // }) => {
+  //   const lines = message.split('\n');
+  //   return (
+  //     <Box sx={{ p: 2, textAlign: 'center' }}>
+  //       {lines.map((line, idx) => (
+  //         <Typography key={idx} variant="body1" color="textSecondary">
+  //           {line}
+  //         </Typography>
+  //       ))}
+  //     </Box>
+  //   );
+  // };
 
   useEffect(() => {
     if (!isLoggingOut && user) {
@@ -464,19 +465,10 @@ export const VulnerabilityScan: React.FC<ContextType> = (props) => {
             <SeverityByProminence data={vulnScanData.severityByProminence} />
           </Grid>
           <Grid size={{ xs: 12, lg: 6 }}>
-            {/* <TopVulnerabilities
+            <TopVulnerabilities
               allData={vulnScanData.topVulnerabilities}
               kevData={vulnScanData.topKevVulnerabilities}
-            /> */}
-            {vulnScanData.topVulnerabilities.length > 0 ||
-            vulnScanData.topKevVulnerabilities.length > 0 ? (
-              <TopVulnerabilities
-                allData={vulnScanData.topVulnerabilities}
-                kevData={vulnScanData.topKevVulnerabilities}
-              />
-            ) : (
-              <FallbackMessage />
-            )}
+            />
           </Grid>
         </Grid>
       </Box>


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.


For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #
Add Error Message Dialog for No Data
## 🗣 Description ##
Closes: [CRASM-2662](https://maestro.dhs.gov/jira/browse/CRASM-2662)  Added new component for displaying a popup no data error dialog to match design in ticket. Once user clicks out of the error popup, they are taken back to the root page and they can modify filters to refresh the search. Message will continue to prompt if no data is returned.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
Update error display for no data returned to make user aware of details.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
User should see the popup dialog when filters return no data.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


## 📷 Screenshots (if appropriate) ##
Error display:

![Screenshot 2025-06-10 at 10 20 35 AM](https://github.com/user-attachments/assets/46cc8e14-701f-4cef-bea8-cb1c8ca88d5d)

Vulnerability Scan Dashboard when closing out the error dialog (Blank until designs are decided):

![Screenshot 2025-06-10 at 10 20 46 AM](https://github.com/user-attachments/assets/899a1204-c6d8-4d65-93c9-a7aac8812ca1)



## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

