### PR TITLE
insert scanned_asset_count into HostSummary - CRASM-2754

### DIFF
--- a/backend/src/xfd_django/xfd_api/tasks/vulnScanningSync.py
+++ b/backend/src/xfd_django/xfd_api/tasks/vulnScanningSync.py
@@ -533,6 +533,7 @@ def create_daily_host_summary(org_id_dict, summary_date=None):
                     "host_ready_count": row["host_ready_count"],
                     "up_host_count": row["up_host_count"],
                     "down_host_count": row["down_host_count"],
+                    "scanned_asset_count": row["scanned_asset_count"],
                 },
             )
         except Organization.DoesNotExist:


### PR DESCRIPTION
Insert scanned_asset_count into HostSummary

## 🗣 Description ##
Add scanned_asset_count to the Host Summary that has been pulled from redshift
## 💭 Motivation and context ##
This was supposed to have been pulled and saved previously but was accidentally omitted.

## 🧪 Testing ##
Will need to be tested on actual redshift.


## ✅ Pre-approval checklist ##


- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
