### PR TITLE
Retrieve scanned_asset_count from HostSummary: CRASM-2867

### DIFF
--- a/frontend/src/types/vuln-scan-stats.ts
+++ b/frontend/src/types/vuln-scan-stats.ts
@@ -76,6 +76,7 @@ export interface HostSummaries {
   host_ready_count?: number | null;
   up_host_count?: number | null;
   down_host_count?: number | null;
+  scanned_asset_count?: number | null;
 }
 
 export interface PortScanSummaries {

--- a/frontend/src/utils/transformVulnScanData.ts
+++ b/frontend/src/utils/transformVulnScanData.ts
@@ -71,7 +71,7 @@ export const transformVulnScanData = (
           ' - ' +
           formatShortDate(latestVulnSummary?.end_date),
         assetsOwned: latestVulnSummary?.assets_owned_count ?? 0,
-        assetsScanned: latestVulnSummary?.scanned_asset_count ?? 0,
+        assetsScanned: latestHostSummary?.scanned_asset_count ?? 0,
         startDate: latestVulnSummary?.start_date ?? '',
         endDate: latestVulnSummary?.end_date ?? ''
       }


### PR DESCRIPTION
Retrieve scanned_asset_count from HostSummary instead of VulnScanSummary

## 🗣 Description ##
Pull scanned_asset_count from the Host Summary response instead of the VulnScanSummary response. 

## 💭 Motivation and context ##
This value is always showing up as 0 on the frontend, because it is pulling from a response that does not contain that value.

## 🧪 Testing ##
Tested locally

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
