### PR TITLE
Add unit tests for new s3 object store endpoint.

### DIFF
--- a/backend/src/xfd_django/xfd_api/tests/test_object_store.py
+++ b/backend/src/xfd_django/xfd_api/tests/test_object_store.py
@@ -1,0 +1,59 @@
+"""Tests for the object-store API endpoint."""
+
+# Standard Python Libraries
+from datetime import datetime
+import secrets
+from unittest.mock import patch
+
+# Third-Party Libraries
+from fastapi.testclient import TestClient
+import pytest
+from xfd_api.auth import create_jwt_token
+from xfd_django.asgi import app
+from xfd_mini_dl.models import User, UserType
+
+client = TestClient(app)
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
+@patch("xfd_api.api_methods.object_store.S3Client")
+def test_get_presigned_url_basic(mock_s3_client):
+    """Basic test for /v1/object-store/presigned-url that skips bucket checks."""
+    # Create a test user
+    user = User.objects.create(
+        first_name="",
+        last_name="",
+        email=f"{secrets.token_hex(4)}@example.com",
+        user_type=UserType.GLOBAL_VIEW,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+    # Mock the S3 client's get_presigned_url method
+    mock_s3_client_instance = mock_s3_client.return_value
+    mock_s3_client_instance.get_presigned_url.return_value = (
+        "https://mocked-url.com/object"
+    )
+
+    # Auth header
+    token = create_jwt_token(user)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    # Request payload
+    payload = {"bucket_name": "ignored-bucket", "object_key": "some/file.txt"}
+
+    # Make request
+    response = client.post(
+        "/v1/object-store/presigned-url", json=payload, headers=headers
+    )
+
+    # Assertions
+    assert response.status_code == 200
+    assert response.json() == {"url": "https://mocked-url.com/object"}
+
+
+@pytest.mark.django_db
+def test_get_object_not_found():
+    """Test retrieving a nonexistent object."""
+    response = client.get("v1/object-store/nonexistent-key")
+    assert response.status_code == 404


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #
Adds unit test for object-store endpoint to prevent other failed CI tests. Closes: [CRASM-2734](https://maestro.dhs.gov/jira/browse/CRASM-2734)
## 🗣 Description ##
Adds unit test for object-store endpoint to prevent other failed CI tests.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
Adds unit test for object-store endpoint to prevent other failed CI tests.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

