### PR TITLE
CRASM-2286 Fix leftover run command in entrypoint.sh

### DIFF
--- a/backend/worker/entrypoint.playwright.sh
+++ b/backend/worker/entrypoint.playwright.sh
@@ -4,10 +4,10 @@ set -euo pipefail
 
 echo "🔁 Cloning into Crossfeed..."
 # Clone Playwright test repo and install dependencies
-RUN git clone --branch "$GIT_BRANCH" https://github.com/cisagov/xfd.git /app/xfd \
- && cd /app/xfd/playwright \
- && npm ci \
- && npx playwright install --with-deps
+ git clone --branch "$GIT_BRANCH" https://github.com/cisagov/xfd.git /app/xfd
+ cd /app/xfd/playwright
+ npm ci
+ npx playwright install --with-deps
 
 echo "🔁 Running Playwright tests..."
 npx playwright test


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

When refactoring the AWS Playwright code, the lines that handle the git clone of the repo were pulled from the Dockerfile and moved into an entrypoint bash script. This code failing might explain the silent errors the code running on the Github Actions side is encountering. 

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This is necessary to get the AWS Playwright code up and running.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Currently being tested with the PR process on merge.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [x] Create a pre-release (necessary if and only if the pre-release version was bumped).
