### PR TITLE
2926 - Allow one users to change state one time on signup

### DIFF
--- a/backend/src/xfd_django/xfd_api/api_methods/user.py
+++ b/backend/src/xfd_django/xfd_api/api_methods/user.py
@@ -447,6 +447,13 @@ def update_user_v2(user_id, user_data, current_user):
         updates = user_data.dict(exclude_unset=True)
         allowed_fields = get_allowed_user_update_fields(current_user, user)
 
+        if user.first_login and user_data.state:
+            user.state = user_data.state
+            user.region_id = REGION_STATE_MAP.get(user_data.state)
+            # Flip this to false to prevent state from being set.
+            user.first_login = False
+            user.save()
+
         # Check for disallowed fields before applying updates
         disallowed_fields = set(updates.keys()) - allowed_fields
         if disallowed_fields:

--- a/backend/src/xfd_django/xfd_api/api_methods/user.py
+++ b/backend/src/xfd_django/xfd_api/api_methods/user.py
@@ -447,13 +447,6 @@ def update_user_v2(user_id, user_data, current_user):
         updates = user_data.dict(exclude_unset=True)
         allowed_fields = get_allowed_user_update_fields(current_user, user)
 
-        if user.first_login and user_data.state:
-            user.state = user_data.state
-            user.region_id = REGION_STATE_MAP.get(user_data.state)
-            # Flip this to false to prevent state from being set.
-            user.first_login = False
-            user.save()
-
         # Check for disallowed fields before applying updates
         disallowed_fields = set(updates.keys()) - allowed_fields
         if disallowed_fields:
@@ -469,6 +462,7 @@ def update_user_v2(user_id, user_data, current_user):
             if field == "state":
                 user.region_id = REGION_STATE_MAP.get(value)
                 user.state = value
+                user.can_select_own_state = False
             else:
                 setattr(user, field, value)
 

--- a/backend/src/xfd_django/xfd_api/auth.py
+++ b/backend/src/xfd_django/xfd_api/auth.py
@@ -453,8 +453,8 @@ def get_allowed_user_update_fields(current_user, target_user):
         }
     elif (
         current_user.id == target_user.id
-        and current_user.can_select_own_state == True
-        and current_user.invite_pending == True
+        and current_user.can_select_own_state is True
+        and current_user.invite_pending is True
     ):
         return {"can_select_own_state", "state", "region_id"}
     return set()

--- a/backend/src/xfd_django/xfd_api/auth.py
+++ b/backend/src/xfd_django/xfd_api/auth.py
@@ -255,6 +255,7 @@ async def process_user(decoded_token):
             cognito_use_case_description=decoded_token.get("nickname"),
             cognito_email_verified=decoded_token.get("email_verified"),
             cognito_groups=decoded_token.get("cognito:groups"),
+            can_select_own_state=True,
         )
 
         # Check for active major maintenance window and login status (New User)
@@ -450,8 +451,12 @@ def get_allowed_user_update_fields(current_user, target_user):
             "date_approved",
             "approved_by",
         }
-    elif current_user.id == target_user.id:
-        return set()
+    elif (
+        current_user.id == target_user.id
+        and current_user.can_select_own_state == True
+        and current_user.invite_pending == True
+    ):
+        return {"can_select_own_state", "state", "region_id"}
     return set()
 
 

--- a/backend/src/xfd_django/xfd_api/schema_models/user.py
+++ b/backend/src/xfd_django/xfd_api/schema_models/user.py
@@ -37,6 +37,7 @@ class User(BaseModel):
     email: str
     invite_pending: bool
     first_login: Optional[bool] = None
+    can_select_own_state: Optional[bool] = False
     login_blocked_by_maintenance: bool
     cognito_use_case_description: Optional[str] = None
     date_approved: Optional[datetime] = None
@@ -63,6 +64,7 @@ class UserResponse(BaseModel):
     email: str
     invite_pending: bool
     first_login: Optional[bool] = None
+    can_select_own_state: Optional[bool] = False
     login_blocked_by_maintenance: bool
     date_accepted_terms: Optional[datetime]
     accepted_terms_version: Optional[str]
@@ -149,6 +151,7 @@ class UpdateUser(BaseModel):
     full_name: Optional[str]
     invite_pending: Optional[bool]
     first_login: Optional[bool]
+    can_select_own_state: Optional[bool] = False
     last_name: Optional[str]
     login_blocked_by_maintenance: Optional[bool]
     organization: Optional[str]
@@ -168,6 +171,7 @@ class UpdateUserV2(BaseModel):
     user_type: Optional[str] = None
     invite_pending: Optional[bool] = None
     first_login: Optional[bool] = None
+    can_select_own_state: Optional[bool] = False
     date_approved: Optional[datetime] = None
     approved_by: Optional[Any] = None
 
@@ -206,3 +210,4 @@ class UserResponseV2(BaseModel):
     user_type: Optional[str] = None
     roles: List[Dict[str, Optional[Any]]]
     first_login: Optional[bool] = None
+    can_select_own_state: Optional[bool] = False

--- a/backend/src/xfd_django/xfd_mini_dl/models.py
+++ b/backend/src/xfd_django/xfd_mini_dl/models.py
@@ -1279,6 +1279,11 @@ class User(AutoLengthCheckModel):
         null=True,
         help_text="A boolean field identifying a users first approved login for prompts.",
     )
+    can_select_own_state = models.BooleanField(
+        db_column="can_select_own_state",
+        default=False,
+        help_text="A boolean field identifying if a user has select their state/region.",
+    )
     date_approved = models.DateTimeField(
         db_column="date_approved",
         blank=True,


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
- Add flag `can_select_own_state` to user model to allow a one-time change to support the current user signup flow
- Update process_user function to flip the `can_select_own_state` flag after state, region id change

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Resolves CRASM-2926

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [x] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
