### PR TITLE
Remove no data error dialog popup for no top vulnerabilities

### DIFF
--- a/frontend/src/pages/VulnerabilityScanDash/TopVulnerabilities.tsx
+++ b/frontend/src/pages/VulnerabilityScanDash/TopVulnerabilities.tsx
@@ -9,7 +9,6 @@ import TruncatedLink from 'components/Dashboard/TruncatedLink';
 import GraphChip from 'components/Dashboard/GraphChip';
 import InfoLabel from 'components/Dashboard/InfoLabel';
 import infoIconContent from './infoIconContent.json';
-import NoDataErrorDialog from 'components/Dialog/NoDataErrorDialog';
 
 const tooltipContentJson = infoIconContent.infoIconContent;
 
@@ -138,11 +137,12 @@ export default function TopVulnerabilities({
         </Grid>
       </Grid>
       <Box sx={{ height: 'auto', mt: -1.5 }}>
-        {tableData.length > 0 ? (
-          <RoundedTable data={tableData} columns={topVulnerabilitiesColumns} />
-        ) : (
-          <NoDataErrorDialog />
-        )}
+        <RoundedTable
+          data={tableData}
+          columns={topVulnerabilitiesColumns}
+          noDataMessage="There were no vulnerabilities found for this organization in the scan
+        results."
+        />
       </Box>
     </Box>
   );


### PR DESCRIPTION
Remove No Data Error Dialog from displaying when no top vulnerabilities are returned in dashboard closes: [CRASM-2712](https://maestro.dhs.gov/jira/browse/CRASM-2712)
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
Remove No Data Error Dialog from displaying when no top vulnerabilities are returned in dashboard closes: [CRASM-2712](https://maestro.dhs.gov/jira/browse/CRASM-2712) 

Added back original noDataMessage that was there prior to No Data Dialog being added.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
No data error popup was displaying when not data was in top vulnerabilities. This should only display when there are no root search results. 
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
No data error should not display now if no top vulnerabilities are returned. 
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

