### PR TITLE
Jd crasm 2928 fix aws playwright git clone

### DIFF
--- a/backend/Dockerfile.playwright
+++ b/backend/Dockerfile.playwright
@@ -7,11 +7,8 @@ WORKDIR /app
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y git awscli
 
-# Set working directory to where tests are located
-WORKDIR /app/xfd/playwright
-
 # Copy the test runner script
-COPY backend/worker/entrypoint.playwright.sh /entrypoint.playwright.sh
+COPY ../worker/entrypoint.playwright.sh /entrypoint.playwright.sh
 RUN chmod +x /entrypoint.playwright.sh
 
 # Define entrypoint

--- a/backend/Dockerfile.playwright
+++ b/backend/Dockerfile.playwright
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y git awscli
 WORKDIR /app/xfd/playwright
 
 # Copy the test runner script
-COPY ../worker/entrypoint.playwright.sh /entrypoint.playwright.sh
+COPY backend/worker/entrypoint.playwright.sh /entrypoint.playwright.sh
 RUN chmod +x /entrypoint.playwright.sh
 
 # Define entrypoint

--- a/backend/worker/entrypoint.playwright.sh
+++ b/backend/worker/entrypoint.playwright.sh
@@ -6,6 +6,7 @@ echo "🔁 Cloning into Crossfeed..."
 # Clone Playwright test repo and install dependencies
 # Ensure a clean clone target
 rm -rf /app/xfd
+mkdir -p /app/xfd
 
 git clone --branch "$GIT_BRANCH" https://github.com/cisagov/xfd.git /app/xfd
 cd /app/xfd/playwright

--- a/backend/worker/entrypoint.playwright.sh
+++ b/backend/worker/entrypoint.playwright.sh
@@ -2,9 +2,33 @@
 
 set -euo pipefail
 
+# Define the cleanup function (like finally)
+upload_reports() {
+  echo "📤 Uploading results to S3..."
+
+  if [[ -d "./playwright-report/html" ]]; then
+    echo "✅ HTML report found, uploading..."
+    aws s3 cp ./playwright-report/html "$S3_HTML_PATH" --recursive --region "$AWS_REGION"
+    aws s3 cp ./playwright-report/html "s3://$AUTOMATED_TEST_REPORTS_BUCKET_NAME/$ENVIRONMENT/playwright-reports/latest/html/" --recursive --region "$AWS_REGION"
+  else
+    echo "⚠️ No HTML report found at ./playwright-report/html"
+  fi
+
+  if [[ -f "./playwright-report/results.json" ]]; then
+    echo "✅ results.json found, uploading..."
+    aws s3 cp ./playwright-report/results.json "$S3_JSON_PATH" --region "$AWS_REGION"
+    aws s3 cp ./playwright-report/results.json "s3://$AUTOMATED_TEST_REPORTS_BUCKET_NAME/$ENVIRONMENT/playwright-reports/latest/results.json" --region "$AWS_REGION"
+  else
+    echo "⚠️ No results.json file found!"
+  fi
+
+  echo "📦 Uploads complete."
+}
+
+# Register the function to run on script exit (success or failure)
+trap upload_reports EXIT
+
 echo "🔁 Cloning into Crossfeed..."
-# Clone Playwright test repo and install dependencies
-# Ensure a clean clone target
 rm -rf /app/xfd
 mkdir -p /app/xfd
 
@@ -14,22 +38,9 @@ npm ci
 npx playwright install --with-deps
 
 echo "🔁 Running Playwright tests..."
-npx playwright test
-
-echo "📤 Uploading results to S3..."
-
-if [[ -d "./playwright-report/html" ]]; then
-  aws s3 cp ./playwright-report/html "$S3_HTML_PATH" --recursive --region "$AWS_REGION"
-  aws s3 cp ./playwright-report/html "s3://$AUTOMATED_TEST_REPORTS_BUCKET_NAME/$ENVIRONMENT/playwright-reports/latest/html/" --recursive --region "$AWS_REGION"
-else
-  echo "⚠️ No HTML report found at ./playwright-report/html"
+# Don't let failure here kill the rest — trap will still run
+if ! npx playwright test; then
+  echo "❌ Playwright tests failed!"
 fi
 
-if [[ -f "./playwright-report/results.json" ]]; then
-  aws s3 cp ./playwright-report/results.json "$S3_JSON_PATH" --region "$AWS_REGION"
-  aws s3 cp ./playwright-report/results.json "s3://$AUTOMATED_TEST_REPORTS_BUCKET_NAME/$ENVIRONMENT/playwright-reports/latest/results.json" --region "$AWS_REGION"
-else
-  echo "⚠️ No results.json file found!"
-fi
-
-echo "✅ Tests completed and uploaded."
+echo "✅ Test execution finished. Awaiting report upload..."

