### PR TITLE
CRASM-2891: FAST AM 15 - Implement PKCE OAuth flow with secure cookies and tests

### DIFF
--- a/backend/src/xfd_django/xfd_api/auth.py
+++ b/backend/src/xfd_django/xfd_api/auth.py
@@ -283,7 +283,10 @@ def get_cookie_domain(frontend_url: str) -> str:
 def set_oauth_cookies_response(state: str, code_verifier: str) -> Response:
     """Return a Response with OAuth state and PKCE code_verifier cookies set."""
     response = Response(content="Cookies set", media_type="text/plain")
-    cookie_domain = get_cookie_domain(settings.FRONTEND_DOMAIN)
+    if settings.ENVIRONMENT == "test":
+        cookie_domain = None
+    else:
+        cookie_domain = get_cookie_domain(settings.FRONTEND_DOMAIN)
     response.set_cookie(
         key="oauth_state",
         value=state,

--- a/backend/src/xfd_django/xfd_api/auth.py
+++ b/backend/src/xfd_django/xfd_api/auth.py
@@ -7,14 +7,14 @@ import json
 import os
 import re
 from typing import Optional
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse
 import uuid
 
 # Third-Party Libraries
 from django.conf import settings
 from django.forms.models import model_to_dict
 from fastapi import Depends, HTTPException, Request, Security, status
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
 from fastapi.security import APIKeyHeader
 import jwt
 import requests
@@ -272,17 +272,64 @@ def update_login_block_status(user: User) -> None:
     user.save()
 
 
+def get_cookie_domain(frontend_url: str) -> str:
+    """Convert full URL to cookie domain starting with a dot."""
+    parsed = urlparse(frontend_url)
+    hostname = parsed.hostname or frontend_url  # fallback
+    return ".{}".format(hostname)
+
+
+# POST: /auth/set-oauth-cookies
+def set_oauth_cookies_response(state: str, code_verifier: str) -> Response:
+    """Return a Response with OAuth state and PKCE code_verifier cookies set."""
+    response = Response(content="Cookies set", media_type="text/plain")
+    cookie_domain = get_cookie_domain(settings.FRONTEND_DOMAIN)
+    response.set_cookie(
+        key="oauth_state",
+        value=state,
+        httponly=True,
+        secure=True,
+        samesite="None",
+        path="/",
+        domain=cookie_domain,
+    )
+    response.set_cookie(
+        key="pkce_code_verifier",
+        value=code_verifier,
+        httponly=True,
+        secure=True,
+        samesite="None",
+        path="/",
+        domain=cookie_domain,
+    )
+    return response
+
+
 # POST: /auth/okta-callback
 async def handle_okta_callback(request):
     """POST API LOGIC."""
     body = await request.json()
-    code = body.get("code", None)
-    if code is None:
-        return HTTPException(
+    code = body.get("code")
+    state = body.get("state")
+
+    # Retrieve from cookies (not from body anymore)
+    cookie_state = request.cookies.get("oauth_state")
+    code_verifier = request.cookies.get("pkce_code_verifier")
+
+    if not code or not state or not cookie_state or not code_verifier:
+        raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Code not found in request body",
+            detail="Missing required OAuth parameters",
         )
-    jwt_data = await get_jwt_from_code(code)
+
+    # Validate state matches the cookie
+    if state != cookie_state:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid or missing OAuth state",
+        )
+
+    jwt_data = await get_jwt_from_code(code, code_verifier)
     print("JWT Data: {}".format(jwt_data))
     if jwt_data is None:
         raise HTTPException(
@@ -295,9 +342,16 @@ async def handle_okta_callback(request):
     resp = await process_user(decoded_token)
     token = resp.get("token")
 
-    # Create a JSONResponse object to return the response and set the cookie
+    # Create a JSONResponse object to return the response and clear cookies
     response = JSONResponse(
         content={"message": "User authenticated", "data": resp, "token": token}
+    )
+    cookie_domain = get_cookie_domain(settings.FRONTEND_DOMAIN)
+    response.delete_cookie(
+        "oauth_state", domain=cookie_domain, path="/", samesite="None"
+    )
+    response.delete_cookie(
+        "pkce_code_verifier", domain=cookie_domain, path="/", samesite="None"
     )
     response.set_cookie(key="token", value=token)
 
@@ -377,7 +431,7 @@ async def process_user(decoded_token):
         raise HTTPException(status_code=400, detail="User not found")
 
 
-async def get_jwt_from_code(auth_code: str):
+async def get_jwt_from_code(auth_code: str, code_verifier: str):
     """Exchange authorization code for JWT tokens and decode."""
     try:
         callback_url = os.getenv("REACT_APP_COGNITO_CALLBACK_URL")
@@ -385,23 +439,20 @@ async def get_jwt_from_code(auth_code: str):
         domain = os.getenv("REACT_APP_COGNITO_DOMAIN")
         proxy_url = os.getenv("LZ_PROXY_URL")
 
-        scope = "openid"
         authorize_token_url = "https://{}/oauth2/token".format(domain)
         authorize_token_body = {
             "grant_type": "authorization_code",
             "client_id": client_id,
             "code": auth_code,
             "redirect_uri": callback_url,
-            "scope": scope,
+            "code_verifier": code_verifier,
         }
         headers = {
             "Content-Type": "application/x-www-form-urlencoded",
         }
 
         # Set up proxies if PROXY_URL is defined
-        proxies = None
-        if proxy_url:
-            proxies = {"http": proxy_url, "https": proxy_url}
+        proxies = {"http": proxy_url, "https": proxy_url} if proxy_url else None
 
         response = requests.post(
             authorize_token_url,

--- a/backend/src/xfd_django/xfd_api/auth.py
+++ b/backend/src/xfd_django/xfd_api/auth.py
@@ -283,7 +283,7 @@ def get_cookie_domain(frontend_url: str) -> str:
 def set_oauth_cookies_response(state: str, code_verifier: str) -> Response:
     """Return a Response with OAuth state and PKCE code_verifier cookies set."""
     response = Response(content="Cookies set", media_type="text/plain")
-    if settings.ENVIRONMENT == "test":
+    if settings.IS_LOCAL:
         cookie_domain = None
     else:
         cookie_domain = get_cookie_domain(settings.FRONTEND_DOMAIN)

--- a/backend/src/xfd_django/xfd_api/tests/test_api_integrity.py
+++ b/backend/src/xfd_django/xfd_api/tests/test_api_integrity.py
@@ -16,6 +16,7 @@ client = TestClient(app)
 PUBLIC_ENDPOINTS = {
     ("POST", "/auth/okta-callback"),
     ("POST", "/auth/callback"),
+    ("POST", "/auth/set-oauth-cookies"),
     ("GET", "/notifications"),
     ("GET", "/healthcheck"),
 }
@@ -57,6 +58,7 @@ EXCLUDED_ENDPOINTS_RESPONSE_MODEL = {
     ("DELETE", "/api-keys/{api_key_id}"),
     ("POST", "/auth/callback"),
     ("POST", "/auth/okta-callback"),
+    ("POST", "/auth/set-oauth-cookies"),
     ("POST", "/domain/export"),
     ("POST", "/vulnerabilities/export"),
     ("DELETE", "/notifications/{notification_id}"),

--- a/backend/src/xfd_django/xfd_api/tests/test_auth.py
+++ b/backend/src/xfd_django/xfd_api/tests/test_auth.py
@@ -38,8 +38,14 @@ def test_okta_callback_success(mock_get_jwt_from_code):
         }
     }
 
-    payload = {"code": "test-auth-code"}
-    response = client.post("/auth/okta-callback", json=payload)
+    response = client.post(
+        "/auth/okta-callback",
+        json={"code": "test-auth-code", "state": "test-state"},
+        cookies={
+            "oauth_state": "test-state",
+            "pkce_code_verifier": "test-code-verifier",
+        },
+    )
 
     assert response.status_code == 200
     data = response.json()
@@ -74,9 +80,14 @@ def test_okta_callback_existing_user(mock_get_jwt_from_code):
         }
     }
 
