### PR TITLE
update api response based on passed dates

### DIFF
--- a/backend/src/xfd_django/xfd_api/api_methods/stats.py
+++ b/backend/src/xfd_django/xfd_api/api_methods/stats.py
@@ -1,5 +1,6 @@
 """Stats methods."""
 # Standard Python Libraries
+from datetime import datetime
 import json
 import uuid
 
@@ -460,58 +461,58 @@ def get_vs_condensed_trending_data(filters, current_user):
 
     start_date = filters.start_date
     end_date = filters.end_date
-    sources = filters.sources
+    sources = filters.sources or []
+    today = datetime.today().date()
+
     results = {}
 
-    # Helper function to replace None values with empty lists
     def replace_none_with_empty_list(results_dict):
         for key, value in results_dict.items():
             if value is None:
                 results_dict[key] = []
         return results_dict
 
-    if "host" in sources:
-        host_summaries = HostSummary.objects.filter(
-            organization=organization, summary_date__range=(start_date, end_date)
-        )
-        for obj in host_summaries:
-            for field, value in model_to_dict(obj).items():
-                key = f"host_summary_{field}"
+    def fetch_and_flatten(model, prefix, exclude_fields=None):
+        exclude_fields = exclude_fields or []
+        qs = model.objects.filter(organization=organization)
+
+        if not start_date and not end_date:
+            latest = qs.order_by("-summary_date").first()
+            summaries = [latest] if latest else []
+        elif start_date and not end_date:
+            summaries = qs.filter(summary_date__range=(start_date, today)).order_by(
+                "summary_date"
+            )
+        elif not start_date and end_date:
+            summaries = qs.filter(summary_date=end_date).order_by("summary_date")
+        else:
+            summaries = qs.filter(summary_date__range=(start_date, end_date)).order_by(
+                "summary_date"
+            )
+
+        if exclude_fields:
+            summaries = summaries.defer(*exclude_fields)
+
+        for obj in summaries:
+            obj_dict = model_to_dict(obj, exclude=exclude_fields)
+            for field, value in obj_dict.items():
+                key = f"{prefix}_{field}"
                 results.setdefault(key, []).append(value)
+
+    if "host" in sources:
+        fetch_and_flatten(HostSummary, "host_summary")
 
     if "port" in sources:
-        port_scan_summaries = PortScanSummary.objects.filter(
-            organization=organization, summary_date__range=(start_date, end_date)
-        )
-        for obj in port_scan_summaries:
-            for field, value in model_to_dict(obj).items():
-                key = f"port_scan_summary_{field}"
-                results.setdefault(key, []).append(value)
+        fetch_and_flatten(PortScanSummary, "port_scan_summary")
 
     if "port_service" in sources:
-        port_scan_service_summaries = PortScanServiceSummary.objects.filter(
-            organization=organization, summary_date__range=(start_date, end_date)
-        )
-        for obj in port_scan_service_summaries:
-            for field, value in model_to_dict(obj).items():
-                key = f"port_scan_service_summary_{field}"
-                results.setdefault(key, []).append(value)
+        fetch_and_flatten(PortScanServiceSummary, "port_scan_service_summary")
 
     if "vs" in sources:
-        vuln_scan_summaries_qs = VulnScanSummary.objects.filter(
-            organization=organization, summary_date__range=(start_date, end_date)
-        )
-        excluded = []
-        if not filters.enhanced_data:
-            vuln_scan_summaries_qs = vuln_scan_summaries_qs.defer("included_tickets")
-            excluded = ["included_tickets"]
-        for summary in vuln_scan_summaries_qs:
-            for field, value in model_to_dict(summary, exclude=excluded).items():
-                key = f"vuln_scan_summary_{field}"
-                results.setdefault(key, []).append(value)
+        exclude = ["included_tickets"] if not filters.enhanced_data else []
+        fetch_and_flatten(VulnScanSummary, "vuln_scan_summary", exclude_fields=exclude)
 
-    results = replace_none_with_empty_list(results)
-    return results
+    return replace_none_with_empty_list(results)
 
 
 def get_vs_trending_data(filters, current_user):
@@ -534,9 +535,8 @@ def get_vs_trending_data(filters, current_user):
         if uuid.UUID(organization_id) not in org_ids:
             raise HTTPException(
                 status_code=404, detail="Access denied to requested organization."
-            )  # User has no accessible organizations
+            )
 
