### PR TITLE
CRASM- 2829: Ensure users can't update themselves except name

### DIFF
--- a/backend/src/xfd_django/xfd_api/api_methods/user.py
+++ b/backend/src/xfd_django/xfd_api/api_methods/user.py
@@ -12,6 +12,7 @@ from xfd_mini_dl.models import Organization, Role, User
 
 from ..auth import (
     can_access_user,
+    get_allowed_user_update_fields,
     is_global_view_admin,
     is_global_write_admin,
     is_org_admin,
@@ -442,16 +443,27 @@ def update_user_v2(user_id, user_data, current_user):
                 status_code=403, detail="Only global admins can update userType."
             )
 
-        # Update fields
-        if user_data.state:
-            user.region_id = REGION_STATE_MAP.get(user_data.state)
+        # Check if allowed fields to update then execute
+        updates = user_data.dict(exclude_unset=True)
+        allowed_fields = get_allowed_user_update_fields(current_user, user)
 
-        print(user_data.dict())
-        # Check for invitePending explicitly
-        if user_data.invite_pending is not None:
-            user.invite_pending = user_data.invite_pending
-        for field, value in user_data.dict(exclude_defaults=True).items():
-            setattr(user, field, value)
+        # Check for disallowed fields before applying updates
+        disallowed_fields = set(updates.keys()) - allowed_fields
+        if disallowed_fields:
+            raise HTTPException(
+                status_code=403,
+                detail="Unauthorized to update the following fields: {}".format(
+                    ", ".join(disallowed_fields)
+                ),
+            )
+
+        # Apply only the allowed updates
+        for field, value in updates.items():
+            if field == "state":
+                user.region_id = REGION_STATE_MAP.get(value)
+                user.state = value
+            else:
+                setattr(user, field, value)
 
         # Save the updated user
         user.save()

--- a/backend/src/xfd_django/xfd_api/api_methods/user.py
+++ b/backend/src/xfd_django/xfd_api/api_methods/user.py
@@ -8,7 +8,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Prefetch
 from django.forms import model_to_dict
 from fastapi import HTTPException