-    payload = {"code": "test-auth-code"}
-
-    response = client.post("/auth/okta-callback", json=payload)
+    response = client.post(
+        "/auth/okta-callback",
+        json={"code": "test-auth-code", "state": "test-state"},
+        cookies={
+            "oauth_state": "test-state",
+            "pkce_code_verifier": "test-code-verifier",
+        },
+    )
 
     assert response.status_code == 200
 
@@ -91,12 +102,17 @@ def test_okta_callback_existing_user(mock_get_jwt_from_code):
 @pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
 def test_okta_callback_missing_code():
     """Test Okta callback with missing auth code (should fail)."""
-    payload = {}  # No code provided
+    response = client.post(
+        "/auth/okta-callback",
+        json={"state": "test-state"},
+        cookies={
+            "oauth_state": "test-state",
+            "pkce_code_verifier": "test-code-verifier",
+        },
+    )
 
-    response = client.post("/auth/okta-callback", json=payload)
-
-    assert response.json()["status_code"] == 400
-    assert response.json()["detail"] == "Code not found in request body"
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Missing required OAuth parameters"
 
 
 # Test that the response is JSON serializable
@@ -135,8 +151,58 @@ def test_okta_callback_user_approved_by_admin(mock_get_jwt_from_code):
         }
     }
 
