### PR TITLE
fill risky_service_table lookup tables when syncing db - CRASM-2807

### DIFF
--- a/backend/src/xfd_django/xfd_api/management/commands/syncmdl.py
+++ b/backend/src/xfd_django/xfd_api/management/commands/syncmdl.py
@@ -11,6 +11,10 @@ from xfd_api.tasks.helpers.syncdb_helpers.es_sync import (
     manage_elasticsearch_indices,
     sync_es_organizations,
 )
+from xfd_api.tasks.helpers.syncdb_helpers.fill_static_tables import (
+    fill_nmi_service_group_table,
+    fill_risky_service_lookup_table,
+)
 from xfd_api.tasks.searchSync import handler as sync_es_domains
 from xfd_api.tasks.syncdb_task import drop_all_tables, synchronize
 
@@ -107,6 +111,8 @@ class Command(BaseCommand):
             self.stdout.write("Dropping and recreating the database...")
             drop_all_tables(app_label="xfd_mini_dl")
         synchronize(target_app_label="xfd_mini_dl")
+        fill_risky_service_lookup_table()
+        fill_nmi_service_group_table()
 
         self.stdout.write("Running Phase 2 column type adjustments …")
         adjust_column_types(target_app_label="xfd_mini_dl")

--- a/backend/src/xfd_django/xfd_api/management/commands/syncmdl.py
+++ b/backend/src/xfd_django/xfd_api/management/commands/syncmdl.py
@@ -39,7 +39,7 @@ class Command(BaseCommand):
             help="Populate the database with sample data.",
         )
 
-    def handle(self, *args, **options):
+    def handle(self, *args, **options):  # pylint: disable=R0915
         """Handle method."""
         dangerouslyforce = options["dangerouslyforce"]
         populate = options["populate"]

--- a/backend/src/xfd_django/xfd_api/tasks/helpers/syncdb_helpers/fill_static_tables.py
+++ b/backend/src/xfd_django/xfd_api/tasks/helpers/syncdb_helpers/fill_static_tables.py
@@ -1,0 +1,73 @@
+"""Functions used to fill static/lookup tables in the mdl."""
+
+from xfd_mini_dl.models import RiskyServiceGroup, NMIServiceGroup
+from django.db import IntegrityError
+
+risky_service_map = {
+    "ms-wbt-server":"rdp",
+    "telnet":"telnet",
+    "rtelnet":"telnet",
+    "microsoft-ds":"smb",
+    "smbdirect":"smb",
+    "ldap":"ldap",
+    "netbios-ns":"netbios",
+    "netbios-dgm":"netbios",
+    "netbios-ssn":"netbios",
+    "ftp":"ftp",
+    "rsftp":"ftp",
+    "ni-ftp":"ftp",
+    "tftp":"ftp",
+    "bftp":"ftp",
+    "msrpc":"rpc",
+    "sqlnet":"sql",
+    "sqlserv":"sql",
+    "sql-net":"sql",
+    "sqlsrv":"sql",
+    "msql":"sql",
+    "mini-sql":"sql",
+    "mysql-cluster":"sql",
+    "ms-sql-s":"sql",
+    "ms-sql-m":"sql",
+    "irc":"irc",
+    "kerberos-sec":"kerberos",
+    "kpasswd5":"kerberos",
+    "klogin":"kerberos",
+    "kshell":"kerberos",
+    "kerberos-adm":"kerberos",
+    "kerberos":"kerberos",
+    "kerberos_master":"kerberos",
+    "krb_prop":"kerberos",
+    "krbupdate":"kerberos",
+    "kpasswd":"kerberos"
+}
+
+nmi_service_group_map = {
+    "microsoft-d":"smb",
+    "ms-wbt-server":"dp",
+    "rtelnet":"telnet",
+    "smbdirect":"smb",
+    "telnet":"telnet"
+}
+
+def fill_risky_service_lookup_table():
+    """Fill the RiskyServiceGroup lookup table with static data."""
+    for service_name, group in risky_service_map.items():
+        try:
+            RiskyServiceGroup.objects.update_or_create(
+                service_name=service_name,
+                defaults={'group': group}
+            )
+        except IntegrityError as e:
+            print(f"Error adding {service_name}: {e}")
+
+
+def fill_nmi_service_group_table():
+    """Fill the NMIServiceGroup lookup table with static data."""
+    for service_name, group in nmi_service_group_map.items():
+        try:
+            NMIServiceGroup.objects.update_or_create(
+                service_name=service_name,
+                defaults={'group': group}
+            )
+        except IntegrityError as e:
+            print(f"Error adding {service_name}: {e}")

--- a/backend/src/xfd_django/xfd_api/tasks/helpers/syncdb_helpers/fill_static_tables.py
+++ b/backend/src/xfd_django/xfd_api/tasks/helpers/syncdb_helpers/fill_static_tables.py
@@ -1,61 +1,62 @@
 """Functions used to fill static/lookup tables in the mdl."""
 
