### PR TITLE
2946 - Update accept terms endpoint to be accessed by unapproved user

### DIFF
--- a/backend/src/xfd_django/xfd_api/tests/test_user.py
+++ b/backend/src/xfd_django/xfd_api/tests/test_user.py
@@ -1595,7 +1595,10 @@ def test_standard_user_cannot_clear_invite_pending():
     )
     print("Bang bang", response.json())
     assert response.status_code == 403
-    assert response.json()["detail"] == "Unauthorized"
+    assert (
+        response.json()["detail"]
+        == "Unauthorized to update the following fields: invite_pending"
+    )
 
 
 @pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
@@ -1617,9 +1620,12 @@ def test_standard_user_cannot_self_approve():
         json=payload,
         headers={"Authorization": f"Bearer {create_jwt_token(user)}"},
     )
-
+    print("Bang bang", response.json())
     assert response.status_code == 403
-    assert response.json()["detail"] == "Unauthorized"
+    assert (
+        response.json()["detail"]
+        == "Unauthorized to update the following fields: date_approved"
+    )
 
 
 @pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])

--- a/backend/src/xfd_django/xfd_api/tests/test_user.py
+++ b/backend/src/xfd_django/xfd_api/tests/test_user.py
@@ -670,6 +670,7 @@ def test_accept_terms_success():
         user_type=UserType.STANDARD,
         created_at=datetime.now(),
         updated_at=datetime.now(),
+        invite_pending=True,
     )
 
     version = "1.0"

--- a/backend/src/xfd_django/xfd_api/tests/test_user.py
+++ b/backend/src/xfd_django/xfd_api/tests/test_user.py
@@ -1620,7 +1620,6 @@ def test_standard_user_cannot_self_approve():
         json=payload,
         headers={"Authorization": f"Bearer {create_jwt_token(user)}"},
     )
-    print("Bang bang", response.json())
     assert response.status_code == 403
     assert (
         response.json()["detail"]

--- a/backend/src/xfd_django/xfd_api/tests/test_user.py
+++ b/backend/src/xfd_django/xfd_api/tests/test_user.py
@@ -1593,7 +1593,6 @@ def test_standard_user_cannot_clear_invite_pending():
         json=payload,
         headers={"Authorization": f"Bearer {create_jwt_token(user)}"},
     )
-    print("Bang bang", response.json())
     assert response.status_code == 403
     assert (
         response.json()["detail"]

--- a/backend/src/xfd_django/xfd_api/views.py
+++ b/backend/src/xfd_django/xfd_api/views.py
@@ -1444,14 +1444,14 @@ async def call_get_users_v2(
 
 @api_router.put(
     "/v2/users/{user_id}",
-    dependencies=[Depends(get_current_active_user)],
+    dependencies=[Depends(get_current_active_user_unsafe)],
     response_model=UserResponseV2,
     tags=["Users"],
 )
 async def update_user_v2_view(
     user_id: str,
     user_data: UpdateUserV2,
-    current_user: User = Depends(get_current_active_user),
+    current_user: User = Depends(get_current_active_user_unsafe),
 ):
     """Update a particular user."""
     return update_user_v2(user_id, user_data, current_user)

--- a/backend/src/xfd_django/xfd_api/views.py
+++ b/backend/src/xfd_django/xfd_api/views.py
@@ -1353,7 +1353,8 @@ async def healthcheck():
     tags=["Users"],
 )
 async def call_accept_terms(
-    version_data: VersionModel, current_user: User = Depends(get_current_active_user)
+    version_data: VersionModel,
+    current_user: User = Depends(get_current_active_user_unsafe),
 ):
     """Accept the latest terms of service."""
     return accept_terms(version_data, current_user)

--- a/backend/src/xfd_django/xfd_api/views.py
+++ b/backend/src/xfd_django/xfd_api/views.py
@@ -1369,7 +1369,7 @@ async def read_users_me(current_user: User = Depends(get_current_active_user_uns
 @api_router.delete(
     "/users/{user_id}",
     response_model=OrganizationSchema.DeleteUserResponseModel,
-    dependencies=[Depends(get_current_active_user)],
+    dependencies=[Depends(get_current_active_user_unsafe)],
     tags=["Users"],
 )
 @log_action(


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
- Updated middleware used by /users/me/acceptTerms to not check for invite_pending.
- Updated test that should have caught this

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Resolves CRASM-2946

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