-    payload = {"code": "test-auth-code"}
-    response = client.post("/auth/okta-callback", json=payload)
+    response = client.post(
+        "/auth/okta-callback",
+        json={"code": "test-auth-code", "state": "test-state"},
+        cookies={
+            "oauth_state": "test-state",
+            "pkce_code_verifier": "test-code-verifier",
+        },
+    )
 
     assert response.status_code == 200
     assert response.json()["data"]["user"]
+
+
+def test_set_oauth_cookies_success():
+    """Test setting PKCE code_verifier and state cookies successfully."""
+    payload = {"code_verifier": "test-code-verifier-123", "state": "test-state-456"}
+
+    response = client.post("/auth/set-oauth-cookies", json=payload)
+
+    assert response.status_code == 200
+    cookies = response.cookies
+
+    # Ensure cookies are properly set
+    assert cookies["oauth_state"] == "test-state-456"
+    assert cookies["pkce_code_verifier"] == "test-code-verifier-123"
+
+
+def test_set_oauth_cookies_missing_state():
+    """Test missing state results in 400 error."""
+    payload = {"code_verifier": "test-code-verifier-123"}
+
+    response = client.post("/auth/set-oauth-cookies", json=payload)
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Missing PKCE code_verifier or state"
+
+
+def test_set_oauth_cookies_missing_code_verifier():
+    """Test missing code_verifier results in 400 error."""
+    payload = {"state": "test-state-456"}
+
+    response = client.post("/auth/set-oauth-cookies", json=payload)
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Missing PKCE code_verifier or state"
+
+
+def test_set_oauth_cookies_missing_both():
+    """Test missing both state and code_verifier results in 400 error."""
+    payload = {}
+
+    response = client.post("/auth/set-oauth-cookies", json=payload)
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Missing PKCE code_verifier or state"

--- a/backend/src/xfd_django/xfd_api/views.py
+++ b/backend/src/xfd_django/xfd_api/views.py
@@ -84,6 +84,7 @@ from .auth import (
     get_current_active_user,
     get_current_active_user_unsafe,
     handle_okta_callback,
+    set_oauth_cookies_response,
 )
 from .login_gov import callback
 from .schema_models import organization_schema as OrganizationSchema
