### PR TITLE
CRASM-2706: All Domains use vuln and service counts instead of json objects

### DIFF
--- a/backend/src/xfd_django/xfd_api/api_methods/domain.py
+++ b/backend/src/xfd_django/xfd_api/api_methods/domain.py
@@ -109,8 +109,9 @@ def search_domains(domain_search: DomainSearch, current_user):
         if current_user.user_type == "regionalAdmin" and current_user.region_id:
             # Get all organization IDs in this region
             region_org_ids = list(
-                Organization.objects.filter(region_id=current_user.region_id)
-                .values_list("id", flat=True)
+                Organization.objects.filter(
+                    region_id=current_user.region_id
+                ).values_list("id", flat=True)
             )
 
             domains = domains.filter(organization_id__in=region_org_ids)

--- a/backend/src/xfd_django/xfd_api/api_methods/domain.py
+++ b/backend/src/xfd_django/xfd_api/api_methods/domain.py
@@ -8,7 +8,7 @@ import io
 from django.core.paginator import Paginator
 from django.db.models import Prefetch
 from fastapi import HTTPException
-from xfd_mini_dl.models import Domain, DomainSearchView, Service
+from xfd_mini_dl.models import Domain, DomainSearchView, Organization, Service
 
 from ..auth import get_org_memberships, is_global_view_admin
 from ..helpers.filter_helpers import apply_domain_filters, sort_direction
@@ -107,9 +107,13 @@ def search_domains(domain_search: DomainSearch, current_user):
 
         # Regional Admins can only view vulnerabilities in their region
         if current_user.user_type == "regionalAdmin" and current_user.region_id:
-            domains = domains.filter(
-                domain__organization__region_id=current_user.region_id
+            # Get all organization IDs in this region
+            region_org_ids = list(
+                Organization.objects.filter(region_id=current_user.region_id)
+                .values_list("id", flat=True)
             )
+
+            domains = domains.filter(organization_id__in=region_org_ids)
 
         # Apply filters if provided
         if domain_search.filters:

--- a/backend/src/xfd_django/xfd_api/api_methods/domain.py
+++ b/backend/src/xfd_django/xfd_api/api_methods/domain.py
@@ -115,6 +115,7 @@ def search_domains(domain_search: DomainSearch, current_user):
             paginator = Paginator(domains, page_size)
             page_obj = paginator.get_page(domain_search.page)
 
+        # Build result
         result = []
         for d in page_obj:
             result.append(
@@ -130,12 +131,15 @@ def search_domains(domain_search: DomainSearch, current_user):
                         "id": d.organization_id,
                         "name": d.organization_name,
                     },
-                    "vulnerabilities": d.vulnerabilities,
-                    "services": d.services,
-                    "webpages": [],
+                    "ports_preview": d.ports_preview,
+                    "services_preview": d.services_preview,
+                    "services_count": d.services_count,
+                    "vulnerabilities_count": d.vulnerabilities_count,
+                    "webpages": 0,
                 }
             )
 
+        # Return
         if page_size == -1:
             return result, len(result)
         else:
@@ -158,7 +162,7 @@ def export_domains(domain_search: DomainSearch, current_user):
 
         # If no domains, generate empty CSV
         if not domains:
-            csv_content = "name,ip,id,ports,products,createdAt,updatedAt,organization\n"
+            csv_content = "name,ip,id,createdAt,updatedAt,organization\n"
         else:
             # Process domains to flatten organization name,
             # ports as string, products as unique string
@@ -167,30 +171,12 @@ def export_domains(domain_search: DomainSearch, current_user):
                 organization_name = (
                     domain.organization.name if domain.organization else ""
                 )
