### PR TITLE
Add logging to see where asset_owned count is failing: CRASM-2945

### DIFF
--- a/backend/src/xfd_django/xfd_api/tasks/vulnScanningSync.py
+++ b/backend/src/xfd_django/xfd_api/tasks/vulnScanningSync.py
@@ -782,15 +782,21 @@ def get_asset_owned_count(org):
         try:
             network = ip_network(str(cidr.network), strict=False)
             total_ips += network.num_addresses
-        except ValueError as e:
+        except (ValueError, TypeError) as e:
             LOGGER.warning(
                 "Invalid CIDR '%s' for organization ID: %s (%s) — %s",
-                cidr.network,
+                getattr(cidr, "network", None),
                 org.id,
                 org.name,
                 str(e),
             )
-            continue  # Skip bad CIDRs
+        except Exception as e:
+            LOGGER.warning(
+                "Unexpected error while processing CIDR for org ID: %s (%s) — %s",
+                org.id,
+                org.name,
+                str(e),
+            )
 
     return total_ips
 

--- a/backend/src/xfd_django/xfd_api/tasks/vulnScanningSync.py
+++ b/backend/src/xfd_django/xfd_api/tasks/vulnScanningSync.py
@@ -774,12 +774,22 @@ def get_asset_owned_count(org):
         cidrorgs__organization=org, cidrorgs__current=True, network__isnull=False
     ).distinct()
 
+    if not cidrs.exists():
+        LOGGER.warning("No CIDRs found for organization ID: %s (%s)", org.id, org.name)
+
     total_ips = 0
     for cidr in cidrs:
         try:
             network = ip_network(str(cidr.network), strict=False)
             total_ips += network.num_addresses
-        except ValueError:
+        except ValueError as e:
+            LOGGER.warning(
+                "Invalid CIDR '%s' for organization ID: %s (%s) — %s",
+                cidr.network,
+                org.id,
+                org.name,
+                str(e),
+            )
             continue  # Skip bad CIDRs
 
     return total_ips


### PR DESCRIPTION
Add logging to see how asset_owned count is failing

## 🗣 Description ##
Add logging to the get_asset_owned_count to see why some orgs are reporting 0 owned assets

## 💭 Motivation and context ##
Some orgs with small cidr ranges are showing 0 owned IPs, we need to validate why their ips aren't getting counted.

## 🧪 Testing ##
Since there are no errors locally, can't really test this one.


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
