### PR TITLE
Update all scans that use is_local and is_dmz params - CRASM-2752

### DIFF
--- a/backend/src/xfd_django/xfd_api/tasks/asm_sync.py
+++ b/backend/src/xfd_django/xfd_api/tasks/asm_sync.py
@@ -43,7 +43,7 @@ def handler(event):
     """Enumerate and identify assets belonging to each stakeholder."""
     try:
         is_dmz = os.getenv("IS_DMZ")
-        is_local = os.getenv("IS_LOCAL") 
+        is_local = os.getenv("IS_LOCAL")
         if str(is_dmz).lower() not in {"true", "1"} and not is_local:
             LOGGER.warning("Scan can only be run in the DMZ or locally. Exitting now.")
             return {

--- a/backend/src/xfd_django/xfd_api/tasks/asm_sync.py
+++ b/backend/src/xfd_django/xfd_api/tasks/asm_sync.py
@@ -42,9 +42,9 @@ headers = settings.DMZ_API_HEADER
 def handler(event):
     """Enumerate and identify assets belonging to each stakeholder."""
     try:
-        is_dmz = os.getenv("IS_DMZ", "0") == "1"
-        is_local = os.getenv("IS_LOCAL", "1") == "1"
-        if not is_dmz and not is_local:
+        is_dmz = os.getenv("IS_DMZ")
+        is_local = os.getenv("IS_LOCAL") 
+        if str(is_dmz).lower() not in {"true", "1"} and not is_local:
             LOGGER.warning("Scan can only be run in the DMZ or locally. Exitting now.")
             return {
                 "status_code": 200,

--- a/backend/src/xfd_django/xfd_api/tasks/credential_sync.py
+++ b/backend/src/xfd_django/xfd_api/tasks/credential_sync.py
@@ -48,10 +48,10 @@ unknown_data_source, uds_created = DataSource.objects.using(db_name).get_or_crea
 def handler(command_options):
     """Retrieve and save credential breaches and exposures from the DMZ."""
     try:
-        is_lz = os.getenv("IS_DMZ", "0") == "0"
-        is_local = os.getenv("IS_LOCAL", "true") == "true"
+        is_dmz = os.getenv("IS_DMZ")
+        is_local = os.getenv("IS_LOCAL")
 
-        if not is_lz and not is_local:
+        if str(is_dmz).lower() in {"true", "1"} and not is_local:
             LOGGER.warning("Scan can only be run in the LZ or locally. Exitting now.")
             return {
                 "statusCode": 200,

--- a/backend/src/xfd_django/xfd_api/tasks/cybersixgill.py
+++ b/backend/src/xfd_django/xfd_api/tasks/cybersixgill.py
@@ -269,10 +269,10 @@ def handler(event):
     """Entrypoint for running Cybersixgill scan, with DMZ/local check."""
     try:
         # Check if script is allowed to run in current environment
-        is_dmz = os.getenv("IS_DMZ", "0") == "1"
-        is_local = os.getenv("IS_LOCAL", "1") == "1"
+        is_dmz = os.getenv("IS_DMZ")
+        is_local = os.getenv("IS_LOCAL")
 
-        if not is_dmz and not is_local:
+        if str(is_dmz).lower() not in {"true", "1"} and not is_local:
             LOGGER.warning("Scan can only be run in the DMZ or locally. Exiting now.")
             return {
                 "statusCode": 200,

--- a/backend/src/xfd_django/xfd_api/tasks/dns_twist.py
+++ b/backend/src/xfd_django/xfd_api/tasks/dns_twist.py
@@ -351,9 +351,9 @@ def main(event):
 def handler(event):
     """Dns Twist sync handler."""
     try:
-        is_dmz = os.getenv("IS_DMZ", "0") == "1"
-        is_local = os.getenv("IS_LOCAL", "1") == "1"
-        if not is_dmz and not is_local:
+        is_dmz = os.getenv("IS_DMZ")
+        is_local = os.getenv("IS_LOCAL")
+        if str(is_dmz).lower() not in {"true", "1"} and not is_local:
             LOGGER.warning("Scan can only be run in the DMZ or locally. Exiting now.")
             return {
                 "statusCode": 200,

--- a/backend/src/xfd_django/xfd_api/tasks/intel_x_identity.py
+++ b/backend/src/xfd_django/xfd_api/tasks/intel_x_identity.py
@@ -54,9 +54,9 @@ SOURCE_OBJ, created = DataSource.objects.get_or_create(
 def handler(command_options):
     """Identify credential breaches associated with stakeholder's root domains."""
     try:
-        is_dmz = os.getenv("IS_DMZ", "0") == "1"
-        is_local = os.getenv("IS_LOCAL", "1") == "1"
-        if not is_dmz and not is_local:
+        is_dmz = os.getenv("IS_DMZ")
+        is_local = os.getenv("IS_LOCAL")
+        if str(is_dmz).lower() not in {"true", "1"} and not is_local:
             LOGGER.warning("Scan can only be run in the DMZ or locally. Exitting now.")
             return {
                 "status_code": 200,

--- a/backend/src/xfd_django/xfd_api/tasks/refresh_vs_summaries.py
+++ b/backend/src/xfd_django/xfd_api/tasks/refresh_vs_summaries.py
@@ -78,7 +78,7 @@ def build_fake_host_summaries():
 
 def handler(event):
     """Retrieve and save NIST update alerts from the DMZ."""
-    is_local_value = os.getenv("IS_LOCAL", "1")
+    is_local_value = os.getenv("IS_LOCAL")
     is_local = str(is_local_value).lower() in ["1", "true"] or is_local_value is True
     LOGGER.info("IS_LOCAL equal %s", os.getenv("IS_LOCAL", "1"))
     try:

--- a/backend/src/xfd_django/xfd_api/tasks/refresh_vs_summaries.py
+++ b/backend/src/xfd_django/xfd_api/tasks/refresh_vs_summaries.py
@@ -79,7 +79,7 @@ def build_fake_host_summaries():
 def handler(event):
     """Retrieve and save NIST update alerts from the DMZ."""
     is_local_value = os.getenv("IS_LOCAL")
-    is_local = str(is_local_value).lower() in ["1", "true"] or is_local_value is True
+    is_local = str(is_local_value).lower() in ["1", "true"]
     LOGGER.info("IS_LOCAL equal %s", os.getenv("IS_LOCAL", "1"))
     try:
         try:

--- a/backend/src/xfd_django/xfd_api/tasks/sync_asm_sync.py
+++ b/backend/src/xfd_django/xfd_api/tasks/sync_asm_sync.py
@@ -44,10 +44,10 @@ unknown_data_source, uds_created = DataSource.objects.using(db_name).get_or_crea
 def handler(command_options):
     """Query ASM data for API endpoint."""
     try:
-        is_lz = os.getenv("IS_DMZ", "0") == "0"
-        is_local = os.getenv("IS_LOCAL", "true") == "true"
+        is_dmz = os.getenv("IS_DMZ")
+        is_local = os.getenv("IS_LOCAL")
 
-        if not is_lz and not is_local:
+        if str(is_dmz).lower() in {"true", "1"} and not is_local:
             LOGGER.warning("Scan can only be run in the LZ or locally. Exitting now.")
             return {
                 "statusCode": 200,

--- a/backend/src/xfd_django/xfd_api/tasks/xpanse_alert_pull.py
+++ b/backend/src/xfd_django/xfd_api/tasks/xpanse_alert_pull.py
@@ -708,9 +708,9 @@ def main(event):
 def handler(event):
     """Xpanse Alert Pull scan handler."""
     try:
-        is_dmz = os.getenv("IS_DMZ", "0") == "1"
-        is_local = os.getenv("IS_LOCAL", "1") == "1"
-        if not is_dmz and not is_local:
+        is_dmz = os.getenv("IS_DMZ")
+        is_local = os.getenv("IS_LOCAL")
+        if str(is_dmz).lower() not in {"true", "1"} and not is_local:
             LOGGER.warning("Scan can only be run in the DMZ or locally. Exiting now.")
             return {
                 "statusCode": 200,

--- a/backend/src/xfd_django/xfd_api/tasks/xpanse_org_sync.py
+++ b/backend/src/xfd_django/xfd_api/tasks/xpanse_org_sync.py
@@ -94,9 +94,9 @@ def main(_event):
 def handler(event):
     """Xpanse Organizations sync handler."""
     try:
-        is_dmz = os.getenv("IS_DMZ", "0") == "1"
-        is_local = os.getenv("IS_LOCAL", "1") == "1"
-        if not is_dmz and not is_local:
+        is_dmz = os.getenv("IS_DMZ")
+        is_local = os.getenv("IS_LOCAL")
+        if str(is_dmz).lower() not in {"true", "1"} and not is_local:
             LOGGER.warning("Scan can only be run in the DMZ or locally. Exiting now.")
             return {
                 "statusCode": 200,

--- a/infrastructure/worker.tf
+++ b/infrastructure/worker.tf
@@ -257,6 +257,10 @@ resource "aws_ecs_task_definition" "worker" {
         "value": "${var.db_port}"
       },
       {
+        "name": "IS_DMZ",
+        "value": "${var.is_dmz}"
+      },
+      {
         "name": "XPANSE_ORG_SYNC_BUCKET_NAME",
         "value": "${var.crossfeed-xpanse-org-sync}"
       }


### PR DESCRIPTION
Update all scans that use is_local and is_dmz params to correctly validate and default

## 🗣 Description ##
Update scans that can only run in specific environements to correctly use the IS_LOCAL and IS_DMZ variables.
Also add IS_DMZ to the terraform worker so that scans can correctly access it.

## 💭 Motivation and context ##
We want to verify that these locked down scans cannot be run in the wrong environment.
## 🧪 Testing ##
needs to be tested in the environments. to validate


## ✅ Pre-approval checklist ##


- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