-                ports = ", ".join(
-                    [str(service.port) for service in domain.services.all()]
-                )
-
-                # Collect unique products
-                products_set = set()
-                for service in domain.services.all():
-                    for product in service.products.all():
-                        if product.name:
-                            product_entry = (
-                                "{} {}".format(product.name, product.version)
-                                if product.version
-                                else product.name
-                            )
-                            products_set.add(product_entry)
-                products = ", ".join(sorted(products_set))
 
                 processed_domains.append(
                     {
                         "name": domain.name,
                         "ip": domain.ip,
                         "id": str(domain.id),
-                        "ports": ports,
-                        "products": products,
                         "created_at": domain.created_at.isoformat()
                         if domain.created_at
                         else "",
@@ -206,8 +192,6 @@ def export_domains(domain_search: DomainSearch, current_user):
                 "name",
                 "ip",
                 "id",
-                "ports",
-                "products",
                 "created_at",
                 "updated_at",
                 "organization",

--- a/backend/src/xfd_django/xfd_api/api_methods/vulnerability.py
+++ b/backend/src/xfd_django/xfd_api/api_methods/vulnerability.py
@@ -383,7 +383,7 @@ def search_vulnerabilities(vulnerability_search: VulnerabilitySearch, current_us
                 domain__organization_id__in=org_ids
             )
         # Regional Admins can only view vulnerabilities in their region
-        if current_user.user_type == "regionalAdmin" and current_user.region_idd:
+        if current_user.user_type == "regionalAdmin" and current_user.region_id:
             vulnerabilities = vulnerabilities.filter(
                 domain__organization__region_id=current_user.region_id
             )

--- a/backend/src/xfd_django/xfd_api/helpers/filter_helpers.py
+++ b/backend/src/xfd_django/xfd_api/helpers/filter_helpers.py
@@ -87,22 +87,6 @@ def apply_domain_filters(domains, filters):
     if filters.organization_name:
         q &= Q(organization_name__icontains=filters.organization_name)
 
-    # Vulnerabilities partial match
-    if filters.vulnerabilities:
-        q &= Q(vulnerabilities__icontains=filters.vulnerabilities)
-
-    # Ports
-    if hasattr(filters, "ports") and filters.ports:
-        try:
-            port_int = int(filters.ports)
-            q &= Q(services__icontains="{}".format(port_int))
-        except ValueError:
-            q &= Q(pk__in=[])
-
-    # Service partial match
-    if filters.service:
-        q &= Q(services__icontains=filters.service)
-
     # Apply the final Q object filter
     filtered = domains.filter(q)
 

--- a/backend/src/xfd_django/xfd_api/schema_models/domain.py
+++ b/backend/src/xfd_django/xfd_api/schema_models/domain.py
@@ -41,13 +41,10 @@ class Domain(BaseModel):
 class DomainFilters(BaseModel):
     """DomainFilters schema."""
 
-    port: Optional[int] = None
-    service: Optional[str] = None
     reverse_name: Optional[str] = None
     ip: Optional[str] = None
     organization: Optional[str] = None
     organization_name: Optional[str] = None
-    vulnerabilities: Optional[str] = None
     tag: Optional[str] = None
     name: Optional[str] = None
 
@@ -75,8 +72,26 @@ class DomainSearch(BaseModel):
 class DomainSearchResponse(BaseModel):
     """List of Domain objects."""
 
-    result: List["GetDomainResponse"]
+    result: List["DomainSearchResult"]
     count: int
+
+
+class DomainSearchResult(BaseModel):
+    """Domain search result."""
+
+    id: UUID
+    name: str
+    ip: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+    country: Optional[str] = None
+    cloud_hosted: Optional[bool] = False
+    organization: Optional["OrganizationResponse"]
+    vulnerabilities_count: Optional[int]
+    services_count: Optional[int]
+    ports_preview: Optional[str]
+    services_preview: Optional[str]
+    webpages: Optional[int] = None
 
 
 class TotalDomainsResponse(BaseModel):

--- a/backend/src/xfd_django/xfd_api/tasks/helpers/syncdb_helpers/create_db_views.py
+++ b/backend/src/xfd_django/xfd_api/tasks/helpers/syncdb_helpers/create_db_views.py
@@ -7,7 +7,7 @@ from django.db import connections
 VW_SERVICE_VERSION = "20250609"
 MAT_VW_COMBINED_VULNS_VERSION = "20250609"
 DOMAIN_MAT_VIEW_VERSION = "20250609"
-DOMAIN_SEARCH_MAT_VIEW_VERSION = "20250610"
+DOMAIN_SEARCH_MAT_VIEW_VERSION = "20250611"
 
 
 def create_vuln_normal_views(database):
@@ -720,29 +720,46 @@ def create_domain_search_mat_view(database):
                 d.created_at,
                 d.updated_at,
 
-                COALESCE(
-                    jsonb_agg(DISTINCT jsonb_build_object(
-                        'id', s.id,
-                        'port', s.port,
-                        'products', s.products,
-                        'last_seen', s.last_seen,
-                        'banner', s.banner
-                    )) FILTER (WHERE s.id IS NOT NULL),
-                    '[]'::jsonb
-                ) AS services,
+            -- First 3 ports preview as comma-separated string
+            (
+                SELECT string_agg(port::text, ', ')
+                FROM (
+                    SELECT sub_inner.port
+                    FROM (
+                        SELECT s2.port, s2.last_seen
+                        FROM mat_vw_service s2
+                        WHERE s2.domain_id = d.id
+                        ORDER BY s2.last_seen DESC
+                    ) sub_inner
+                    GROUP BY sub_inner.port
+                    ORDER BY max(sub_inner.last_seen) DESC
+                    LIMIT 3
+                ) sub
+            ) AS ports_preview,
 
-                COALESCE(
-                    jsonb_agg(DISTINCT jsonb_build_object(
-                        'id', v.vuln_id,
-                        'scan_source', v.scan_source,
-                        'title', v.title,
-                        'severity', v.severity,
-                        'state', v.state,
-                        'created_at', v.created_at,
-                        'cve', v.cve
-                    )) FILTER (WHERE v.vuln_id IS NOT NULL),
-                    '[]'::jsonb
-                ) AS vulnerabilities
+            -- First 3 service names preview as comma-separated string
+            (
+                SELECT string_agg(service_name, ', ')
+                FROM (
+                    SELECT sub_inner.service_name
+                    FROM (
+                        SELECT (s2.products->0->>'name') AS service_name, s2.last_seen
+                        FROM mat_vw_service s2
+                        WHERE s2.domain_id = d.id
+                        ORDER BY s2.last_seen DESC
+                    ) sub_inner
+                    GROUP BY sub_inner.service_name
+                    ORDER BY max(sub_inner.last_seen) DESC
+                    LIMIT 3
+                ) sub
+            ) AS services_preview,
+
+            -- Services count
+            COUNT(DISTINCT s.id) AS services_count,
+
+            -- Vulnerabilities count
+            CASE WHEN COUNT(DISTINCT v.vuln_id) = 0 THEN NULL ELSE COUNT(DISTINCT v.vuln_id) END AS vulnerabilities_count
+
             FROM
                 mat_vw_domain d
 

--- a/backend/src/xfd_django/xfd_api/tests/test_domain.py
+++ b/backend/src/xfd_django/xfd_api/tests/test_domain.py
@@ -218,64 +218,6 @@ def test_search_domain_by_ip(user, domain, refresh_vuln_views):
             search_fields["ip"], result["ip"]
         )
 
-
-@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
-def test_search_domain_by_port(user, domain, refresh_vuln_views):
-    """Test domain by port."""
-    response = client.post(
-        "/domain/search",
-        json={"page": 1, "filters": {"port": search_fields["port"]}, "page_size": 25},
-        headers={"Authorization": "Bearer " + create_jwt_token(user)},
-    )
-    assert response.status_code == 200
-    data = response.json()
-    assert data is not None, "Response is empty"
-    assert "result" in data, "Response does not contain 'result' key"
-    assert len(data["result"]) > 0, "No result found for the given IP"
-
-    for domain_data in data["result"]:
-        domain_id = domain_data.get("id", None)
-
-        assert domain_id is not None, "Domain Id not found in Response"
-        services = Service.objects.filter(domain=domain_id)
-        for service in services:
-            assert (
-                str(service.port) == search_fields["port"]
-            ), "Domain with ID {} does not have a service with port {}".format(
-                domain_id, domain.services.first().port
-            )
-
-
-@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
-def test_search_domain_by_service(user, domain, refresh_vuln_views):
-    """Test domain by service."""
-    services = Service.objects.filter(service="Apache httpd")
-    assert services.exists(), "No Service rows with 'Apache httpd' exist"
-
-    # Step 2: Check that Domain rows exist
-    domains = Domain.objects.filter(id=domain.id)
-    assert domains.exists(), f"Domain with id {domain.id} does not exist"
-
-    response = client.post(
-        "/domain/search",
-        json={
-            "page": 1,
-            "filters": {"service": "Apache httpd"},
-            "page_size": 25,
-        },
-        headers={"Authorization": "Bearer " + create_jwt_token(user)},
-    )
-    assert response.status_code == 200
-
-    data = response.json()
-    assert data is not None, "Response body is empty"
-    assert "result" in data, "Response does not contain 'result' key"
-    assert len(data["result"]) > 0, "No result found for the given service"
-
-    for domain_data in data["result"]:
-        assert domain_data["id"] == str(domain.id)
-
-
 @pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
 def test_search_domain_by_organization(user, domain, refresh_vuln_views):
     """Test domain by org."""
@@ -329,33 +271,6 @@ def test_search_domain_by_organization_name(user, domain, refresh_vuln_views):
             result["id"], search_fields["organization_name"]
         )
 