-from xfd_mini_dl.models import RiskyServiceGroup, NMIServiceGroup
+# Third-Party Libraries
 from django.db import IntegrityError
+from xfd_mini_dl.models import NMIServiceGroup, RiskyServiceGroup
 
 risky_service_map = {
-    "ms-wbt-server":"rdp",
-    "telnet":"telnet",
-    "rtelnet":"telnet",
-    "microsoft-ds":"smb",
-    "smbdirect":"smb",
-    "ldap":"ldap",
-    "netbios-ns":"netbios",
-    "netbios-dgm":"netbios",
-    "netbios-ssn":"netbios",
-    "ftp":"ftp",
-    "rsftp":"ftp",
-    "ni-ftp":"ftp",
-    "tftp":"ftp",
-    "bftp":"ftp",
-    "msrpc":"rpc",
-    "sqlnet":"sql",
-    "sqlserv":"sql",
-    "sql-net":"sql",
-    "sqlsrv":"sql",
-    "msql":"sql",
-    "mini-sql":"sql",
-    "mysql-cluster":"sql",
-    "ms-sql-s":"sql",
-    "ms-sql-m":"sql",
-    "irc":"irc",
-    "kerberos-sec":"kerberos",
-    "kpasswd5":"kerberos",
-    "klogin":"kerberos",
-    "kshell":"kerberos",
-    "kerberos-adm":"kerberos",
-    "kerberos":"kerberos",
-    "kerberos_master":"kerberos",
-    "krb_prop":"kerberos",
-    "krbupdate":"kerberos",
-    "kpasswd":"kerberos"
+    "ms-wbt-server": "rdp",
+    "telnet": "telnet",
+    "rtelnet": "telnet",
+    "microsoft-ds": "smb",
+    "smbdirect": "smb",
+    "ldap": "ldap",
+    "netbios-ns": "netbios",
+    "netbios-dgm": "netbios",
+    "netbios-ssn": "netbios",
+    "ftp": "ftp",
+    "rsftp": "ftp",
+    "ni-ftp": "ftp",
+    "tftp": "ftp",
+    "bftp": "ftp",
+    "msrpc": "rpc",
+    "sqlnet": "sql",
+    "sqlserv": "sql",
+    "sql-net": "sql",
+    "sqlsrv": "sql",
+    "msql": "sql",
+    "mini-sql": "sql",
+    "mysql-cluster": "sql",
+    "ms-sql-s": "sql",
+    "ms-sql-m": "sql",
+    "irc": "irc",
+    "kerberos-sec": "kerberos",
+    "kpasswd5": "kerberos",
+    "klogin": "kerberos",
+    "kshell": "kerberos",
+    "kerberos-adm": "kerberos",
+    "kerberos": "kerberos",
+    "kerberos_master": "kerberos",
+    "krb_prop": "kerberos",
+    "krbupdate": "kerberos",
+    "kpasswd": "kerberos",
 }
 
 nmi_service_group_map = {
-    "microsoft-d":"smb",
-    "ms-wbt-server":"dp",
-    "rtelnet":"telnet",
-    "smbdirect":"smb",
-    "telnet":"telnet"
+    "microsoft-d": "smb",
+    "ms-wbt-server": "dp",
+    "rtelnet": "telnet",
+    "smbdirect": "smb",
+    "telnet": "telnet",
 }
+
 
 def fill_risky_service_lookup_table():
     """Fill the RiskyServiceGroup lookup table with static data."""
     for service_name, group in risky_service_map.items():
         try:
             RiskyServiceGroup.objects.update_or_create(
-                service_name=service_name,
-                defaults={'group': group}
+                service_name=service_name, defaults={"group": group}
             )
         except IntegrityError as e:
             print(f"Error adding {service_name}: {e}")
@@ -66,8 +67,7 @@ def fill_nmi_service_group_table():
     for service_name, group in nmi_service_group_map.items():
         try:
             NMIServiceGroup.objects.update_or_create(
-                service_name=service_name,
-                defaults={'group': group}
+                service_name=service_name, defaults={"group": group}
             )
         except IntegrityError as e:
             print(f"Error adding {service_name}: {e}")


### PR DESCRIPTION
Fill RiskyServiceGroup lookup table when syncing the mdl

## 🗣 Description ##
The mini datalake has 2 lookup tables used to group risky services into groups. This table needs to be filled so the backend can lookup the correct groups. This PR adds some helper functions that fill the table when the database gets synced ensuring that the tables are always filled without any manual effort
## 💭 Motivation and context ##
Since the tables are currently empty the scans that reference them are always returning null or 0. In order to provide this data to the end user the lookup needs to be filled to provide them with accurate data.

## 🧪 Testing ##
tested locally

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
