### PR TITLE
Create daily summaries only after refreshing materialized views - CRASM-2751

### DIFF
--- a/backend/src/xfd_django/xfd_api/tasks/vulnScanningSync.py
+++ b/backend/src/xfd_django/xfd_api/tasks/vulnScanningSync.py
@@ -225,7 +225,9 @@ def main():  # pylint: disable=R0915
 
     # 🔁 REFRESH MATERIALIZED VIEWS BEFORE CREATING SUMMARIES
     LOGGER.info("Refreshing materialized views before creating summaries...")
-    refresh_materialized_views()
+    # Create or refresh materialized views
+    result = refresh_materialized_views({})
+    LOGGER.info(result)
     LOGGER.info("Finished refreshing materialized views")
 
     # ✅ Create summaries with individual error handling

--- a/backend/src/xfd_django/xfd_api/tasks/vulnScanningSync.py
+++ b/backend/src/xfd_django/xfd_api/tasks/vulnScanningSync.py
@@ -188,7 +188,6 @@ def main():  # pylint: disable=R0915
         LOGGER.info("Setting port scans latest flag")
         enforce_latest_flag_port_scan()
 
-
     # Fill CIDR live IPs
     fill_cidr_live_ips_bulk_update()
 
@@ -223,7 +222,7 @@ def main():  # pylint: disable=R0915
             chunk_number - 1,
         )
         LOGGER.info("Finished processing tickets")
-    
+
     # 🔁 REFRESH MATERIALIZED VIEWS BEFORE CREATING SUMMARIES
     LOGGER.info("Refreshing materialized views before creating summaries...")
     refresh_materialized_views()
@@ -242,14 +241,19 @@ def main():  # pylint: disable=R0915
         create_port_scan_service_summaries()
         LOGGER.info("Finished port scan service summaries")
     except Exception as e:
-        LOGGER.error("Failed to create port scan service summaries: %s", e, exc_info=True)
+        LOGGER.error(
+            "Failed to create port scan service summaries: %s", e, exc_info=True
+        )
 
     LOGGER.info("Creating vulnerability scan summary...")
     try:
         create_vuln_scan_summary()
         LOGGER.info("Finished vulnerability scan summary")
     except Exception as e:
-        LOGGER.error("Failed to create vulnerability scan summary: %s", e, exc_info=True)
+        LOGGER.error(
+            "Failed to create vulnerability scan summary: %s", e, exc_info=True
+        )
+
 
 def detect_data_set(query):
     """Detect the data set from the query."""

--- a/backend/src/xfd_django/xfd_api/tasks/vulnScanningSync.py
+++ b/backend/src/xfd_django/xfd_api/tasks/vulnScanningSync.py
@@ -23,6 +23,7 @@ from django.utils import timezone
 import psycopg2
 import requests
 from xfd_api.helpers.regionStateMap import REGION_STATE_MAP
+from xfd_api.tasks.refresh_material_views import handler as refresh_materialized_views
 from xfd_api.utils.chunk import chunk_list_by_bytes
 from xfd_api.utils.csv_utils import create_checksum
 from xfd_api.utils.hash import hash_ip
@@ -187,11 +188,6 @@ def main():  # pylint: disable=R0915
         LOGGER.info("Setting port scans latest flag")
         enforce_latest_flag_port_scan()
 
-        # Create port scan summaries
-        LOGGER.info("Creating port scan summaries")
-        create_port_scan_summary()
-        create_port_scan_service_summaries()
-        LOGGER.info("Finished processing port scans")
 
     # Fill CIDR live IPs
     fill_cidr_live_ips_bulk_update()
@@ -227,13 +223,33 @@ def main():  # pylint: disable=R0915
             chunk_number - 1,
         )
         LOGGER.info("Finished processing tickets")
-        try:
-            create_vuln_scan_summary()
-        except Exception as e:
-            raise QueryError(
-                SCAN_NAME, str(e), "Error creating vulnerability scan summary"
-            ) from e
+    
+    # 🔁 REFRESH MATERIALIZED VIEWS BEFORE CREATING SUMMARIES
+    LOGGER.info("Refreshing materialized views before creating summaries...")
+    refresh_materialized_views()
+    LOGGER.info("Finished refreshing materialized views")
 
+    # ✅ Create summaries with individual error handling
+    LOGGER.info("Creating port scan summary...")
+    try:
+        create_port_scan_summary()
+        LOGGER.info("Finished port scan summary")
+    except Exception as e:
+        LOGGER.error("Failed to create port scan summary: %s", e, exc_info=True)
+
+    LOGGER.info("Creating port scan service summaries...")
+    try:
+        create_port_scan_service_summaries()
+        LOGGER.info("Finished port scan service summaries")
+    except Exception as e:
+        LOGGER.error("Failed to create port scan service summaries: %s", e, exc_info=True)
+
+    LOGGER.info("Creating vulnerability scan summary...")
+    try:
+        create_vuln_scan_summary()
+        LOGGER.info("Finished vulnerability scan summary")
+    except Exception as e:
+        LOGGER.error("Failed to create vulnerability scan summary: %s", e, exc_info=True)
 
 def detect_data_set(query):
     """Detect the data set from the query."""


### PR DESCRIPTION
## 🗣 Description ##
Run summary creation only after the materialized view has fully refreshed.

## 💭 Motivation and context ##
Some of the summaries reference domains found in the materialized views, there is an edge case where the referenced domain may be new and will show up as null if the view is not refreshed.


## ✅ Pre-approval checklist ##


- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
