### PR TITLE
Fix Scan Details to not show null on screen 2784

### DIFF
--- a/frontend/src/pages/Scans/ScanTasksView.tsx
+++ b/frontend/src/pages/Scans/ScanTasksView.tsx
@@ -470,14 +470,26 @@ export const ScanTasksView: React.FC = () => {
               />
             </>
           )}
-          <Typography variant="h6" component="div">
-            Input:
-          </Typography>
-          <pre>
-            {detailsParams?.row?.input &&
-              JSON.stringify(JSON.parse(detailsParams?.row?.input), null, 2)}
-          </pre>
-
+          {(() => {
+            const rawInput = detailsParams?.row?.input;
+            if (!rawInput) return '';
+            try {
+              const parsedJSON = JSON.parse(rawInput);
+              const formattedJSON = JSON.stringify(parsedJSON, null, 2);
+              if (formattedJSON === '{}' || formattedJSON === '[]') return '';
+              return (
+                <>
+                  <Typography variant="h6" component="div">
+                    Input:
+                  </Typography>
+                  <pre>{formattedJSON}</pre>
+                </>
+              );
+            } catch (e) {
+              console.log(e);
+              return '';
+            }
+          })()}
           <Typography variant="h6" component="div">
             Output:
           </Typography>


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
Scan Details page has Input data displayed as null
CRASM-2784
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
The UI should not display "null" on screen
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
I'm unable to test this locally as this is linked to AWS so it will need to be tested in Staging with a new scan.

1. Navigate to staging
2. Navigate to Admin Hub
3. Select Admin Tools
4. Under the Scan History tab Details column click on any inf link
5. On Scan Details pop up page, scroll down to verify Input field data displayed with "null" value
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