--- a/backend/worker/entrypoint.playwright.sh
+++ b/backend/worker/entrypoint.playwright.sh
@@ -4,18 +4,31 @@ set -euo pipefail
 
 echo "🔁 Cloning into Crossfeed..."
 # Clone Playwright test repo and install dependencies
- git clone --branch "$GIT_BRANCH" https://github.com/cisagov/xfd.git /app/xfd
- cd /app/xfd/playwright
- npm ci
- npx playwright install --with-deps
+# Ensure a clean clone target
+rm -rf /app/xfd
+
+git clone --branch "$GIT_BRANCH" https://github.com/cisagov/xfd.git /app/xfd
+cd /app/xfd/playwright
+npm ci
+npx playwright install --with-deps
 
 echo "🔁 Running Playwright tests..."
 npx playwright test
 
 echo "📤 Uploading results to S3..."
-aws s3 cp ./playwright-report/html "$S3_HTML_PATH" --recursive --region "$AWS_REGION"
-aws s3 cp ./playwright-report/results.json "$S3_JSON_PATH" --region "$AWS_REGION"
-aws s3 cp ./playwright-report/html "s3://$AUTOMATED_TEST_REPORTS_BUCKET_NAME/$ENVIRONMENT/playwright-reports/latest/html/" --recursive --region "$AWS_REGION"
-aws s3 cp ./playwright-report/results.json "s3://$AUTOMATED_TEST_REPORTS_BUCKET_NAME/$ENVIRONMENT/playwright-reports/latest/results.json" --region "$AWS_REGION"
+
+if [[ -d "./playwright-report/html" ]]; then
+  aws s3 cp ./playwright-report/html "$S3_HTML_PATH" --recursive --region "$AWS_REGION"
+  aws s3 cp ./playwright-report/html "s3://$AUTOMATED_TEST_REPORTS_BUCKET_NAME/$ENVIRONMENT/playwright-reports/latest/html/" --recursive --region "$AWS_REGION"
+else
+  echo "⚠️ No HTML report found at ./playwright-report/html"
+fi
+
+if [[ -f "./playwright-report/results.json" ]]; then
+  aws s3 cp ./playwright-report/results.json "$S3_JSON_PATH" --region "$AWS_REGION"
+  aws s3 cp ./playwright-report/results.json "s3://$AUTOMATED_TEST_REPORTS_BUCKET_NAME/$ENVIRONMENT/playwright-reports/latest/results.json" --region "$AWS_REGION"
+else
+  echo "⚠️ No results.json file found!"
+fi
 
 echo "✅ Tests completed and uploaded."

--- a/playwright/run_playwright_tests.sh
+++ b/playwright/run_playwright_tests.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
-
 set -euo pipefail
 set -x
 
-# Get the current datetime (e.g., 2025-04-10T12:34:56)
+# ⏱️ Generate timestamp
 DATETIME=$(date +%Y-%m-%dT%H:%M:%S)
 echo "📅 Test timestamp: $DATETIME"
 echo "📦 Bucket: $AUTOMATED_TEST_REPORTS_BUCKET_NAME"
 echo "🌎 Region: $AWS_REGION"
 echo "📤 Uploading to: s3://$AUTOMATED_TEST_REPORTS_BUCKET_NAME/playwright-reports/$DATETIME/"
 
+# 🧩 Build ECS container overrides for task environment
 OVERRIDES=$(
   jq -n \
     --arg datetime "$DATETIME" \
@@ -25,29 +25,31 @@ OVERRIDES=$(
     --arg s3HtmlPath "s3://$AUTOMATED_TEST_REPORTS_BUCKET_NAME/$ENVIRONMENT/playwright-reports/$DATETIME/html/" \
     --arg s3JsonPath "s3://$AUTOMATED_TEST_REPORTS_BUCKET_NAME/$ENVIRONMENT/playwright-reports/$DATETIME/results.json" \
     '{
-    "containerOverrides": [
-      {
-        "name": "main",
-        "environment": [
-          { "name": "DATETIME", "value": $datetime },
-          { "name": "AUTOMATED_TEST_REPORTS_BUCKET_NAME", "value": $bucket },
-          { "name": "AWS_REGION", "value": $region },
-          { "name": "PW_XFD_URL", "value": $url },
-          { "name": "PW_XFD_USERNAME", "value": $username },
-          { "name": "PW_XFD_PASSWORD", "value": $password },
-          { "name": "PW_XFD_2FA_SECRET", "value": $otpsecret },
-          { "name": "PW_XFD_LOGIN", "value": $login },
-          { "name": "GIT_BRANCH", "value": $git_branch },
-          { "name": "ENVIRONMENT", "value": $environment },
-          { "name": "S3_HTML_PATH", "value": $s3HtmlPath },
-          { "name": "S3_JSON_PATH", "value": $s3JsonPath }
-        ],
-      }
-    ]
-  }'
+      "containerOverrides": [
+        {
+          "name": "main",
+          "environment": [
+            { "name": "DATETIME", "value": $datetime },
+            { "name": "AUTOMATED_TEST_REPORTS_BUCKET_NAME", "value": $bucket },
+            { "name": "AWS_REGION", "value": $region },
+            { "name": "PW_XFD_URL", "value": $url },
+            { "name": "PW_XFD_USERNAME", "value": $username },
+            { "name": "PW_XFD_PASSWORD", "value": $password },
+            { "name": "PW_XFD_2FA_SECRET", "value": $otpsecret },
+            { "name": "PW_XFD_LOGIN", "value": $login },
+            { "name": "GIT_BRANCH", "value": $git_branch },
+            { "name": "ENVIRONMENT", "value": $environment },
+            { "name": "S3_HTML_PATH", "value": $s3HtmlPath },
+            { "name": "S3_JSON_PATH", "value": $s3JsonPath }
+          ]
+        }
+      ]
+    }'
 )
 
