### PR TITLE
CRASM-2716 Update the NoDataErrorDialog to show on Zero Value Results

### DIFF
--- a/frontend/src/pages/VulnerabilityScanDash/VulnerabilityScan.tsx
+++ b/frontend/src/pages/VulnerabilityScanDash/VulnerabilityScan.tsx
@@ -404,6 +404,17 @@ export const VulnerabilityScan: React.FC<ContextType> = (props) => {
     </Modal>
   );
 
+  const isDataEmpty =
+    !vulnScanData.vulnScanSummary.length &&
+    !vulnScanData.vulnScanKeyMetrics.length &&
+    !vulnScanData.detectedServicesKeyMetrics.length &&
+    !vulnScanData.detectedHostsKeyMetrics.length &&
+    !vulnScanData.detectedHostsTop5VulnerableHosts.length &&
+    !vulnScanData.topVulnerabilities.length &&
+    !vulnScanData.topKevVulnerabilities.length &&
+    !vulnScanData.riskyServices.length &&
+    !vulnScanData.severityByProminence.length;
+
   if (isUpdateStateFormOpen) {
     return (
       <UpdateStateForm
@@ -505,7 +516,8 @@ export const VulnerabilityScan: React.FC<ContextType> = (props) => {
       </Stack>
     );
   }
-  if (error) {
+
+  if (error || isDataEmpty) {
     return (
       <Box
         sx={{
@@ -527,6 +539,7 @@ export const VulnerabilityScan: React.FC<ContextType> = (props) => {
       </Box>
     );
   }
+
   return (
     <>
       {' '}


### PR DESCRIPTION
Closes: [CRASM-2716](https://maestro.dhs.gov/jira/browse/CRASM-2716)
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
Per leadership request, make the noDataErrorDialog show when the page loads, but there are zero values in the data.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
Per leadership request, make the noDataErrorDialog show when the page loads, but there are zero values in the data.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
On orgs with zero values in landing page, you should see the rendered results in the background as well as the error dialog.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