-from xfd_mini_dl.models import Organization, Role, User
+from xfd_mini_dl.models import Organization, Role, User, UserType
 
 from ..auth import (
     can_access_user,
@@ -515,19 +515,32 @@ def approve_user_registration(user_id, current_user):
     if not is_valid_uuid(user_id):
         raise HTTPException(status_code=404, detail="Invalid user ID.")
 
+    if str(current_user.id) == str(user_id):
+        raise HTTPException(status_code=403, detail="Users cannot approve themselves.")
+
     try:
         # Retrieve the user by ID
         user = User.objects.get(id=user_id)
-        user.date_approved = datetime.now()
-        user.approved_by = current_user
-        user.first_login = True
-        user.save()
     except ObjectDoesNotExist:
         raise HTTPException(status_code=404, detail="User not found.")
+
+    if not (
+        is_global_write_admin(current_user)
+        or current_user.user_type == UserType.REGIONAL_ADMIN
+    ):
+        raise HTTPException(
+            status_code=403, detail="Only regional or global admins can approve users."
+        )
 
     # Ensure authorizer's region matches the user's region
     if not matches_user_region(current_user, user.region_id):
         raise HTTPException(status_code=403, detail="Unauthorized region access.")
+
+    # Approve user
+    user.date_approved = datetime.now()
+    user.approved_by = current_user
+    user.first_login = True
+    user.save()
 
     # Send email notification
     try:
@@ -565,6 +578,20 @@ def deny_user_registration(user_id: str, current_user: User):
         user = User.objects.filter(id=user_id).first()
         if not user:
             raise HTTPException(status_code=404, detail="User not found.")
+
+        if str(current_user.id) == str(user_id):
+            raise HTTPException(
+                status_code=403, detail="Users cannot approve themselves."
+            )
+
+        if not (
+            is_global_write_admin(current_user)
+            or current_user.user_type == UserType.REGIONAL_ADMIN
+        ):
+            raise HTTPException(
+                status_code=403,
+                detail="Only regional or global admins can approve users.",
+            )
 
         # Ensure authorizer's region matches the user's region
         if not matches_user_region(current_user, user.region_id):

--- a/backend/src/xfd_django/xfd_api/auth.py
+++ b/backend/src/xfd_django/xfd_api/auth.py
@@ -396,7 +396,6 @@ def get_allowed_user_update_fields(current_user, target_user):
         return {
             "first_name",
             "last_name",
-            "email",
             "state",
             "region_id",
             "user_type",
@@ -413,7 +412,6 @@ def get_allowed_user_update_fields(current_user, target_user):
         return {
             "first_name",
             "last_name",
-            "email",
             "state",
             "invite_pending",
             "date_approved",

--- a/backend/src/xfd_django/xfd_api/auth.py
+++ b/backend/src/xfd_django/xfd_api/auth.py
@@ -413,11 +413,12 @@ def get_allowed_user_update_fields(current_user, target_user):
             "first_name",
             "last_name",
             "invite_pending",
+            "first_login",
             "date_approved",
             "approved_by",
         }
     elif current_user.id == target_user.id:
-        return {"first_name", "last_name"}
+        return set()
     return set()
 
 

--- a/backend/src/xfd_django/xfd_api/auth.py
+++ b/backend/src/xfd_django/xfd_api/auth.py
@@ -390,6 +390,40 @@ def can_access_user(current_user, target_user_id) -> bool:
     return False
 
 
+def get_allowed_user_update_fields(current_user, target_user):
+    """Get allowed user update fields."""
+    if is_global_write_admin(current_user):
+        return {
+            "first_name",
+            "last_name",
+            "email",
+            "state",
+            "region_id",
+            "user_type",
+            "invite_pending",
+            "date_approved",
+            "approved_by",
+            "accepted_terms_version",
+            "login_blocked_by_maintenance",
+        }
+    elif (
+        is_regional_admin(current_user)
+        and current_user.region_id == target_user.region_id
+    ):
+        return {
+            "first_name",
+            "last_name",
+            "email",
+            "state",
+            "invite_pending",
+            "date_approved",
+            "approved_by",
+        }
+    elif current_user.id == target_user.id:
+        return {"first_name", "last_name"}
+    return set()
+
+
 def get_org_memberships(current_user) -> list[str]:
     """Return the organization IDs that a user is a member of."""
     # Check if the user has a 'roles' attribute and it's not None

--- a/backend/src/xfd_django/xfd_api/auth.py
+++ b/backend/src/xfd_django/xfd_api/auth.py
@@ -412,7 +412,6 @@ def get_allowed_user_update_fields(current_user, target_user):
         return {
             "first_name",
             "last_name",
-            "state",
             "invite_pending",
             "date_approved",
             "approved_by",

--- a/backend/src/xfd_django/xfd_api/tests/test_user.py
+++ b/backend/src/xfd_django/xfd_api/tests/test_user.py
@@ -1525,7 +1525,7 @@ def test_update_user_v2_regional_admin_cannot_update_user_type():
 
 
 @pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
-def test_update_user_v2_regional_admin_can_update_in_region_state():
+def test_update_user_v2_regional_admin_cannot_update_in_region_state():
     """Test update user v2 standard user."""
     regional_admin = User.objects.create(
         first_name="RA",
@@ -1550,12 +1550,11 @@ def test_update_user_v2_regional_admin_can_update_in_region_state():
         headers={"Authorization": f"Bearer {create_jwt_token(regional_admin)}"},
     )
 
-    assert response.status_code == 200
-    assert response.json()["state"] == "NY"
+    assert response.status_code == 403
 
 
 @pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
-def test_update_user_v2_standard_user_can_update_name():
+def test_update_user_v2_standard_user_cannot_update_name():
     """Test update user v2 standard user."""
     user = User.objects.create(
         first_name="Old",
@@ -1572,9 +1571,7 @@ def test_update_user_v2_standard_user_can_update_name():
         headers={"Authorization": f"Bearer {create_jwt_token(user)}"},
     )
 
-    assert response.status_code == 200
-    assert response.json()["first_name"] == "New"
-    assert response.json()["last_name"] == "Name"
+    assert response.status_code == 403
 
 
 @pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
@@ -1727,3 +1724,241 @@ def test_get_me_unauthenticated():
     response = client.get("/users/me")
 
     assert response.status_code == 401
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
+def test_standard_user_updates_self_user_type_unauthenticated():
+    """Test that a standard user cannot update their own userType."""
+    user = User.objects.create(
+        first_name="Test",
+        last_name="User",
+        email="{}@example.com".format(secrets.token_hex(4)),
+        user_type=UserType.STANDARD,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    payload = {
+        "user_type": UserType.STANDARD,
+    }
+    response = client.put(
+        f"/v2/users/{user.id}",
+        json=payload,
+        headers={"Authorization": "Bearer {}".format(create_jwt_token(user))},
+    )
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Only global admins can update userType."
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
+def test_standard_user_updates_self_unauthenticated():
+    """Test that a standard user cannot update their own details."""
+    user = User.objects.create(
+        first_name="Test",
+        last_name="User",
+        email="{}@example.com".format(secrets.token_hex(4)),
+        user_type=UserType.STANDARD,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    payload = {
+        "first_name": "Updated",
+        "last_name": "User",
+        "email": "adasdasdadsss@example.com",
+        "approved": True,
+        "invite_pending": False,
+        "region_id": "11",
+        "state": "CA",
+    }
+    response = client.put(
+        f"/v2/users/{user.id}",
+        json=payload,
+        headers={"Authorization": "Bearer {}".format(create_jwt_token(user))},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
+def test_standard_user_updates_other_unauthenticated():
+    """Test that a standard user cannot update another user's details."""
+    user = User.objects.create(
+        first_name="Test",
+        last_name="User",
+        email="{}@example.com".format(secrets.token_hex(4)),
+        user_type=UserType.STANDARD,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    user_to_update = User.objects.create(
+        first_name="Test",
+        last_name="User",
+        email="{}@example.com".format(secrets.token_hex(4)),
+        user_type=UserType.STANDARD,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    payload = {}
+    response = client.put(
+        f"/v2/users/{user_to_update.id}",
+        json=payload,
+        headers={"Authorization": "Bearer {}".format(create_jwt_token(user))},
+    )
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Unauthorized access."
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
+def test_regional_user_updates_self_confirm_authorized_fields():
+    """Test that a regional admin can update their own user details."""
+    user = User.objects.create(
+        first_name="Test",
+        last_name="User",
+        email="{}@example.com".format(secrets.token_hex(4)),
+        user_type=UserType.REGIONAL_ADMIN,
+        region_id="1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        first_login=True,
+        invite_pending=True,
+    )
+
+    payload = {
+        "first_name": "Updated",
+        "last_name": "New",
+        "invite_pending": False,
+        "first_login": False,
+        "date_approved": datetime.now().isoformat(),
+        "approved_by": None,
+    }
+
+    response = client.put(
+        f"/v2/users/{user.id}",
+        json=payload,
+        headers={"Authorization": "Bearer {}".format(create_jwt_token(user))},
+    )
+    assert response.status_code == 200
+    assert response.json()["first_name"] == "Updated"
+    assert response.json()["last_name"] == "New"
+    assert response.json()["first_login"] is None
+    assert response.json()["approved_by"] is None
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
+def test_regional_user_updates_other_confirm_authorized_fields():
+    """Test that a regional admin can update another user's details."""
+    user = User.objects.create(
+        first_name="Test",
+        last_name="User",
+        email="{}@example.com".format(secrets.token_hex(4)),
+        user_type=UserType.REGIONAL_ADMIN,
+        region_id="1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        first_login=True,
+        invite_pending=True,
+    )
+
+    user_to_update = User.objects.create(
+        first_name="Test",
+        last_name="User",
+        email="{}@example.com".format(secrets.token_hex(4)),
+        user_type=UserType.STANDARD,
+        region_id="1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        first_login=True,
+        invite_pending=True,
+    )
+    payload = {
+        "first_name": "Updated",
+        "last_name": "New",
+        "invite_pending": False,
+        "first_login": False,
+        "date_approved": datetime.now().isoformat(),
+        "approved_by": None,
+    }
+    response = client.put(
+        f"/v2/users/{user_to_update.id}",
+        json=payload,
+        headers={"Authorization": "Bearer {}".format(create_jwt_token(user))},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["first_name"] == "Updated"
+    assert response.json()["last_name"] == "New"
+    assert response.json()["first_login"] is None
+    assert response.json()["date_approved"] is None
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
+def test_global_user_updates_confirm_authorized_fields():
+    """Test that a global admin can update another user's details."""
+    user = User.objects.create(
+        first_name="Test",
+        last_name="User",
+        email="{}@example.com".format(secrets.token_hex(4)),
+        user_type=UserType.GLOBAL_ADMIN,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+    user_to_update = User.objects.create(
+        first_name="Test",
+        last_name="User",
+        email="{}@example.com".format(secrets.token_hex(4)),
+        user_type=UserType.STANDARD,
+        region_id="1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        login_blocked_by_maintenance=True,
+    )
+    payload = {
+        "region_id": "2",
+        "state": "NY",
+        "first_name": "Updated",
+        "last_name": "New",
+        "user_type": UserType.REGIONAL_ADMIN,
+        "date_approved": datetime.now().isoformat(),
+        "accepted_terms_version": "1.0",
+        "login_blocked_by_maintenance": False,
+    }
+    response = client.put(
+        f"/v2/users/{user_to_update.id}",
+        json=payload,
+        headers={"Authorization": "Bearer {}".format(create_jwt_token(user))},
+    )
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
+def test_global_user_updates_confirm_unauthorized_fields():
+    """Test that a global admin cannot update unauthorized fields."""
+    user = User.objects.create(
+        first_name="Test",
+        last_name="User",
+        email="{}@example.com".format(secrets.token_hex(4)),
+        user_type=UserType.GLOBAL_ADMIN,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+    user_to_update = User.objects.create(
+        first_name="Test",
+        last_name="User",
+        email="{}@example.com".format(secrets.token_hex(4)),
+        user_type=UserType.STANDARD,
+        region_id="1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        login_blocked_by_maintenance=True,
+    )
+    payload = {"email": "{}@example.com".format(secrets.token_hex(4))}
+    response = client.put(
+        f"/v2/users/{user_to_update.id}",
+        json=payload,
+        headers={"Authorization": "Bearer {}".format(create_jwt_token(user))},
+    )
+    assert response.status_code == 403
+    assert (
+        response.json()["detail"]
+        == "Unauthorized to update the following fields: email"
+    )

--- a/backend/src/xfd_django/xfd_api/tests/test_user.py
+++ b/backend/src/xfd_django/xfd_api/tests/test_user.py
@@ -1521,7 +1521,7 @@ def test_update_user_v2_regional_admin_cannot_update_user_type():
     )
 
     assert response.status_code == 403
-    assert "user_type" in response.json()["detail"]
+    assert "Only global admins can update userType." in response.json()["detail"]
 
 
 @pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])

--- a/backend/src/xfd_django/xfd_api/tests/test_user.py
+++ b/backend/src/xfd_django/xfd_api/tests/test_user.py
@@ -1448,6 +1448,183 @@ def test_update_user_v2_update_userType_by_non_admin_fails():
 
 
 @pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
+def test_update_user_v2_standard_user_cannot_update_own_email():
+    """Test update user v2 standard user."""
+    user = User.objects.create(
+        first_name="Self",
+        last_name="User",
+        email="original@example.com",
+        user_type=UserType.STANDARD,
+    )
+
+    payload = {"email": "hacked@example.com"}
+
+    response = client.put(
+        f"/v2/users/{user.id}",
+        json=payload,
+        headers={"Authorization": f"Bearer {create_jwt_token(user)}"},
+    )
+
+    assert response.status_code == 403
+    assert "email" in response.json()["detail"]
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
+def test_update_user_v2_standard_user_cannot_approve_themselves():
+    """Test update user v2 standard user."""
+    user = User.objects.create(
+        first_name="Self",
+        last_name="User",
+        email="{}@example.com".format(secrets.token_hex(4)),
+        user_type=UserType.STANDARD,
+    )
+
+    payload = {
+        "date_approved": datetime.now().isoformat(),
+        "approved_by": None,
+    }
+
+    response = client.put(
+        f"/v2/users/{user.id}",
+        json=payload,
+        headers={"Authorization": f"Bearer {create_jwt_token(user)}"},
+    )
+
+    assert response.status_code == 403
+    assert "date_approved" in response.json()["detail"]
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
+def test_update_user_v2_regional_admin_cannot_update_user_type():
+    """Test update user v2 standard user."""
+    regional_admin = User.objects.create(
+        first_name="RA",
+        last_name="Admin",
+        email="{}@example.com".format(secrets.token_hex(4)),
+        user_type=UserType.REGIONAL_ADMIN,
+        region_id="X1",
+    )
+    user = User.objects.create(
+        first_name="Target",
+        last_name="User",
+        email="{}@example.com".format(secrets.token_hex(4)),
+        user_type=UserType.STANDARD,
+        region_id="X1",
+    )
+
+    payload = {"user_type": UserType.GLOBAL_ADMIN}
+
+    response = client.put(
+        f"/v2/users/{user.id}",
+        json=payload,
+        headers={"Authorization": f"Bearer {create_jwt_token(regional_admin)}"},
+    )
+
+    assert response.status_code == 403
+    assert "user_type" in response.json()["detail"]
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
+def test_update_user_v2_regional_admin_can_update_in_region_state():
+    """Test update user v2 standard user."""
+    regional_admin = User.objects.create(
+        first_name="RA",
+        last_name="Admin",
+        email="{}@example.com".format(secrets.token_hex(4)),
+        user_type=UserType.REGIONAL_ADMIN,
+        region_id="X1",
+    )
+    user = User.objects.create(
+        first_name="Target",
+        last_name="User",
+        email="{}@example.com".format(secrets.token_hex(4)),
+        user_type=UserType.STANDARD,
+        region_id="X1",
+    )
+
+    payload = {"state": "NY"}
+
+    response = client.put(
+        f"/v2/users/{user.id}",
+        json=payload,
+        headers={"Authorization": f"Bearer {create_jwt_token(regional_admin)}"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["state"] == "NY"
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
+def test_update_user_v2_standard_user_can_update_name():
+    """Test update user v2 standard user."""
+    user = User.objects.create(
+        first_name="Old",
+        last_name="Name",
+        email="{}@example.com".format(secrets.token_hex(4)),
+        user_type=UserType.STANDARD,
+    )
+
+    payload = {"first_name": "New", "last_name": "Name"}
+
+    response = client.put(
+        f"/v2/users/{user.id}",
+        json=payload,
+        headers={"Authorization": f"Bearer {create_jwt_token(user)}"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["first_name"] == "New"
+    assert response.json()["last_name"] == "Name"
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
+def test_standard_user_cannot_clear_invite_pending():
+    """Standard user should not be able to set invite_pending to false on themselves."""
+    user = User.objects.create(
+        first_name="Self",
+        last_name="Invitee",
+        email="{}@example.com".format(secrets.token_hex(4)),
+        user_type=UserType.STANDARD,
+        invite_pending=True,
+    )
+
+    payload = {"invite_pending": False}
+
+    response = client.put(
+        f"/v2/users/{user.id}",
+        json=payload,
+        headers={"Authorization": f"Bearer {create_jwt_token(user)}"},
+    )
+
+    assert response.status_code == 403
+    assert "invite_pending" in response.json()["detail"]
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
+def test_standard_user_cannot_self_approve():
+    """Standard user should not be able to set 'approved' field via API."""
+    user = User.objects.create(
+        first_name="Self",
+        last_name="Approver",
+        email="{}@example.com".format(secrets.token_hex(4)),
+        user_type=UserType.STANDARD,
+        invite_pending=True,
+    )
+
+    # 'approved' isn't a direct field, but we simulate by trying to set date_approved
+    payload = {"date_approved": datetime.now().isoformat()}
+
+    response = client.put(
+        f"/v2/users/{user.id}",
+        json=payload,
+        headers={"Authorization": f"Bearer {create_jwt_token(user)}"},
+    )
+
+    assert response.status_code == 403
+    assert "date_approved" in response.json()["detail"]
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
 def test_get_me_success():
     """Test that an authenticated user can retrieve their own user data."""
     user = User.objects.create(

--- a/frontend/src/pages/Users/UserForm.tsx
+++ b/frontend/src/pages/Users/UserForm.tsx
@@ -209,7 +209,6 @@ export const UserForm: React.FC<UserFormProps> = ({
     const body = {
       first_name: values.first_name,
       last_name: values.last_name,
-      email: values.email,
       user_type: values.user_type,
       state: values.state,
       region_id: values.region_id


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This ticket addresses the issue with users being able to update their own user objects. 

- Ensures the PUT /v2/users/{} endpoint has correct role based permissions and users can only update specific fields like first_name and last_name
- Write more pytests to ensure this stays locked down

## 💭 Motivation and context ##
Users should only be able to update their first_name and last_name.

## 🧪 Testing ##

Created new pytests and passes pre-commit and github checks.

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [x] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Revert dependencies to default branches.
- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