-    # Regional Admins can only view vulnerabilities in their region
     if current_user.user_type == "regionalAdmin" and current_user.region_id:
         if organization.region_id != current_user.region_id:
             raise HTTPException(
@@ -545,47 +545,48 @@ def get_vs_trending_data(filters, current_user):
 
     start_date = filters.start_date
     end_date = filters.end_date
-    sources = filters.sources
-    if "host" in sources:
-        host_summaries = HostSummary.objects.filter(
-            organization=organization, summary_date__range=(start_date, end_date)
-        )
-        host_dicts = [model_to_dict(obj) for obj in host_summaries]
-    else:
-        host_dicts = None
+    sources = filters.sources or []
+    today = datetime.today().date()
 
-    if "port" in sources:
-        port_scan_summaries = PortScanSummary.objects.filter(
-            organization=organization, summary_date__range=(start_date, end_date)
+    def fetch_summaries(model, exclude_fields=None):
+        exclude_fields = exclude_fields or []
+        qs = model.objects.filter(organization=organization)
+
+        if not start_date and not end_date:
+            latest = qs.order_by("-summary_date").first()
+            return [model_to_dict(latest, exclude=exclude_fields)] if latest else []
+
+        if start_date and not end_date:
+            qs = qs.filter(summary_date__range=(start_date, today))
+        elif not start_date and end_date:
+            qs = qs.filter(summary_date=end_date)
+        else:
+            qs = qs.filter(summary_date__range=(start_date, end_date))
+
+        qs = qs.order_by("summary_date")  # Order ascending by date
+
+        if exclude_fields:
+            qs = qs.defer(*exclude_fields)
+
+        return [model_to_dict(obj, exclude=exclude_fields) for obj in qs]
+
+    host_dicts = fetch_summaries(HostSummary) if "host" in sources else None
+
+    ports_dicts = fetch_summaries(PortScanSummary) if "port" in sources else None
+
+    port_services_dicts = (
+        fetch_summaries(PortScanServiceSummary) if "port_service" in sources else None
+    )
+
+    vuln_scan_summaries = (
+        fetch_summaries(
+            VulnScanSummary,
+            exclude_fields=["included_tickets"] if not filters.enhanced_data else [],
         )
-        ports_dicts = [model_to_dict(obj) for obj in port_scan_summaries]
-    else:
-        ports_dicts = None
-    if "port_service" in sources:
-        port_scan_service_summaries = PortScanServiceSummary.objects.filter(
-            organization=organization, summary_date__range=(start_date, end_date)
-        )
-        port_services_dicts = [
-            model_to_dict(obj) for obj in port_scan_service_summaries
-        ]
-    else:
-        port_services_dicts = None
-    if "vs" in sources:
-        vuln_scan_summaries_qs = VulnScanSummary.objects.filter(
-            organization=organization, summary_date__range=(start_date, end_date)
-        )
-        excluded = []
-        # Defer the field you don’t want to load into memory
-        if not filters.enhanced_data:
-            vuln_scan_summaries_qs = vuln_scan_summaries_qs.defer("included_tickets")
-            excluded = ["included_tickets"]
-        # Convert to dicts while excluding the field
-        vuln_scan_summaries = [
-            model_to_dict(summary, exclude=excluded)
-            for summary in vuln_scan_summaries_qs
-        ]
-    else:
-        vuln_scan_summaries = None
+        if "vs" in sources
+        else None
+    )
+
     return {
         "host_summaries": host_dicts,
         "port_scan_summaries": ports_dicts,

--- a/backend/src/xfd_django/xfd_api/schema_models/stat_schema.py
+++ b/backend/src/xfd_django/xfd_api/schema_models/stat_schema.py
@@ -1,11 +1,11 @@
 """Stats schema."""
 # Standard Python Libraries
-from datetime import date, datetime, timedelta
+from datetime import date, datetime
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
 # Third-Party Libraries
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 
 # Reusing the previously defined models
@@ -116,14 +116,8 @@ class TrendStatsFilterSchema(BaseModel):
     """Filter options for trend statistics queries."""
 
     organization_id: str
-    start_date: Optional[date] = Field(
-        default_factory=lambda: (
-            datetime.today() - timedelta(days=180)
-        ).date()  # Using `datetime.today()`
-    )
-    end_date: Optional[date] = Field(
-        default_factory=lambda: datetime.today().date()  # Using `datetime.today()`
-    )
+    start_date: Optional[date] = None
+    end_date: Optional[date] = None
     sources: Optional[List[str]] = ["vs"]
     enhanced_data: Optional[bool] = False
 
@@ -305,7 +299,6 @@ class VsTrendCondensedResponse(BaseModel):
     vuln_scan_summary_false_positive_count: Optional[List[int]] = []
     vuln_scan_summary_vulnerable_host_count: Optional[List[int]] = []
     vuln_scan_summary_unique_service_count: Optional[List[int]] = []
-    vuln_scan_summary_unique_none_severity_count: Optional[List[int]] = []
     vuln_scan_summary_unique_low_severity_count: Optional[List[int]] = []
     vuln_scan_summary_unique_medium_severity_count: Optional[List[int]] = []
     vuln_scan_summary_unique_high_severity_count: Optional[List[int]] = []
@@ -313,7 +306,6 @@ class VsTrendCondensedResponse(BaseModel):
     vuln_scan_summary_risky_services_count: Optional[List[int]] = []
     vuln_scan_summary_unsupported_software_count: Optional[List[int]] = []
     vuln_scan_summary_unique_os_count: Optional[List[int]] = []
-    vuln_scan_summary_none_severity_count: Optional[List[int]] = []
     vuln_scan_summary_low_severity_count: Optional[List[int]] = []
     vuln_scan_summary_medium_severity_count: Optional[List[int]] = []
     vuln_scan_summary_high_severity_count: Optional[List[int]] = []
@@ -322,7 +314,6 @@ class VsTrendCondensedResponse(BaseModel):
     vuln_scan_summary_high_max_age: Optional[List[int]] = []
     vuln_scan_summary_medium_max_age: Optional[List[int]] = []
     vuln_scan_summary_low_max_age: Optional[List[int]] = []
-    vuln_scan_summary_none_kev_count: Optional[List[int]] = []
     vuln_scan_summary_low_kev_count: Optional[List[int]] = []
     vuln_scan_summary_medium_kev_count: Optional[List[int]] = []
     vuln_scan_summary_high_kev_count: Optional[List[int]] = []

--- a/frontend/src/pages/VulnerabilityScanDash/VulnerabilityScan.tsx
+++ b/frontend/src/pages/VulnerabilityScanDash/VulnerabilityScan.tsx
@@ -56,12 +56,6 @@ const InitialVSData = {
   severityByProminence: []
 };
 
-const formatDate = (date: Date): string => date.toISOString().split('T')[0];
-const today = formatDate(new Date());
-const yesterday = formatDate(
-  new Date(new Date().setDate(new Date().getDate() - 1))
-);
-
 const tooltipContentJson = infoIconContent.infoIconContent;
 
 export const transformScanData = (rawData: any) => {
@@ -198,8 +192,6 @@ export const VulnerabilityScan: React.FC<ContextType> = (props) => {
           body: {
             filters: {
               organization_id: selectedOrgId,
-              start_date: yesterday,
-              end_date: today,
               sources: ['vs', 'port', 'port_service', 'host'],
               enhanced_data: false
             }

--- a/frontend/src/utils/transformVulnScanData.ts
+++ b/frontend/src/utils/transformVulnScanData.ts
@@ -18,6 +18,8 @@ export function formatShortDate(
   });
 }
 
+// Utility function to get the latest summary based on summary_date and transform the data.
+// This function is not needed when no dates are provided, but should be kept in case there are multiple entries.
 function getLatestSummary<T extends { summary_date?: string | null }>(
   summaries: T[]
 ): T | undefined {


### PR DESCRIPTION
update api response based on passed dates
## 🗣 Description ##
Update stats/trends endpoint to return the most recent summaries if no dates are passed. Also update logic if only one of the two is passed 

## 💭 Motivation and context ##
Frontend wasn't sure which summary to post if the last two days didn't have a summary. This change will always return the most recent summary, making sure the most up to date data is always displayed


## 🧪 Testing ##
Tested locally and via pytests

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