@@ -286,6 +287,21 @@ async def callback_route(request: Request):
         return user_info
     except Exception as error:
         raise HTTPException(status_code=400, detail=str(error))
+
+
+# Set PKCE and state cookies for OAuth
+@api_router.post("/auth/set-oauth-cookies", tags=["Auth"])
+async def set_oauth_cookies(request: Request):
+    """Set PKCE code_verifier and state cookies for OAuth flow."""
+    body = await request.json()
+    state = body.get("state")
+    code_verifier = body.get("code_verifier")
+
+    if not state or not code_verifier:
+        raise HTTPException(
+            status_code=400, detail="Missing PKCE code_verifier or state"
+        )
+    return set_oauth_cookies_response(state, code_verifier)
 
 
 # ========================================

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -41,6 +41,7 @@
         "nanoid": "^5.0.9",
         "papaparse": "^5.3.2",
         "path-to-regexp": "^8.2.0",
+        "pkce-challenge": "^5.0.0",
         "postcss": "^8.4.18",
         "query-string": "^7.1.1",
         "rc-pagination": "^5.1.0",
@@ -34358,6 +34359,14 @@
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "version": "4.0.7"
+    },
+    "node_modules/pkce-challenge": {
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
+      "version": "5.0.0"
     },
     "node_modules/pkg-dir": {
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -49,6 +49,7 @@
     "nanoid": "^5.0.9",
     "papaparse": "^5.3.2",
     "path-to-regexp": "^8.2.0",
+    "pkce-challenge": "^5.0.0",
     "postcss": "^8.4.18",
     "query-string": "^7.1.1",
     "rc-pagination": "^5.1.0",

--- a/frontend/src/pages/AuthLogin/AuthLogin.tsx
+++ b/frontend/src/pages/AuthLogin/AuthLogin.tsx
@@ -4,6 +4,8 @@ import { Button } from '@trussworks/react-uswds';
 import { Alert, AlertTitle, Box, Grid, Typography } from '@mui/material';
 import { CrossfeedWarning } from 'components/WarningBanner';
 import { initialNotificationValues, MaintenanceNotification } from 'types';
+import { v4 as uuidv4 } from 'uuid';
+import pkceChallenge from 'pkce-challenge';
 
 const LoginButton = () => {
   // TODO: Capture default values here once determined
@@ -11,11 +13,32 @@ const LoginButton = () => {
   const clientId = process.env.REACT_APP_COGNITO_CLIENT_ID || 'default_value';
   const callbackUrl =
     process.env.REACT_APP_COGNITO_CALLBACK_URL || 'default_value';
-  const encodedCallbackUrl = encodeURIComponent(callbackUrl);
 
-  const redirectToAuth = () => {
-    // Adjust this callback URL once determined
-    window.location.href = `https://${domain}/oauth2/authorize?identity_provider=Okta&redirect_uri=${encodedCallbackUrl}&response_type=CODE&client_id=${clientId}&scope=email openid profile`;
+  const redirectToAuth = async () => {
+    const { code_challenge, code_verifier } = await pkceChallenge();
+    const state = uuidv4();
+
+    try {
+      await fetch(`${process.env.REACT_APP_API_URL}/auth/set-oauth-cookies`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          code_verifier,
+          state
+        })
+      });
+      console.log('Cookies set, redirecting to Okta...');
+      const authorizeUrl = `https://${domain}/oauth2/authorize?identity_provider=Okta&redirect_uri=${encodeURIComponent(
+        callbackUrl
+      )}&response_type=code&client_id=${clientId}&scope=email+openid+profile&state=${state}&code_challenge=${encodeURIComponent(
+        code_challenge
+      )}&code_challenge_method=S256`;
+
+      window.location.href = authorizeUrl;
+    } catch (err) {
+      console.error('Error setting cookies before redirect:', err);
+    }
   };
 
   return (

--- a/frontend/src/pages/OktaCallback/OktaCallback.tsx
+++ b/frontend/src/pages/OktaCallback/OktaCallback.tsx
@@ -10,42 +10,45 @@ type OktaCallbackResponse = {
 };
 
 export const OktaCallback: React.FC = () => {
-  const { apiPost, login } = useAuthContext();
+  const { login } = useAuthContext();
   const history = useHistory();
 
   const handleOktaCallback = useCallback(async () => {
-    const { code } = parse(window.location.search);
-    console.log('Code: ', code);
-    const nonce = localStorage.getItem('nonce');
-    console.log('Nonce: ', nonce);
+    const { code, state } = parse(window.location.search);
+
+    if (!code || !state) {
+      console.error('Missing OAuth parameters');
+      history.replace('/');
+      return;
+    }
 
     try {
-      // Pass request to backend callback endpoint
-      const response = await apiPost<OktaCallbackResponse>(
-        '/auth/okta-callback',
+      const res = await fetch(
+        `${process.env.REACT_APP_API_URL}/auth/okta-callback`,
         {
-          body: {
-            code: code
-          }
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ code, state })
         }
       );
-      console.log('Response: ', response);
-      console.log('token ', response.token);
 
-      // Login
-      await login(response.token);
+      const data: OktaCallbackResponse & { detail?: string } = await res.json();
+      if (!res.ok) throw new Error(data?.detail || 'OAuth callback failed');
+
+      await login(data.token);
 
       // Storage Management
-      localStorage.setItem('token', response.token);
+      localStorage.setItem('token', data.token);
       localStorage.removeItem('nonce');
       localStorage.removeItem('state');
 
-      history.push('/');
+      history.replace('/');
     } catch (e) {
       console.error(e);
-      history.push('/');
+      history.replace('/');
     }
-  }, [apiPost, history, login]);
+  }, [history, login]);
 
   useEffect(() => {
     handleOktaCallback();

--- a/frontend/src/types/pkce-challenge.d.ts
+++ b/frontend/src/types/pkce-challenge.d.ts
@@ -1,0 +1,6 @@
+declare module 'pkce-challenge' {
+  export default function pkceChallenge(length?: number): {
+    code_verifier: string;
+    code_challenge: string;
+  };
+}

--- a/playwright/run_playwright_tests.sh
+++ b/playwright/run_playwright_tests.sh
@@ -53,7 +53,6 @@ OVERRIDES=$(jq -n \
     ]
   }')
 
-
 # 🚀 Launch ECS task
 echo "🚀 Starting ECS task..."
 TASK_ARN=$(aws ecs run-task \
@@ -70,9 +69,9 @@ TASK_ARN=$(aws ecs run-task \
   --region "$AWS_REGION" \
   --overrides "$OVERRIDES" \
   --query 'tasks[0].taskArn' \
-  --output text 2>/dev/null) || {
-    echo "❌ Failed to run ECS task." >&2
-    exit 1
+  --output text 2> /dev/null) || {
+  echo "❌ Failed to run ECS task." >&2
+  exit 1
 }
 
 if [[ -z "$TASK_ARN" || "$TASK_ARN" == "None" ]]; then


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

These changes improve the security of our Okta login by adding PKCE, a mechanism that prevents attackers from hijacking login sessions.

We now store temporary security values (state and code verifier) in secure, HttpOnly cookies at the start of the login flow. When the user returns from Okta, we verify these cookies to ensure the login response is valid and tied to the original request.

This required adding a new API endpoint to set these cookies. We also added tests to confirm this works correctly.

## 💭 Motivation and context ##

The previous login flow was missing key OAuth protections: it didn’t use PKCE or a state parameter to verify that the OAuth login request and response belonged to the same user session.

This exposed the application to OAuth CSRF attacks where a malicious user could trick someone into completing a login flow they didn't initiate.

## 🧪 Testing ##

Added tests and replicated pen-tester actions.

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [x] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Revert dependencies to default branches.
- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release (necessary if and only if the version was bumped).
