### PR TITLE
CRASM-2286_Move env block to the job level scope.

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -29,6 +29,21 @@ jobs:
     environment: staging
     timeout-minutes: 60
     if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      AWS_SUBNET: ${{ secrets.AWS_SUBNET }}
+      AWS_SECURITY_GROUP: ${{ secrets.AWS_SECURITY_GROUP }}
+      AUTOMATED_TEST_REPORTS_BUCKET_NAME: cisa-crossfeed-staging-cd-automated-test-reports
+      PW_XFD_URL: http://xfd-frontend-1:3000/
+      PW_XFD_USERNAME: ${{ secrets.PW_XFD_USERNAME }}
+      PW_XFD_PASSWORD: ${{ secrets.PW_XFD_PASSWORD }}
+      PW_XFD_2FA_SECRET: ${{ secrets.PW_XFD_2FA_SECRET }}
+      PW_XFD_LOGIN: ${{ secrets.PW_XFD_USERNAME }}
+      PW_HEADLESS: true
+      ENVIRONMENT: staging
+      GIT_BRANCH: develop
     steps:
       - uses: actions/checkout@v3
 
@@ -36,21 +51,6 @@ jobs:
         run: echo "ENVIRONMENT=staging" >> $GITHUB_ENV
 
       - name: Run Playwright tests
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-          AWS_SUBNET: ${{ secrets.AWS_SUBNET }}
-          AWS_SECURITY_GROUP: ${{ secrets.AWS_SECURITY_GROUP }}
-          AUTOMATED_TEST_REPORTS_BUCKET_NAME: cisa-crossfeed-staging-cd-automated-test-reports
-          PW_XFD_URL: http://xfd-frontend-1:3000/
-          PW_XFD_USERNAME: ${{ secrets.PW_XFD_USERNAME }}
-          PW_XFD_PASSWORD: ${{ secrets.PW_XFD_PASSWORD }}
-          PW_XFD_2FA_SECRET: ${{ secrets.PW_XFD_2FA_SECRET }}
-          PW_XFD_LOGIN: ${{ secrets.PW_XFD_USERNAME }}
-          PW_HEADLESS: true
-          ENVIRONMENT: staging
-          GIT_BRANCH: develop
         run: |
          chmod +x run_playwright_tests.sh
          CLUSTER_NAME=crossfeed-playwright-staging-cd-ecs-cluster \
@@ -60,8 +60,6 @@ jobs:
         continue-on-error: false  # Ensure it stops if the ECS task fails
 
       - name: Download test report from S3
-        env:
-          AUTOMATED_TEST_REPORTS_BUCKET_NAME: cisa-crossfeed-staging-cd-automated-test-reports
         run: |
           mkdir -p ./playwright-report/html
           aws s3 cp \
@@ -91,6 +89,21 @@ jobs:
      environment: integration
      timeout-minutes: 60
      if: github.event_name == 'push' && github.ref == 'refs/heads/integration'
+     env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      AWS_SUBNET: ${{ secrets.AWS_SUBNET }}
+      AWS_SECURITY_GROUP: ${{ secrets.AWS_SECURITY_GROUP }}
+      AUTOMATED_TEST_REPORTS_BUCKET_NAME: cisa-crossfeed-integration-automated-test-reports
+      PW_XFD_URL: http://xfd-frontend-1:3000/
+      PW_XFD_USERNAME: ${{ secrets.PW_XFD_USERNAME }}
+      PW_XFD_PASSWORD: ${{ secrets.PW_XFD_PASSWORD }}
+      PW_XFD_2FA_SECRET: ${{ secrets.PW_XFD_2FA_SECRET }}
+      PW_XFD_LOGIN: ${{ secrets.PW_XFD_USERNAME }} # or hardcode if needed
+      PW_HEADLESS: true
+      ENVIRONMENT: integration
+      GIT_BRANCH: integration
      steps:
       - uses: actions/checkout@v3
 
@@ -99,21 +112,6 @@ jobs:
 
       - name: Run Playwright tests
         working-directory: ./playwright
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-          AWS_SUBNET: ${{ secrets.AWS_SUBNET }}
-          AWS_SECURITY_GROUP: ${{ secrets.AWS_SECURITY_GROUP }}
-          AUTOMATED_TEST_REPORTS_BUCKET_NAME: cisa-crossfeed-integration-automated-test-reports
-          PW_XFD_URL: http://xfd-frontend-1:3000/
-          PW_XFD_USERNAME: ${{ secrets.PW_XFD_USERNAME }}
-          PW_XFD_PASSWORD: ${{ secrets.PW_XFD_PASSWORD }}
-          PW_XFD_2FA_SECRET: ${{ secrets.PW_XFD_2FA_SECRET }}
-          PW_XFD_LOGIN: ${{ secrets.PW_XFD_USERNAME }} # or hardcode if needed
-          PW_HEADLESS: true
-          ENVIRONMENT: integration
-          GIT_BRANCH: integration
         run: |
           chmod +x run_playwright_tests.sh
           CLUSTER_NAME=crossfeed-playwright-integration-ecs-cluster \
@@ -123,8 +121,6 @@ jobs:
         continue-on-error: false  # Ensure it stops if the ECS task fails
 
       - name: Download test report from S3
-        env:
-          AUTOMATED_TEST_REPORTS_BUCKET_NAME: cisa-crossfeed-staging-cd-automated-test-reports
         run: |
           mkdir -p ./playwright-report/html
           aws s3 cp \


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Moves the env block from the run Playwright test step to the job level scope. 

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This is needed to fix the regression test workflows.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Tested during PR merge. 
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [x] Create a pre-release (necessary if and only if the pre-release version was bumped).