-
-@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
-def test_search_domain_by_vulnerabilities(user, domain, refresh_vuln_views):
-    """Test domain by vuln."""
-    # Test search domains by vulnerabilities
-    response = client.post(
-        "/domain/search",
-        json={
-            "page": 1,
-            "filters": {"vulnerabilities": str(domain.vulnerabilities.first().title)},
-            "page_size": 25,
-        },
-        headers={"Authorization": "Bearer " + create_jwt_token(user)},
-    )
-    assert response.status_code == 200
-    data = response.json()
-    assert "result" in data, "Response does not contain 'result' key"
-    assert len(data["result"]) > 0, "No result found for the given vulnerability"
-
-    for result in data["result"]:
-        assert str(domain.id) == str(
-            result["id"]
-        ), "Response domain {} did not relate back to the expected vulnerability {}".format(
-            result["id"], domain.id
-        )
-
-
 @pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
 def test_search_domains_multiple_criteria(user, domain, refresh_vuln_views):
     """Test domain by multi-criteria."""
@@ -364,7 +279,7 @@ def test_search_domains_multiple_criteria(user, domain, refresh_vuln_views):
         "/domain/search",
         json={
             "page": 1,
-            "filters": {"ip": search_fields["ip"], "port": search_fields["port"]},
+            "filters": {"ip": search_fields["ip"], "organization_name": search_fields["organization_name"]},
             "page_size": 25,
         },
         headers={"Authorization": "Bearer " + create_jwt_token(user)},

