### PR TITLE
Update Regression Testing Playwright Documentation

### DIFF
--- a/playwright/README.md
+++ b/playwright/README.md
@@ -21,6 +21,7 @@ This README will guide you through setting up, configuring, and running Playwrig
   - [Environment Variables for Local Testing](#environment-variables-for-local-testing)
   - [Environment Variables for Local Testing in VS Code](#environment-variables-for-local-testing-in-vs-code)
 - [Local Testing via Docker](#local-testing-via-docker)
+- [Github Actions Testing with Amazon ECS](#github-actions-testing-with-amazon-ecs)
 - [Logging into Crossfeed and Preserving Browser State](#logging-into-crossfeed-and-preserving-browser-state)
 - [Adding Test Cases](#adding-test-cases)
 - [Test Results](#test-results)
@@ -33,7 +34,9 @@ This README will guide you through setting up, configuring, and running Playwrig
 
 Since Playwright is intended to run in 3 different modes `[localhost, local Docker, Github Actions/AWS]`, a configuration tool at `utils/env.ts` is created to help set default URLs and headless mode options.
 
-The `PW_XFD_URL` environment variable is to be set by the build processes. If no variable has been set, by default it will try to test against `http://localhost` . The pertinent environment variables are located in `xfd/.env` and are prefixed with `PW_*`
+ Environment variables pertinent to Playwright are located in `xfd/playwright/.env` and are prefixed with `PW_*`. A blank dummy file is included in the repository to satisfy linters and checkers. This file can be used to set variables for running Playwright in localhost or Docker, but do not check in that file. It is excluded by .gitignore, but be careful when checking in code.
+
+Some environment variables values are defined in this README, but information that is secret will not be shared in this document. Ask the automated testing team for the values to continue setting up the configuration.
 
 ## **Local Testing via Terminal**
 
@@ -56,13 +59,18 @@ This mode is intended for frontend developers to write their own feature test ca
 For local testing, the following variables need to be loaded into your environment.
 
 ```env
+PW_XFD_URL=http://localhost
 PW_XFD_USERNAME
 PW_XFD_PASSWORD
 PW_XFD_2FA_ISSUER
 PW_XFD_2FA_SECRET
 PW_XFD_USER_ROLE
 PW_XFD_LOGIN
+PW_HEADLESS=false
+PW_CI=false
 ```
+
+In local testing, `PW_HEADLESS` can optionally be set to true or false. `PW_CI` should be set to false, as this variable will adjust the behavior of how the global setup will load the other environment variables.
 
 ### **Environment Variables for Local Testing in VS Code**
 
@@ -70,21 +78,45 @@ If you are using testing in VS Code using the Playwright extension, add the foll
 
 ```json
 "playwright.env": {
-        "PW_XFD_URL":"",
+        "PW_XFD_URL":"http://localhost",
         "PW_XFD_USERNAME":"",
         "PW_XFD_PASSWORD":"",
         "PW_XFD_2FA_ISSUER":"",
         "PW_XFD_2FA_SECRET":"",
         "PW_XFD_USER_ROLE":"",
-        "PW_XFD_LOGIN" : ""
+        "PW_XFD_LOGIN" : "",
+        "PW_HEADLESS" : "false",
+        "PW_CI": "false"
 }
 ```
 
 ## **Local Testing via Docker**
 
+For running in a Dockerzied environment, the following variable should be set in the `xfd/playwright/.env`
+
+```env
+PW_XFD_URL=http://frontend:3000
+PW_XFD_USERNAME
+PW_XFD_PASSWORD
+PW_XFD_2FA_ISSUER
+PW_XFD_2FA_SECRET
+PW_XFD_USER_ROLE
+PW_XFD_LOGIN
+PW_HEADLESS=true
+PW_CI=false
+```
+
 This mode is intended to kick off as part of the build process. A docker container will be created using the same Playwright test.
 
 A wait feature will listen for the frontend to begin accepting requests, as the frontend will take longer to compile than Playwright to be ready for testing. When a code 200 is received from the frontend, the Playwright tests will begin.
+
+For this Dockerized environment, `PW_HEADLESS` must be set to true and `PW_CI` must be set to false.
+
+## **Github Actions Testing with Amazon ECS**
+
+In this mode, the Playwright tests are run everytime changes are committed to the develop and integration branches `xfd/frontend/` directory, or to the `xfd/.github/regression.yml` file itself. The Regression Testing workflow (which so far only encompasses Playwright) calls out to a containerized version of Crossfeed's Playwright testing suite stored on Amazon ECR via an ECS task. When the task is triggered, Playwright ECS will run against either the staging-cd or integration instances of Playwright. Test results are stored in Amazon S3 bucket and downloaded as artifacts to the Github Actions workflow.
+
+There is no need for any frontend developer to alter any configuration of Playwright ECS. The entire configuration is set by the workflow process.
 
 ## **Logging into Crossfeed and Preserving Browser State**
 

--- a/playwright/README.md
+++ b/playwright/README.md
@@ -21,7 +21,7 @@ This README will guide you through setting up, configuring, and running Playwrig
   - [Environment Variables for Local Testing](#environment-variables-for-local-testing)
   - [Environment Variables for Local Testing in VS Code](#environment-variables-for-local-testing-in-vs-code)
 - [Local Testing via Docker](#local-testing-via-docker)
-- [Github Actions Testing with Amazon ECS](#github-actions-testing-with-amazon-ecs)
+- [GitHub Actions Testing with Amazon ECS](#github-actions-testing-with-amazon-ecs)
 - [Logging into Crossfeed and Preserving Browser State](#logging-into-crossfeed-and-preserving-browser-state)
 - [Adding Test Cases](#adding-test-cases)
 - [Test Results](#test-results)
@@ -32,7 +32,7 @@ This README will guide you through setting up, configuring, and running Playwrig
 
 ## Playwright configuration for Crossfeed
 
-Since Playwright is intended to run in 3 different modes `[localhost, local Docker, Github Actions/AWS]`, a configuration tool at `utils/env.ts` is created to help set default URLs and headless mode options.
+Since Playwright is intended to run in 3 different modes `[localhost, local Docker, GitHub Actions/AWS]`, a configuration tool at `utils/env.ts` is created to help set default URLs and headless mode options.
 
  Environment variables pertinent to Playwright are located in `xfd/playwright/.env` and are prefixed with `PW_*`. A blank dummy file is included in the repository to satisfy linters and checkers. This file can be used to set variables for running Playwright in localhost or Docker, but do not check in that file. It is excluded by .gitignore, but be careful when checking in code.
 
@@ -92,7 +92,7 @@ If you are using testing in VS Code using the Playwright extension, add the foll
 
 ## **Local Testing via Docker**
 
-For running in a Dockerzied environment, the following variable should be set in the `xfd/playwright/.env`
+For running in a Dockerized environment, the following variable should be set in the `xfd/playwright/.env`
 
 ```env
 PW_XFD_URL=http://frontend:3000
@@ -112,9 +112,9 @@ A wait feature will listen for the frontend to begin accepting requests, as the 
 
 For this Dockerized environment, `PW_HEADLESS` must be set to true and `PW_CI` must be set to false.
 
-## **Github Actions Testing with Amazon ECS**
+## **GitHub Actions Testing with Amazon ECS**
 
-In this mode, the Playwright tests are run everytime changes are committed to the develop and integration branches `xfd/frontend/` directory, or to the `xfd/.github/regression.yml` file itself. The Regression Testing workflow (which so far only encompasses Playwright) calls out to a containerized version of Crossfeed's Playwright testing suite stored on Amazon ECR via an ECS task. When the task is triggered, Playwright ECS will run against either the staging-cd or integration instances of Playwright. Test results are stored in Amazon S3 bucket and downloaded as artifacts to the Github Actions workflow.
+In this mode, the Playwright tests are run everytime changes are committed to the develop and integration branches `xfd/frontend/` directory, or to the `xfd/.github/workflows/regression.yml` file itself. The Regression Testing workflow (which so far only encompasses Playwright) calls out to a containerized version of Crossfeed's Playwright testing suite stored on Amazon ECR via an ECS task. When the task is triggered, Playwright ECS will run against either the staging-cd or integration instances of Playwright. Test results are stored in Amazon S3 bucket and downloaded as artifacts to the GitHub Actions workflow.
 
 There is no need for any frontend developer to alter any configuration of Playwright ECS. The entire configuration is set by the workflow process.
 
@@ -122,7 +122,7 @@ There is no need for any frontend developer to alter any configuration of Playwr
 
 The global setup script located at `xfd/playwright/global-setup.ts` performs the task of logging into Crossfeed and storing the browsers state to `xfd/playwright/storageState.json`. This script works by manually performing the steps to login to Crossfeed through the browser.
 
-This process does not use the PIV card certificate process, but a username/password process with 2FA tokens. The necessary environment variables are not stored in code, but populated by the build process (manually setting environment variables, set by docker-compose, or populated by Github Actions).
+This process does not use the PIV card certificate process, but a username/password process with 2FA tokens. The necessary environment variables are not stored in code, but populated by the build process (manually setting environment variables, set by docker-compose, or populated by GitHub Actions).
 
 The login process also uses `waitForFrontend()` to listen for a response code 200 from Crossfeed's frontend before performing the login procedure.
 


### PR DESCRIPTION
…aywright workflow.

<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Make changes to Playwright's documentation to cover the new changes and bug fixes. 

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This change is required to help new developers become familiar with how the testing suite works. 
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

N/A
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