-echo "Starting ECS task to run Playwright tests..."
+echo "$OVERRIDES" | jq .
+
+echo "🚀 Starting ECS task to run Playwright tests..."
 
 TASK_ARN=$(aws ecs run-task \
   --cluster "$CLUSTER_NAME" \
@@ -60,29 +62,73 @@ TASK_ARN=$(aws ecs run-task \
       \"assignPublicIp\": \"ENABLED\"
     }
   }" \
-  --region "${AWS_REGION}" \
+  --region "$AWS_REGION" \
   --overrides "$OVERRIDES" \
   --query 'tasks[0].taskArn' \
-  --output text 2> /dev/null) || {
+  --output text 2>/dev/null) || {
   echo "❌ Failed to run ECS task (aws command error)." >&2
   exit 1
 }
 
-# Sanity check: ensure the result isn't empty
+# ✅ Sanity check
 if [[ -z "$TASK_ARN" || "$TASK_ARN" == "None" ]]; then
   echo "❌ Failed to run ECS task. No ARN returned." >&2
   exit 1
 fi
 
-echo "Started ECS Task with ARN: $TASK_ARN"
-echo "Waiting for ECS task to complete..."
+echo "✅ Started ECS Task with ARN: $TASK_ARN"
+echo "⏳ Waiting for ECS task to complete..."
 
 aws ecs wait tasks-stopped \
   --cluster "$CLUSTER_NAME" \
   --tasks "$TASK_ARN" \
-  --region "${AWS_REGION}" || {
+  --region "$AWS_REGION" || {
   echo "❌ Task did not complete successfully." >&2
   exit 1
 }
 
-echo "ECS task $TASK_ARN completed successfully."
+echo "✅ ECS task $TASK_ARN stopped. Checking container exit code..."
+
+EXIT_CODE=$(aws ecs describe-tasks \
+  --cluster "$CLUSTER_NAME" \
+  --tasks "$TASK_ARN" \
+  --region "$AWS_REGION" \
+  --query 'tasks[0].containers[0].exitCode' \
+  --output text)
+
+echo "📦 Container exit code: $EXIT_CODE"
+
+if [[ "$EXIT_CODE" != "0" ]]; then
+  echo "❌ Container failed with exit code $EXIT_CODE. Fetching logs..."
+
+  LOG_GROUP=$(aws ecs describe-task-definition \
+    --task-definition "$TASK_DEFINITION" \
+    --region "$AWS_REGION" \
+    --query 'taskDefinition.containerDefinitions[0].logConfiguration.options."awslogs-group"' \
+    --output text)
+
+  LOG_STREAM_PREFIX=$(aws ecs describe-task-definition \
+    --task-definition "$TASK_DEFINITION" \
+    --region "$AWS_REGION" \
+    --query 'taskDefinition.containerDefinitions[0].logConfiguration.options."awslogs-stream-prefix"' \
+    --output text)
+
+  TASK_ID="${TASK_ARN##*/}"
+  LOG_STREAM_NAME="${LOG_STREAM_PREFIX}/main/${TASK_ID}"
+
+  echo "📜 Fetching logs from CloudWatch:"
+  echo "   • Log Group:   $LOG_GROUP"
+  echo "   • Log Stream:  $LOG_STREAM_NAME"
+
+  aws logs get-log-events \
+    --log-group-name "$LOG_GROUP" \
+    --log-stream-name "$LOG_STREAM_NAME" \
+    --limit 50 \
+    --region "$AWS_REGION" \
+    --output text | tee ecs-task-error.log
+
+  echo "❌ ECS task failed. See logs above or check ecs-task-error.log"
+  exit "$EXIT_CODE"
+fi
+
+echo "🎉 ECS task completed successfully!"


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Playwright AWS was dying silently early into the run. After adding error checks, it was found it was dying at the git clone command. This change should fix it. 

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This is needed to get the Dockerfile working again.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Tested the Dockerfile changes locally before push. Will check how it works across the entier pipeline later.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [x] Create a pre-release (necessary if and only if the pre-release version was bumped).