--- a/backend/src/xfd_django/xfd_api/tests/test_domain.py
+++ b/backend/src/xfd_django/xfd_api/tests/test_domain.py
@@ -281,7 +281,10 @@ def test_search_domains_multiple_criteria(user, domain, refresh_vuln_views):
         "/domain/search",
         json={
             "page": 1,
-            "filters": {"ip": search_fields["ip"], "organization_name": search_fields["organization_name"]},
+            "filters": {
+                "ip": search_fields["ip"],
+                "organization_name": search_fields["organization_name"],
+            },
             "page_size": 25,
         },
         headers={"Authorization": "Bearer " + create_jwt_token(user)},

--- a/backend/src/xfd_django/xfd_api/tests/test_domain.py
+++ b/backend/src/xfd_django/xfd_api/tests/test_domain.py
@@ -218,6 +218,7 @@ def test_search_domain_by_ip(user, domain, refresh_vuln_views):
             search_fields["ip"], result["ip"]
         )
 
+
 @pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
 def test_search_domain_by_organization(user, domain, refresh_vuln_views):
     """Test domain by org."""
@@ -270,6 +271,7 @@ def test_search_domain_by_organization_name(user, domain, refresh_vuln_views):
         ), "Domain with ID {} did not contain Organization Id {}".format(
             result["id"], search_fields["organization_name"]
         )
+
 
 @pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
 def test_search_domains_multiple_criteria(user, domain, refresh_vuln_views):

--- a/backend/src/xfd_django/xfd_mini_dl/models.py
+++ b/backend/src/xfd_django/xfd_mini_dl/models.py
@@ -4667,9 +4667,10 @@ class DomainSearchView(models.Model):
     reverse_name = models.TextField(null=True)
     created_at = models.DateTimeField()
     updated_at = models.DateTimeField()
-
-    services = models.JSONField()
-    vulnerabilities = models.JSONField()
+    ports_preview = models.TextField(null=True)
+    services_preview = models.TextField(null=True)
+    services_count = models.IntegerField(null=True)
+    vulnerabilities_count = models.IntegerField(null=True)
 
     class Meta:
         """Set DomainSearchView metadata."""

--- a/frontend/src/hooks/useDomainApi.ts
+++ b/frontend/src/hooks/useDomainApi.ts
@@ -1,14 +1,14 @@
-import { Query, Domain } from 'types';
+import { Query, Domain, DomainSearchApiResponse } from 'types';
 import { useAuthContext } from 'context';
 import { useCallback } from 'react';
 import { ORGANIZATION_EXCLUSIONS } from './useUserTypeFilters';
 
-export interface DomainQuery extends Query<Domain> {
+export interface DomainQuery extends Query<DomainSearchApiResponse> {
   showAll?: boolean;
 }
 
 interface ApiResponse {
-  result: Domain[];
+  result: DomainSearchApiResponse[];
   count: number;
   url?: string;
 }
@@ -19,7 +19,7 @@ export const useDomainApi = (showAll?: boolean) => {
   const { currentOrganization, apiPost, apiGet } = useAuthContext();
   const listDomains = useCallback(
     async (query: DomainQuery, doExport = false) => {
-      const { page, filters, pageSize = PAGE_SIZE } = query;
+      const { page, filters, page_size = PAGE_SIZE } = query;
       const tableFilters: any = filters
         .filter((f) => Boolean(f.value))
         .reduce(
@@ -43,7 +43,7 @@ export const useDomainApi = (showAll?: boolean) => {
         doExport ? '/domain/export' : '/domain/search',
         {
           body: {
-            pageSize,
+            page_size,
             page,
             filters: tableFilters
           }
@@ -54,7 +54,7 @@ export const useDomainApi = (showAll?: boolean) => {
         domains: result,
         count,
         url,
-        pageCount: Math.ceil(count / pageSize)
+        pageCount: Math.ceil(count / page_size)
       };
     },
     [apiPost, currentOrganization]

--- a/frontend/src/pages/Domains/Domains.tsx
+++ b/frontend/src/pages/Domains/Domains.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Query } from 'types';
 import { Subnav } from 'components';
-import { Domain } from 'types';
+import { DomainSearchApiResponse } from 'types';
 import { useAuthContext } from 'context';
 import { useDomainApi } from 'hooks';
 import { Box, Stack } from '@mui/system';
@@ -20,20 +20,23 @@ export interface DomainRow {
   organization_name: string;
   name: string;
   ip: string;
-  ports: string[];
-  service: string[];
-  vulnerabilities: (string | null)[];
+  ports_preview: string;
+  services_preview: string;
+  services_count: number;
+  vulnerabilities_count: number;
   updated_at: string;
   created_at: string;
 }
 
 export const Domains: React.FC = () => {
   const { showAllOrganizations } = useAuthContext();
-  const [domains, setDomains] = useState<Domain[]>([]);
+  const [domains, setDomains] = useState<DomainSearchApiResponse[]>([]);
   const [totalResults, setTotalResults] = useState(0);
   const { listDomains } = useDomainApi(showAllOrganizations);
   const history = useHistory();
-  const [filters, setFilters] = useState<Query<Domain>['filters']>([]);
+  const [filters, setFilters] = useState<
+    Query<DomainSearchApiResponse>['filters']
+  >([]);
   const [loadingError, setLoadingError] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [filterModel, setFilterModel] = useState({
@@ -47,7 +50,7 @@ export const Domains: React.FC = () => {
   // TO-DO
   // Implement regional rollup on domains view to allow for proper domain drilldown from dashboard
   const fetchDomains = useCallback(
-    async (q: Query<Domain>) => {
+    async (q: Query<DomainSearchApiResponse>) => {
       try {
         const { domains, count } = await listDomains(q);
         if (domains.length === 0) {
@@ -82,6 +85,22 @@ export const Domains: React.FC = () => {
     [listDomains]
   );
 
+  function formatPreview(
+    preview: string,
+    totalCount: number,
+    maxFullCount = 3,
+    maxPreviewCount = 2
+  ) {
+    if (totalCount <= maxFullCount) {
+      // Show full preview as-is
+      return preview;
+    } else {
+      // Show first N preview, add (X total)
+      const previewItems = preview.split(',').map((item) => item.trim());
+      const limitedPreview = previewItems.slice(0, maxPreviewCount).join(', ');
+      return `${limitedPreview} (${totalCount} total)`;
+    }
+  }
   const [paginationModel, setPaginationModel] = useState({
     page: 0,
     pageSize: PAGE_SIZE,
@@ -103,11 +122,13 @@ export const Domains: React.FC = () => {
     organization_name: domain.organization.name,
     name: domain.name,
     ip: domain.ip,
-    ports: [domain.services.map((service) => service.port).join(', ')],
-    service: domain.services.map((service) =>
-      service.products.map((p) => p.name).join(', ')
+    ports_preview: formatPreview(domain.ports_preview, domain.services_count),
+    services_preview: formatPreview(
+      domain.services_preview,
+      domain.services_count
     ),
-    vulnerabilities: domain.vulnerabilities.map((vuln) => vuln.title),
+    services_count: domain.services_count,
+    vulnerabilities_count: domain.vulnerabilities_count,
     updated_at: `${differenceInCalendarDays(
       Date.now(),
       parseISO(domain.updated_at)
@@ -127,13 +148,18 @@ export const Domains: React.FC = () => {
     },
     { field: 'name', headerName: 'Domain', minWidth: 100, flex: 2 },
     { field: 'ip', headerName: 'IP', minWidth: 50, flex: 1 },
-    { field: 'ports', headerName: 'Ports', minWidth: 100, flex: 1 },
-    { field: 'service', headerName: 'Services', minWidth: 100, flex: 2 },
+    { field: 'ports_preview', headerName: 'Ports', minWidth: 100, flex: 1 },
     {
-      field: 'vulnerabilities',
-      headerName: 'Vulnerabilities',
+      field: 'services_preview',
+      headerName: 'Services',
       minWidth: 100,
       flex: 2
+    },
+    {
+      field: 'vulnerabilities_count',
+      headerName: 'Vulnerabilities',
+      minWidth: 50,
+      flex: 1
     },
     { field: 'updated_at', headerName: 'Updated At', minWidth: 50, flex: 1 },
     { field: 'created_at', headerName: 'Created At', minWidth: 50, flex: 1 },

--- a/frontend/src/types/domain.ts
+++ b/frontend/src/types/domain.ts
@@ -138,6 +138,24 @@ export interface Domain {
   subdomain_source: string | null;
 }
 
+export interface DomainSearchApiResponse {
+  id: string;
+  name: string;
+  ip: string;
+  created_at: string;
+  updated_at: string;
+  country: string | null;
+  cloud_hosted: boolean;
+  organization: {
+    id: string;
+    name: string;
+  };
+  ports_preview: string;
+  services_preview: string;
+  services_count: number;
+  vulnerabilities_count: number;
+}
+
 export interface SSLInfo {
   issuerOrg: string | null;
   issuerCN: string | null;

--- a/frontend/src/types/query.ts
+++ b/frontend/src/types/query.ts
@@ -7,6 +7,7 @@ export interface CustomGridFilterItem<T> extends GridFilterItem {
 export interface Query<T extends object> {
   page: number;
   filters: CustomGridFilterItem<T>[];
+  // TODO: CRASM-2708: Update /vulnerabilities/search call to pass page_size instead of pageSize
   pageSize?: number;
   page_size?: number;
   showAll?: boolean;

--- a/frontend/src/types/query.ts
+++ b/frontend/src/types/query.ts
@@ -8,5 +8,6 @@ export interface Query<T extends object> {
   page: number;
   filters: CustomGridFilterItem<T>[];
   pageSize?: number;
+  page_size?: number;
   showAll?: boolean;
 }


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

- Updates DomainSearch materialized view to calculate counts instead of full json
- Updates the domain/search endpoint to call the original Domain view and get a count of vulnerabilities and services instead of the json list
- Confirms the frontend to use the /domain/{id} endpoint when filling out the domain drill-down page
- Fixes page_size being passed to /domains/search instead of pageSize

<img width="1704" alt="Screenshot 2025-06-11 at 4 17 28 PM" src="https://github.com/user-attachments/assets/22434570-5b00-4c2f-913a-3c2bd9e4115a" />

<img width="348" alt="Screenshot 2025-06-11 at 4 19 45 PM" src="https://github.com/user-attachments/assets/47144e64-845a-4535-a0cc-645d05d52440" />

## 💭 Motivation and context ##

The original design of the Inventory All domains page decided to list all vulnerabilities and services in the domains table (per domain). These are not even readable and are causing timeout or exceeded memory errors.

These should be counts instead and then in the domain drill-down all of the domains and services are requested through the domain/{id} endpoint.


## 🧪 Testing ##

Passes pre-commit and github checks

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [x] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Revert dependencies to default branches.
- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
