### PR TITLE
Add ability to request historical data for VS Vulns: CRASM-2726

### DIFF
--- a/backend/src/xfd_django/xfd_api/api_methods/vulnerability.py
+++ b/backend/src/xfd_django/xfd_api/api_methods/vulnerability.py
@@ -144,7 +144,7 @@ def v2_get_vulnerability_by_id(
             page=1,
             sort="ASC",
             order="id",
-            filters=VulnerabilityFilters(id=str(vuln_id)),
+            filters=VulnerabilityFilters(id=str(vuln_id), false_positive=None),
         )
 
         vulnerabilities, count = search_vulnerabilities(search, current_user)

--- a/backend/src/xfd_django/xfd_api/api_methods/vulnerability.py
+++ b/backend/src/xfd_django/xfd_api/api_methods/vulnerability.py
@@ -5,8 +5,7 @@ import csv
 from datetime import datetime, timedelta
 import io
 import logging
-from typing import Optional, List
-from django.forms.models import model_to_dict
+from typing import List, Optional
 
 # Third-Party Libraries
 from django.core.paginator import Paginator
@@ -32,22 +31,20 @@ from ..helpers.uuid_helpers import is_valid_uuid
 from ..models import Domain
 from ..schema_models.vulnerability import (
     CveDetailsResponse,
-    GetVulnerabilityResponse,
-    GetVulnerabilityByIdRequest,
     GetV2VulnerabilityResponse,
+    GetVulnerabilityByIdRequest,
+    GetVulnerabilityResponse,
     PortScanResponse,
-    TicketEventResponse,
     UserExposure,
     VsTicketEvent,
     VsVulnerabilityResponse,
     VulnByIdRequest,
-    VulnScanResponse,
-    
 )
 from ..schema_models.vulnerability import (
     VulnerabilityFilters,
     VulnerabilityGroupResponse,
     VulnerabilitySearch,
+    VulnScanResponse,
 )
 from ..schema_models.vulnerability import Vulnerability as VulnerabilitySchema
 
@@ -93,17 +90,23 @@ def get_vulnerability_by_id(vulnerability_id, current_user):
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
+
 def convert_scan(event):
+    """Convert vuln or port scan to match pydantic reponse."""
     if event.vuln_scan:
         return VulnScanResponse.from_orm(event.vuln_scan)
     elif event.port_scan:
         return PortScanResponse.from_orm(event.port_scan)
     return None
 
+
 def get_ticket_history(vuln_id: str, limit: Optional[int] = None) -> List[dict]:
+    """Return scan history for a requested ticket."""
     try:
         ticket = Ticket.objects.get(id=vuln_id)
-        events_query = ticket.ticket_events.select_related("vuln_scan", "port_scan").order_by("-event_timestamp")
+        events_query = ticket.ticket_events.select_related(
+            "vuln_scan", "port_scan"
+        ).order_by("-event_timestamp")
 
         if limit is not None:
             events_query = events_query[:limit]
@@ -112,21 +115,26 @@ def get_ticket_history(vuln_id: str, limit: Optional[int] = None) -> List[dict]:
         for event in events_query:
             scan_data = convert_scan(event)
 
-            history.append({
-                "id": str(event.id),
-                "action": event.action,
-                "reason": event.reason,
-                "event_timestamp": event.event_timestamp,
-                "delta": event.delta,
-                "scan": scan_data.model_dump() if scan_data else None,
-            })
+            history.append(
+                {
+                    "id": str(event.id),
+                    "action": event.action,
+                    "reason": event.reason,
+                    "event_timestamp": event.event_timestamp,
+                    "delta": event.delta,
+                    "scan": scan_data.model_dump() if scan_data else None,
+                }
+            )
 
         return history
 
     except Ticket.DoesNotExist:
         return []
-    
-def v2_get_vulnerability_by_id(vuln_id: str, request: Optional[VulnByIdRequest], current_user):
+
+
+def v2_get_vulnerability_by_id(
+    vuln_id: str, request: Optional[VulnByIdRequest], current_user
+):
     """Get vulnerability by id: v2."""
     try:
         if request is None:
@@ -171,13 +179,16 @@ def v2_get_vulnerability_by_id(vuln_id: str, request: Optional[VulnByIdRequest],
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
+
 def infer_scan_source(vulnerability_id: str) -> Optional[str]:
+    """Identify scan_source if none is provided."""
     try:
         vuln = Vulnerability.objects.get(id=vulnerability_id)
         return vuln.scan_source
     except Exception:
         return None
-    
+
+
 def get_vulnerability_by_scan_source_and_id(
     vulnerability_id: str,
     request: Optional[GetVulnerabilityByIdRequest],
@@ -186,7 +197,7 @@ def get_vulnerability_by_scan_source_and_id(
     """Get vulnerability by scan_source and id."""
     if request is None:
         request = GetVulnerabilityByIdRequest()
-    
+
     scan_source = request.scan_source or infer_scan_source(vulnerability_id)
 
     if scan_source is None:
@@ -226,8 +237,9 @@ def get_vulnerability_by_scan_source_and_id(
                     .prefetch_related(
                         Prefetch(
                             "ticket_events",
-                            queryset=TicketEvent.objects.select_related("vuln_scan", "port_scan")
-                            .order_by("-event_timestamp")[:request.history_limit]
+                            queryset=TicketEvent.objects.select_related(
+                                "vuln_scan", "port_scan"
+                            ).order_by("-event_timestamp")[: request.history_limit]
                             if request.history
                             else TicketEvent.objects.none(),
                             to_attr="prefetched_events",
@@ -257,7 +269,7 @@ def get_vulnerability_by_scan_source_and_id(
                         )
 
                 ticket_response = {
-                    "type": "vuln_scanning_tickets",
+                    "source_type": "vuln_scanning_tickets",
                     "id": str(ticket.id),
                     "cve_string": ticket.cve_string,
                     # "cve_id":
@@ -323,7 +335,7 @@ def get_vulnerability_by_scan_source_and_id(
                     )
 
                 response = {
-                    "type": "credential_breach",
+                    "source_type": "credential_breach",
                     "breach_name": related_breach.breach_name,
                     "description": related_breach.description,
                     "breach_date": related_breach.breach_date,
@@ -355,7 +367,7 @@ def get_vulnerability_by_scan_source_and_id(
             )
 
             vuln_response = {
-                "type": "shodan_vulnerability",
+                "source_type": "shodan_vulnerability",
                 "shodan_identified_organization_name": shodan_vuln.organization_name,
                 "ip_string": shodan_vuln.ip_string,
                 "port": shodan_vuln.port,

--- a/backend/src/xfd_django/xfd_api/api_methods/vulnerability.py
+++ b/backend/src/xfd_django/xfd_api/api_methods/vulnerability.py
@@ -70,7 +70,10 @@ def get_vulnerability_by_id(vulnerability_id, current_user):
             page=1,
             sort="ASC",
             order="id",
-            filters=VulnerabilityFilters(id=str(vulnerability_id), false_positive=None),
+            show_all=True,
+            filters=VulnerabilityFilters(
+                id=str(vulnerability_id), false_positive=None, state=None
+            ),
         )
         vulnerabilities, count = search_vulnerabilities(search, current_user)
 
@@ -137,6 +140,9 @@ def v2_get_vulnerability_by_id(
 ):
     """Get vulnerability by id: v2."""
     try:
+        if not is_valid_uuid(vuln_id):
+            raise HTTPException(status_code=400, detail="Invalid vulnerability ID")
+
         if request is None:
             request = VulnByIdRequest()  # Use default values
 
@@ -144,7 +150,10 @@ def v2_get_vulnerability_by_id(
             page=1,
             sort="ASC",
             order="id",
-            filters=VulnerabilityFilters(id=str(vuln_id), false_positive=None),
+            show_all=True,
+            filters=VulnerabilityFilters(
+                id=str(vuln_id), false_positive=None, state=None
+            ),
         )
 
         vulnerabilities, count = search_vulnerabilities(search, current_user)
@@ -195,6 +204,9 @@ def get_vulnerability_by_scan_source_and_id(
     current_user,
 ):  # pylint: disable=R0915
     """Get vulnerability by scan_source and id."""
+    if not is_valid_uuid(vulnerability_id):
+        raise HTTPException(status_code=400, detail="Invalid vulnerability ID")
+
     if request is None:
         request = GetVulnerabilityByIdRequest()
 

--- a/backend/src/xfd_django/xfd_api/api_methods/vulnerability.py
+++ b/backend/src/xfd_django/xfd_api/api_methods/vulnerability.py
@@ -152,7 +152,7 @@ def v2_get_vulnerability_by_id(vuln_id: str, request: Optional[VulnByIdRequest],
 
         # ✅ Conditional ticket history logic
         if request.history and response.scan_source == "vuln_scanning_tickets":
-            ticket_history = get_ticket_history(vuln_id, limit=request.scan_limit)
+            ticket_history = get_ticket_history(vuln_id, limit=request.history_limit)
             response.ticket_history = ticket_history
 
         # ✅ Enrich CVE details if `cve` exists
@@ -227,7 +227,7 @@ def get_vulnerability_by_scan_source_and_id(
                         Prefetch(
                             "ticket_events",
                             queryset=TicketEvent.objects.select_related("vuln_scan", "port_scan")
-                            .order_by("-event_timestamp")[:request.scan_limit]
+                            .order_by("-event_timestamp")[:request.history_limit]
                             if request.history
                             else TicketEvent.objects.none(),
                             to_attr="prefetched_events",

--- a/backend/src/xfd_django/xfd_api/api_methods/vulnerability.py
+++ b/backend/src/xfd_django/xfd_api/api_methods/vulnerability.py
@@ -202,7 +202,7 @@ def get_vulnerability_by_scan_source_and_id(
     vulnerability_id: str,
     request: Optional[GetVulnerabilityByIdRequest],
     current_user,
-):  # pylint: disable=R0915
+):  # pylint: disable=R0915, R0912
     """Get vulnerability by scan_source and id."""
     if not is_valid_uuid(vulnerability_id):
         raise HTTPException(status_code=400, detail="Invalid vulnerability ID")

--- a/backend/src/xfd_django/xfd_api/api_methods/vulnerability.py
+++ b/backend/src/xfd_django/xfd_api/api_methods/vulnerability.py
@@ -5,6 +5,8 @@ import csv
 from datetime import datetime, timedelta
 import io
 import logging
+from typing import Optional, List
+from django.forms.models import model_to_dict
 
 # Third-Party Libraries
 from django.core.paginator import Paginator
@@ -15,6 +17,7 @@ from xfd_mini_dl.models import (  # Add Domain import here when done
     CisaKevCatalog,
     CredentialBreaches,
     CredentialExposures,
+    Cve,
     Service,
     ShodanVulns,
     Ticket,
@@ -28,10 +31,18 @@ from ..helpers.s3_client import S3Client
 from ..helpers.uuid_helpers import is_valid_uuid
 from ..models import Domain
 from ..schema_models.vulnerability import (
+    CveDetailsResponse,
     GetVulnerabilityResponse,
+    GetVulnerabilityByIdRequest,
+    GetV2VulnerabilityResponse,
+    PortScanResponse,
+    TicketEventResponse,
     UserExposure,
     VsTicketEvent,
     VsVulnerabilityResponse,
+    VulnByIdRequest,
+    VulnScanResponse,
+    
 )
 from ..schema_models.vulnerability import (
     VulnerabilityFilters,
@@ -82,11 +93,105 @@ def get_vulnerability_by_id(vulnerability_id, current_user):
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
+def convert_scan(event):
+    if event.vuln_scan:
+        return VulnScanResponse.from_orm(event.vuln_scan)
+    elif event.port_scan:
+        return PortScanResponse.from_orm(event.port_scan)
+    return None
 
+def get_ticket_history(vuln_id: str, limit: Optional[int] = None) -> List[dict]:
+    try:
+        ticket = Ticket.objects.get(id=vuln_id)
+        events_query = ticket.ticket_events.select_related("vuln_scan", "port_scan").order_by("-event_timestamp")
+
+        if limit is not None:
+            events_query = events_query[:limit]
+
+        history = []
+        for event in events_query:
+            scan_data = convert_scan(event)
+
+            history.append({
+                "id": str(event.id),
+                "action": event.action,
+                "reason": event.reason,
+                "event_timestamp": event.event_timestamp,
+                "delta": event.delta,
+                "scan": scan_data.model_dump() if scan_data else None,
+            })
+
+        return history
+
+    except Ticket.DoesNotExist:
+        return []
+    
+def v2_get_vulnerability_by_id(vuln_id: str, request: Optional[VulnByIdRequest], current_user):
+    """Get vulnerability by id: v2."""
+    try:
+        if request is None:
+            request = VulnByIdRequest()  # Use default values
+
+        search = VulnerabilitySearch(
+            page=1,
+            sort="ASC",
+            order="id",
+            filters=VulnerabilityFilters(id=str(vuln_id)),
+        )
+
+        vulnerabilities, count = search_vulnerabilities(search, current_user)
+
+        if count == 0:
+            raise HTTPException(status_code=404, detail="Vulnerability not found.")
+
+        enrich_kev_fields(vulnerabilities)
+
+        vulnerability = vulnerabilities[0]
+
+        response = GetV2VulnerabilityResponse.from_orm(vulnerability)
+
+        # ✅ Conditional ticket history logic
+        if request.history and response.scan_source == "vuln_scanning_tickets":
+            ticket_history = get_ticket_history(vuln_id, limit=request.scan_limit)
+            response.ticket_history = ticket_history
+
+        # ✅ Enrich CVE details if `cve` exists
+        if response.cve:
+            try:
+                cve_record = Cve.objects.get(name=response.cve)
+                response.cve_details = CveDetailsResponse.from_orm(cve_record)
+            except Cve.DoesNotExist:
+                # You can log this if needed
+                pass
+
+        return response
+
+    except HTTPException as he:
+        raise he
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+def infer_scan_source(vulnerability_id: str) -> Optional[str]:
+    try:
+        vuln = Vulnerability.objects.get(id=vulnerability_id)
+        return vuln.scan_source
+    except Exception:
+        return None
+    
 def get_vulnerability_by_scan_source_and_id(
-    scan_source: str, vulnerability_id: str, current_user
+    vulnerability_id: str,
+    request: Optional[GetVulnerabilityByIdRequest],
+    current_user,
 ):
     """Get vulnerability by scan_source and id."""
+    if request is None:
+        request = GetVulnerabilityByIdRequest()
+    
+    scan_source = request.scan_source or infer_scan_source(vulnerability_id)
+
+    if scan_source is None:
+        raise HTTPException(status_code=400, detail="Could not determine scan source")
+
     try:
         # Initialize a VulnerabilitySearch with filters.id set to the vulnerability_id
         # Permissions check
@@ -121,16 +226,38 @@ def get_vulnerability_by_scan_source_and_id(
                     .prefetch_related(
                         Prefetch(
                             "ticket_events",
-                            queryset=TicketEvent.objects.select_related(
-                                "vuln_scan"
-                            ).order_by("-event_timestamp")[:10],
+                            queryset=TicketEvent.objects.select_related("vuln_scan", "port_scan")
+                            .order_by("-event_timestamp")[:request.scan_limit]
+                            if request.history
+                            else TicketEvent.objects.none(),
                             to_attr="prefetched_events",
                         )
                     )
                     .get(id=vulnerability_id, **filters)
                 )
 
+                ticket_events = []
+                if request.history:
+                    for event in ticket.prefetched_events:
+                        scan_data = None
+                        if event.vuln_scan:
+                            scan_data = VulnScanResponse.from_orm(event.vuln_scan)
+                        elif event.port_scan:
+                            scan_data = PortScanResponse.from_orm(event.port_scan)
+
+                        ticket_events.append(
+                            VsTicketEvent(
+                                id=str(event.id),
+                                action=event.action,
+                                reason=event.reason,
+                                event_timestamp=event.event_timestamp,
+                                delta=event.delta,
+                                scan=scan_data,
+                            )
+                        )
+
                 ticket_response = {
+                    "type": "vuln_scanning_tickets",
                     "id": str(ticket.id),
                     "cve_string": ticket.cve_string,
                     # "cve_id":
@@ -157,32 +284,13 @@ def get_vulnerability_by_scan_source_and_id(
                     "opened_timestamp": ticket.opened_timestamp,
                     "is_open": ticket.is_open,
                     "is_kev": ticket.is_kev,
+                    "is_kev_ransomware": ticket.is_kev_ransomware,
                     "is_risky": ticket.is_risky,
                     "service_name": ticket.service_name,
+                    "nmi_service_group": ticket.nmi_service_group,
+                    "risky_service_group": ticket.risky_service_group,
                     "operating_system": ticket.operating_system,
-                    "ticket_events": [
-                        VsTicketEvent(
-                            id=str(event.id),
-                            action=event.action,
-                            reason=event.reason,
-                            event_timestamp=event.event_timestamp,
-                            delta=event.delta,
-                            vuln_scan_description=event.vuln_scan.description
-                            if event.vuln_scan
-                            else None,
-                            vuln_scan_cpe=event.vuln_scan.cpe
-                            if event.vuln_scan
-                            else None,
-                            vuln_scan_solution=event.vuln_scan.solution
-                            if event.vuln_scan
-                            else None,
-                            vuln_scan_synopsis=event.vuln_scan.synopsis
-                            if event.vuln_scan
-                            else None,
-                            # add other fields you need
-                        )
-                        for event in ticket.prefetched_events
-                    ],
+                    "ticket_events": ticket_events,
                 }
 
                 return VsVulnerabilityResponse(**ticket_response)
@@ -215,6 +323,7 @@ def get_vulnerability_by_scan_source_and_id(
                     )
 
                 response = {
+                    "type": "credential_breach",
                     "breach_name": related_breach.breach_name,
                     "description": related_breach.description,
                     "breach_date": related_breach.breach_date,
@@ -246,6 +355,7 @@ def get_vulnerability_by_scan_source_and_id(
             )
 
             vuln_response = {
+                "type": "shodan_vulnerability",
                 "shodan_identified_organization_name": shodan_vuln.organization_name,
                 "ip_string": shodan_vuln.ip_string,
                 "port": shodan_vuln.port,

--- a/backend/src/xfd_django/xfd_api/api_methods/vulnerability.py
+++ b/backend/src/xfd_django/xfd_api/api_methods/vulnerability.py
@@ -193,7 +193,7 @@ def get_vulnerability_by_scan_source_and_id(
     vulnerability_id: str,
     request: Optional[GetVulnerabilityByIdRequest],
     current_user,
-):
+):  # pylint: disable=R0915
     """Get vulnerability by scan_source and id."""
     if request is None:
         request = GetVulnerabilityByIdRequest()

--- a/backend/src/xfd_django/xfd_api/schema_models/vulnerability.py
+++ b/backend/src/xfd_django/xfd_api/schema_models/vulnerability.py
@@ -45,7 +45,7 @@ class VulnerabilityFilters(BaseModel):
     domain: Optional[str] = None
     severity: Optional[str] = None
     cpe: Optional[str] = None
-    state: Optional[str] = None
+    state: Optional[str] = "open"
     substate: Optional[str] = None
     organization: Optional[str] = None
     tag: Optional[str] = None

--- a/backend/src/xfd_django/xfd_api/schema_models/vulnerability.py
+++ b/backend/src/xfd_django/xfd_api/schema_models/vulnerability.py
@@ -1,7 +1,7 @@
 """Vulnerability schemas."""
 # Standard Python Libraries
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Union, Literal
+from typing import Any, Dict, List, Literal, Optional, Union
 from uuid import UUID
 
 # Third-Party Libraries
@@ -164,7 +164,10 @@ class ServiceResponse(BaseModel):
 
     model_config = {"from_attributes": True}
 
+
 class CveDetailsResponse(BaseModel):
+    """CVE details response model."""
+
     id: UUID
     name: Optional[str]
     published_at: Optional[datetime]
@@ -207,7 +210,11 @@ class CveDetailsResponse(BaseModel):
     dve_score: Optional[float]  # Note: Will auto-convert from Decimal
 
     model_config = {"from_attributes": True}
+
+
 class PortScanResponse(BaseModel):
+    """Port Scan Response model."""
+
     id: str
     ip_string: Optional[str]
     latest: Optional[bool]
@@ -236,7 +243,10 @@ class PortScanResponse(BaseModel):
 
     model_config = {"from_attributes": True}
 
+
 class VulnScanResponse(BaseModel):
+    """Vuln Scan Response model."""
+
     id: str
     cert_id: Optional[str]
     cpe: Optional[str]
@@ -296,7 +306,10 @@ class VulnScanResponse(BaseModel):
 
     model_config = {"from_attributes": True}
 
+
 class TicketEventResponse(BaseModel):
+    """Ticket Event Response model."""
+
     id: Any
     action: Optional[str]
     reason: Optional[str]
@@ -306,8 +319,9 @@ class TicketEventResponse(BaseModel):
 
     model_config = {"from_attributes": True}
 
+
 class GetV2VulnerabilityResponse(BaseModel):
-    """Get a single vulnerability response model: V2"""
+    """Get a single vulnerability response model: V2."""
 
     id: str
     scan_source: Optional[str]
@@ -363,16 +377,22 @@ class GetV2VulnerabilityResponse(BaseModel):
                 )
         # You can add other scan_type conditions here
         return self
+
+
 class VulnByIdRequest(BaseModel):
-    """Get a single vulnerability request: V2"""
-    
-    history: Optional[bool]=False
+    """Get a single vulnerability request: V2."""
+
+    history: Optional[bool] = False
     history_limit: Optional[int] = None
 
+
 class GetVulnerabilityByIdRequest(BaseModel):
+    """Get Vulnerability By Id Request model."""
+
     scan_source: Optional[str] = None  # Optional: will infer if missing
     history: Optional[bool] = False
     history_limit: Optional[int] = 10
+
 
 class GetVulnerabilityResponse(BaseModel):
     """Get a single vulnerability response model."""
@@ -463,7 +483,7 @@ class UserExposure(BaseModel):
 class CredBreachVulnerabilityResponse(BaseModel):
     """Credential Breach Vulnerability Response."""
 
-    type: Literal["credential_breach"] = "credential_breach"
+    source_type: Literal["credential_breach"] = "credential_breach"
     breach_name: Optional[str] = None
     description: Optional[str] = None
     breach_date: Optional[datetime] = None
@@ -478,6 +498,8 @@ class CredBreachVulnerabilityResponse(BaseModel):
 
 
 class VsTicketEvent(BaseModel):
+    """VS Ticket Even model."""
+
     id: str
     action: Optional[str] = None
     reason: Optional[str] = None
@@ -491,7 +513,7 @@ class VsTicketEvent(BaseModel):
 class VsVulnerabilityResponse(BaseModel):
     """VS Vulnerability Response."""
 
-    type: Literal["vuln_scanning_tickets"] = "vuln_scanning_tickets"
+    source_type: Literal["vuln_scanning_tickets"] = "vuln_scanning_tickets"
     id: str
     cve_string: Optional[str] = None
     cvss_base_score: Optional[float] = None
@@ -528,7 +550,7 @@ class VsVulnerabilityResponse(BaseModel):
 class ShodanVulnerabiltyResponse(BaseModel):
     """Shodan Vulnerability Response."""
 
-    type: Literal["shodan_vulnerability"] = "shodan_vulnerability"
+    source_type: Literal["shodan_vulnerability"] = "shodan_vulnerability"
     shodan_identified_organization_name: Optional[str] = None
     ip_string: Optional[str] = None
     port: Optional[str] = None

--- a/backend/src/xfd_django/xfd_api/schema_models/vulnerability.py
+++ b/backend/src/xfd_django/xfd_api/schema_models/vulnerability.py
@@ -367,12 +367,12 @@ class VulnByIdRequest(BaseModel):
     """Get a single vulnerability request: V2"""
     
     history: Optional[bool]=False
-    scan_limit: Optional[int] = None
+    history_limit: Optional[int] = None
 
 class GetVulnerabilityByIdRequest(BaseModel):
     scan_source: Optional[str] = None  # Optional: will infer if missing
     history: Optional[bool] = False
-    scan_limit: Optional[int] = 10
+    history_limit: Optional[int] = 10
 
 class GetVulnerabilityResponse(BaseModel):
     """Get a single vulnerability response model."""

--- a/backend/src/xfd_django/xfd_api/schema_models/vulnerability.py
+++ b/backend/src/xfd_django/xfd_api/schema_models/vulnerability.py
@@ -1,7 +1,7 @@
 """Vulnerability schemas."""
 # Standard Python Libraries
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union, Literal
 from uuid import UUID
 
 # Third-Party Libraries
@@ -164,6 +164,215 @@ class ServiceResponse(BaseModel):
 
     model_config = {"from_attributes": True}
 
+class CveDetailsResponse(BaseModel):
+    id: UUID
+    name: Optional[str]
+    published_at: Optional[datetime]
+    modified_at: Optional[datetime]
+    status: Optional[str]
+
+    description: Optional[str]
+
+    cvss_v2_source: Optional[str]
+    cvss_v2_type: Optional[str]
+    cvss_v2_version: Optional[str]
+    cvss_v2_vector_string: Optional[str]
+    cvss_v2_base_score: Optional[str]
+    cvss_v2_base_severity: Optional[str]
+    cvss_v2_exploitability_score: Optional[str]
+    cvss_v2_impact_score: Optional[str]
+
+    cvss_v3_source: Optional[str]
+    cvss_v3_type: Optional[str]
+    cvss_v3_version: Optional[str]
+    cvss_v3_vector_string: Optional[str]
+    cvss_v3_base_score: Optional[str]
+    cvss_v3_base_severity: Optional[str]
+    cvss_v3_exploitability_score: Optional[str]
+    cvss_v3_impact_score: Optional[str]
+
+    cvss_v4_source: Optional[str]
+    cvss_v4_type: Optional[str]
+    cvss_v4_version: Optional[str]
+    cvss_v4_vector_string: Optional[str]
+    cvss_v4_base_score: Optional[str]
+    cvss_v4_base_severity: Optional[str]
+    cvss_v4_exploitability_score: Optional[str]
+    cvss_v4_impact_score: Optional[str]
+
+    weaknesses: Optional[List[Optional[str]]]
+    reference_urls: Optional[List[Optional[str]]]
+    cpe_list: Optional[List[Optional[str]]]
+
+    dve_score: Optional[float]  # Note: Will auto-convert from Decimal
+
+    model_config = {"from_attributes": True}
+class PortScanResponse(BaseModel):
+    id: str
+    ip_string: Optional[str]
+    latest: Optional[bool]
+    port: Optional[int]
+    protocol: Optional[str]
+    reason: Optional[str]
+    service: Optional[Dict]  # assuming this is a JSON field
+    service_name: Optional[str]
+    service_confidence: Optional[int]
+    service_method: Optional[str]
+    service_cpe: Optional[str]
+    service_hostname: Optional[str]
+    service_extra_info: Optional[str]
+    service_os_type: Optional[str]
+    service_product: Optional[str]
+    service_version: Optional[str]
+    service_tunnel: Optional[str]
+    service_device_type: Optional[str]
+    source: Optional[str]
+    state: Optional[str]
+    time_scanned: Optional[datetime]
+    nmi_service_group: Optional[str]
+    risky_service_group: Optional[str]
+
+    type: str = "port"
+
+    model_config = {"from_attributes": True}
+
+class VulnScanResponse(BaseModel):
+    id: str
+    cert_id: Optional[str]
+    cpe: Optional[str]
+    cve_string: Optional[str]
+    cvss_base_score: Optional[str]
+    cvss_temporal_score: Optional[str]
+    cvss_temporal_vector: Optional[str]
+    cvss_vector: Optional[str]
+    description: Optional[str]
+    exploit_available: Optional[str]
+    exploitability_ease: Optional[str]
+    ip_string: Optional[str]
+    latest: Optional[bool]
+    owner: Optional[str]
+    osvdb_id: Optional[str]
+    patch_publication_timestamp: Optional[datetime]
+    cisa_known_exploited: Optional[datetime]
+    port: Optional[int]
+    port_protocol: Optional[str]
+    risk_factor: Optional[str]
+    script_version: Optional[str]
+    see_also: Optional[str]
+    service: Optional[str]
+    severity: Optional[int]
+    solution: Optional[str]
+    source: Optional[str]
+    synopsis: Optional[str]
+    vuln_detection_timestamp: Optional[datetime]
+    vuln_publication_timestamp: Optional[datetime]
+    xref: Optional[str]
+    cwe: Optional[str]
+    bid: Optional[str]
+    exploited_by_malware: Optional[bool]
+    thorough_tests: Optional[bool]
+    cvss_score_rationale: Optional[str]
+    cvss_score_source: Optional[str]
+    cvss3_base_score: Optional[float]
+    cvss3_vector: Optional[str]
+    cvss3_temporal_vector: Optional[str]
+    cvss3_temporal_score: Optional[float]
+    asset_inventory: Optional[bool]
+    plugin_id: Optional[str]
+    plugin_modification_date: Optional[datetime]
+    plugin_publication_date: Optional[datetime]
+    plugin_name: Optional[str]
+    plugin_type: Optional[str]
+    plugin_family: Optional[str]
+    f_name: Optional[str]
+    cisco_bug_id: Optional[str]
+    cisco_sa: Optional[str]
+    plugin_output: Optional[str]
+    other_findings: Optional[Dict]
+    nmi_service_group: Optional[str]
+    risky_service_group: Optional[str]
+
+    type: str = "vuln"
+
+    model_config = {"from_attributes": True}
+
+class TicketEventResponse(BaseModel):
+    id: Any
+    action: Optional[str]
+    reason: Optional[str]
+    event_timestamp: Optional[datetime]
+    delta: Optional[str]
+    scan: Optional[Union[VulnScanResponse, PortScanResponse]]
+
+    model_config = {"from_attributes": True}
+
+class GetV2VulnerabilityResponse(BaseModel):
+    """Get a single vulnerability response model: V2"""
+
+    id: str
+    scan_source: Optional[str]
+    created_at: Optional[datetime]
+    updated_at: Optional[datetime]
+    last_seen: Optional[datetime]
+    cve: Optional[str]
+    cve_details: Optional[CveDetailsResponse] = None
+    title: Optional[str]
+    product: Optional[str]
+    domain_string: Optional[str]
+    domain: Optional[DomainResponse]
+    protocol: Optional[str]
+    port: Optional[str]
+    cvss: Optional[float]
+    severity: Optional[str]
+    organization: Optional[OrganizationResponse]
+    state: Optional[str]
+    source: Optional[str]
+    description: Optional[str]
+    is_kev: Optional[bool]
+    service_string: Optional[str]
+    is_risky_service: Optional[bool]
+    os: Optional[str]
+    cwe: Optional[str]
+    cpe: Optional[str]
+    references: Optional[List[Any]]
+    substate: Optional[str]
+    needs_population: Optional[bool] = False
+    actions: Optional[List[Any]]
+    structured_data: Optional[Any]
+    kev_results: Optional[dict]
+    ip_string: Optional[str]
+    cvss_vector: Optional[str]
+    severity_int: Optional[int]
+    plugin_id: Optional[str]
+    solution: Optional[str]
+    synopsis: Optional[str]
+    results: Optional[str]
+    ticket_history: Optional[List[TicketEventResponse]] = None
+
+    model_config = {"from_attributes": True}
+
+    @model_validator(mode="after")
+    def validate_id_based_on_scan_type(self):
+        """Validate UUID based on scan source."""
+        if self.scan_source != "vuln_scanning_tickets":
+            try:
+                UUID(self.id)  # Will raise ValueError if invalid
+            except ValueError:
+                raise ValueError(
+                    f"id must be a valid UUID when scan_type is not 'vuln_scanning_tickets', got: {self.id}"
+                )
+        # You can add other scan_type conditions here
+        return self
+class VulnByIdRequest(BaseModel):
+    """Get a single vulnerability request: V2"""
+    
+    history: Optional[bool]=False
+    scan_limit: Optional[int] = None
+
+class GetVulnerabilityByIdRequest(BaseModel):
+    scan_source: Optional[str] = None  # Optional: will infer if missing
+    history: Optional[bool] = False
+    scan_limit: Optional[int] = 10
 
 class GetVulnerabilityResponse(BaseModel):
     """Get a single vulnerability response model."""
@@ -254,6 +463,7 @@ class UserExposure(BaseModel):
 class CredBreachVulnerabilityResponse(BaseModel):
     """Credential Breach Vulnerability Response."""
 
+    type: Literal["credential_breach"] = "credential_breach"
     breach_name: Optional[str] = None
     description: Optional[str] = None
     breach_date: Optional[datetime] = None
@@ -268,22 +478,20 @@ class CredBreachVulnerabilityResponse(BaseModel):
 
 
 class VsTicketEvent(BaseModel):
-    """Vulnerability scanning ticket event response schema."""
-
     id: str
     action: Optional[str] = None
     reason: Optional[str] = None
     event_timestamp: Optional[datetime] = None
     delta: Optional[list[dict]] = None
-    vuln_scan_description: Optional[str] = None
-    vuln_scan_cpe: Optional[str] = None
-    vuln_scan_solution: Optional[str] = None
-    vuln_scan_synopsis: Optional[str] = None
+    scan: Optional[Union[VulnScanResponse, PortScanResponse]] = None
+
+    model_config = {"from_attributes": True}
 
 
 class VsVulnerabilityResponse(BaseModel):
     """VS Vulnerability Response."""
 
+    type: Literal["vuln_scanning_tickets"] = "vuln_scanning_tickets"
     id: str
     cve_string: Optional[str] = None
     cvss_base_score: Optional[float] = None
@@ -306,8 +514,11 @@ class VsVulnerabilityResponse(BaseModel):
     opened_timestamp: Optional[datetime] = None
     is_open: Optional[bool] = None
     is_kev: Optional[bool] = None
+    is_kev_ransomware: Optional[bool] = None
     is_risky: Optional[bool] = None
     service_name: Optional[str] = None
+    nmi_service_group: Optional[str] = None
+    risky_service_group: Optional[str] = None
     operating_system: Optional[str] = None
     ticket_events: Optional[list[VsTicketEvent]] = None
 
@@ -317,6 +528,7 @@ class VsVulnerabilityResponse(BaseModel):
 class ShodanVulnerabiltyResponse(BaseModel):
     """Shodan Vulnerability Response."""
 
+    type: Literal["shodan_vulnerability"] = "shodan_vulnerability"
     shodan_identified_organization_name: Optional[str] = None
     ip_string: Optional[str] = None
     port: Optional[str] = None

--- a/backend/src/xfd_django/xfd_api/tests/test_vulnerabilities.py
+++ b/backend/src/xfd_django/xfd_api/tests/test_vulnerabilities.py
@@ -316,8 +316,6 @@ def test_v2_get_vulnerability_by_id(user, vulnerability, refresh_vuln_views):
     )
     data = response.json()
 
-    print(data)
-
     assert response.status_code == 200
     assert data["id"] == str(vulnerability.id)
     assert data["domain"]["id"] == str(vulnerability.domain.id)
@@ -343,13 +341,12 @@ def test_v2_get_vulnerability_by_id_with_history(
 
 @pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
 def test_v2_get_vulnerability_by_source_id(user, vulnerability, refresh_vuln_views):
-    """Test v2 vulnerability_by_id endpoint with scan_source query param."""
+    """Test v2 vulnerability_details endpoint with scan_source query param."""
     response = client.get(
-        "/v2/vulnerability_by_id/{}".format(str(vulnerability.id)),
+        "/v2/vulnerability_details/{}".format(str(vulnerability.id)),
         headers={"Authorization": f"Bearer {create_jwt_token(user)}"},
     )
     data = response.json()
-    print(data)
 
     assert response.status_code == 200
     assert data["name"] == search_fields["title"]

--- a/backend/src/xfd_django/xfd_api/tests/test_vulnerabilities.py
+++ b/backend/src/xfd_django/xfd_api/tests/test_vulnerabilities.py
@@ -345,7 +345,7 @@ def test_v2_get_vulnerability_by_id_with_history(
 def test_v2_get_vulnerability_by_source_id(user, vulnerability, refresh_vuln_views):
     """Test v2 vulnerability_by_id endpoint with scan_source query param."""
     response = client.get(
-        f"/v2/vulnerability_by_id/{vulnerability.id}?scan_source=shodan_vulnerability",
+        f"/v2/vulnerability_by_id/{vulnerability.id}",
         headers={"Authorization": f"Bearer {create_jwt_token(user)}"},
     )
     data = response.json()

--- a/backend/src/xfd_django/xfd_api/tests/test_vulnerabilities.py
+++ b/backend/src/xfd_django/xfd_api/tests/test_vulnerabilities.py
@@ -307,6 +307,67 @@ def test_get_vulnerability_by_id_fails_404(user, vulnerability, refresh_vuln_vie
     assert response.status_code == 404
 
 
+@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
+def test_v2_get_vulnerability_by_id(user, vulnerability, refresh_vuln_views):
+    """Test v2 vulnerability by ID endpoint with default query params."""
+    response = client.get(
+        "/v2/vulnerabilities/{}".format(str(vulnerability.id)),
+        headers={"Authorization": "Bearer " + create_jwt_token(user)},
+    )
+    data = response.json()
+
+    print(data)
+
+    assert response.status_code == 200
+    assert data["id"] == str(vulnerability.id)
+    assert data["domain"]["id"] == str(vulnerability.domain.id)
+    assert data["severity"] == vulnerability.severity
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
+def test_v2_get_vulnerability_by_id_with_history(
+    user, vulnerability, refresh_vuln_views
+):
+    """Test v2 vulnerability by ID with ticket history query params."""
+    response = client.get(
+        f"/v2/vulnerabilities/{vulnerability.id}?history=true&scan_limit=5",
+        headers={"Authorization": f"Bearer {create_jwt_token(user)}"},
+    )
+    data = response.json()
+
+    assert response.status_code == 200
+    assert data["id"] == str(vulnerability.id)
+    # Optional: assert on ticket_history if it's available based on test data
+    assert "ticket_history" in data
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
+def test_v2_get_vulnerability_by_source_id(user, vulnerability, refresh_vuln_views):
+    """Test v2 vulnerability_by_id endpoint with scan_source query param."""
+    response = client.get(
+        f"/v2/vulnerability_by_id/{vulnerability.id}?scan_source=shodan_vulnerability",
+        headers={"Authorization": f"Bearer {create_jwt_token(user)}"},
+    )
+    data = response.json()
+    print(data)
+
+    assert response.status_code == 200
+    assert data["name"] == search_fields["title"]
+    # Depending on which source you’re testing for, add more assertions
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
+def test_v2_get_vulnerability_by_id_not_found(user):
+    """Test v2 vulnerability by ID returns 404 when not found."""
+    bad_id = "00000000-0000-0000-0000-000000000000"
+    response = client.get(
+        f"/v2/vulnerabilities/{bad_id}",
+        headers={"Authorization": f"Bearer {create_jwt_token(user)}"},
+    )
+
+    assert response.status_code == 404
+
+
 # @pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
 # def test_update_vulnerability(user, vulnerability, refresh_vuln_views):
 #     """Test vulnerability."""

--- a/backend/src/xfd_django/xfd_api/tests/test_vulnerabilities.py
+++ b/backend/src/xfd_django/xfd_api/tests/test_vulnerabilities.py
@@ -345,7 +345,7 @@ def test_v2_get_vulnerability_by_id_with_history(
 def test_v2_get_vulnerability_by_source_id(user, vulnerability, refresh_vuln_views):
     """Test v2 vulnerability_by_id endpoint with scan_source query param."""
     response = client.get(
-        f"/v2/vulnerability_by_id/{vulnerability.id}",
+        "/v2/vulnerability_by_id/{}".format(str(vulnerability.id)),
         headers={"Authorization": f"Bearer {create_jwt_token(user)}"},
     )
     data = response.json()

--- a/backend/src/xfd_django/xfd_api/views.py
+++ b/backend/src/xfd_django/xfd_api/views.py
@@ -140,14 +140,14 @@ from .schema_models.user_log_schema import (
 )
 from .schema_models.vulnerability import (
     CredBreachVulnerabilityResponse,
-    GetVulnerabilityResponse,
     GetV2VulnerabilityResponse,
     GetVulnerabilityByIdRequest,
+    GetVulnerabilityResponse,
     ShodanVulnerabiltyResponse,
     VsVulnerabilityResponse,
+    VulnByIdRequest,
     VulnerabilitySearch,
     VulnerabilitySearchResponse,
-    VulnByIdRequest,
 )
 from .tools.serializers import serialize_organization, serialize_user
 from .tools.user_logger_decorator import (
@@ -1604,21 +1604,23 @@ async def call_get_vulnerability_by_id(
     """Get vulnerability by id."""
     return get_vulnerability_by_id(vulnerability_id, current_user)
 
+
 @api_router.get(
     "/v2/vulnerabilities/{vuln_id}",
     dependencies=[Depends(get_current_active_user)],
     response_model=GetV2VulnerabilityResponse,
     tags=["Vulnerabilities"],
 )
-async def call_get_vulnerability_by_id(
+async def v2_call_get_vulnerability_by_id(
     vuln_id: str = Path(..., description="Vulnerability ID"),
     history: Optional[bool] = Query(False, description="Include ticket history"),
     history_limit: Optional[int] = Query(None, description="Limit for scan history"),
-    current_user: User = Depends(get_current_active_user)
+    current_user: User = Depends(get_current_active_user),
 ):
     """Get vulnerability by id."""
     request = VulnByIdRequest(history=history, history_limit=history_limit)
     return v2_get_vulnerability_by_id(vuln_id, request, current_user)
+
 
 @api_router.get(
     "/v2/vulnerability_by_id/{vulnerability_id}",
@@ -1637,10 +1639,9 @@ async def get_vulnerability_by_source_id_route(
     history_limit: Optional[int] = Query(10, description="Limit for scan history"),
     current_user: User = Depends(get_current_active_user),
 ):
+    """Get Vulnerability by Id: V2."""
     request = GetVulnerabilityByIdRequest(
-        scan_source=scan_source,
-        history=history,
-        history_limit=history_limit
+        scan_source=scan_source, history=history, history_limit=history_limit
     )
     return get_vulnerability_by_scan_source_and_id(
         vulnerability_id=vulnerability_id,

--- a/backend/src/xfd_django/xfd_api/views.py
+++ b/backend/src/xfd_django/xfd_api/views.py
@@ -13,6 +13,7 @@ from fastapi import (
     Body,
     Depends,
     HTTPException,
+    Path,
     Query,
     Request,
     Response,
@@ -78,6 +79,7 @@ from .api_methods.vulnerability import (
     get_vulnerability_by_id,
     get_vulnerability_by_scan_source_and_id,
     search_vulnerabilities,
+    v2_get_vulnerability_by_id,
 )
 from .api_methods.xpanse_sync import xpanse_sync_post
 from .auth import (
@@ -139,10 +141,13 @@ from .schema_models.user_log_schema import (
 from .schema_models.vulnerability import (
     CredBreachVulnerabilityResponse,
     GetVulnerabilityResponse,
+    GetV2VulnerabilityResponse,
+    GetVulnerabilityByIdRequest,
     ShodanVulnerabiltyResponse,
     VsVulnerabilityResponse,
     VulnerabilitySearch,
     VulnerabilitySearchResponse,
+    VulnByIdRequest,
 )
 from .tools.serializers import serialize_organization, serialize_user
 from .tools.user_logger_decorator import (
@@ -1599,9 +1604,22 @@ async def call_get_vulnerability_by_id(
     """Get vulnerability by id."""
     return get_vulnerability_by_id(vulnerability_id, current_user)
 
+@api_router.post(
+    "/v2/vulnerabilities/{vuln_id}",
+    dependencies=[Depends(get_current_active_user)],
+    response_model=GetV2VulnerabilityResponse,
+    tags=["Vulnerabilities"],
+)
+async def call_get_vulnerability_by_id(
+    vuln_id: str = Path(..., description="Vulnerability ID"),
+    vuln_by_id_request: Optional[VulnByIdRequest] = Body(default=None),
+    current_user: User = Depends(get_current_active_user)
+):
+    """Get vulnerability by id."""
+    return v2_get_vulnerability_by_id(vuln_id, vuln_by_id_request, current_user)
 
-@api_router.get(
-    "/vulnerabilities/{scan_source}/{vulnerability_id}",
+@api_router.post(
+    "/v2/vulnerability_by_id/{vulnerability_id}",
     dependencies=[Depends(get_current_active_user)],
     response_model=Union[
         CredBreachVulnerabilityResponse,
@@ -1611,13 +1629,14 @@ async def call_get_vulnerability_by_id(
     tags=["Vulnerabilities"],
 )
 async def get_vulnerability_by_source_id_route(
-    scan_source: str,
     vulnerability_id: str,
+    request: Optional[GetVulnerabilityByIdRequest] = Body(default=None),
     current_user: User = Depends(get_current_active_user),
 ):
-    """Get vulnerability by id."""
     return get_vulnerability_by_scan_source_and_id(
-        scan_source, vulnerability_id, current_user
+        vulnerability_id=vulnerability_id,
+        request=request,
+        current_user=current_user,
     )
 
 

--- a/backend/src/xfd_django/xfd_api/views.py
+++ b/backend/src/xfd_django/xfd_api/views.py
@@ -1614,7 +1614,9 @@ async def call_get_vulnerability_by_id(
 async def v2_call_get_vulnerability_by_id(
     vuln_id: str = Path(..., description="Vulnerability ID"),
     history: Optional[bool] = Query(False, description="Include ticket history"),
-    history_limit: Optional[int] = Query(None, description="Limit for scan history"),
+    history_limit: Optional[int] = Query(
+        None, gt=0, description="Limit for scan history"
+    ),
     current_user: User = Depends(get_current_active_user),
 ):
     """Get vulnerability by id."""
@@ -1623,7 +1625,7 @@ async def v2_call_get_vulnerability_by_id(
 
 
 @api_router.get(
-    "/v2/vulnerability_by_id/{vulnerability_id}",
+    "/v2/vulnerability_details/{vulnerability_id}",
     dependencies=[Depends(get_current_active_user)],
     response_model=Union[
         CredBreachVulnerabilityResponse,
@@ -1636,10 +1638,12 @@ async def get_vulnerability_by_source_id_route(
     vulnerability_id: str = Path(..., description="The ID of the vulnerability"),
     scan_source: Optional[str] = Query(None, description="Scan source (e.g. shodan)"),
     history: Optional[bool] = Query(False, description="Include ticket history"),
-    history_limit: Optional[int] = Query(10, description="Limit for scan history"),
+    history_limit: Optional[int] = Query(
+        10, gt=0, description="Limit for scan history"
+    ),
     current_user: User = Depends(get_current_active_user),
 ):
-    """Get Vulnerability by Id: V2."""
+    """Get vulnerability details by Id: V2."""
     request = GetVulnerabilityByIdRequest(
         scan_source=scan_source, history=history, history_limit=history_limit
     )

--- a/backend/src/xfd_django/xfd_api/views.py
+++ b/backend/src/xfd_django/xfd_api/views.py
@@ -1604,7 +1604,7 @@ async def call_get_vulnerability_by_id(
     """Get vulnerability by id."""
     return get_vulnerability_by_id(vulnerability_id, current_user)
 
-@api_router.post(
+@api_router.get(
     "/v2/vulnerabilities/{vuln_id}",
     dependencies=[Depends(get_current_active_user)],
     response_model=GetV2VulnerabilityResponse,
@@ -1612,13 +1612,15 @@ async def call_get_vulnerability_by_id(
 )
 async def call_get_vulnerability_by_id(
     vuln_id: str = Path(..., description="Vulnerability ID"),
-    vuln_by_id_request: Optional[VulnByIdRequest] = Body(default=None),
+    history: Optional[bool] = Query(False, description="Include ticket history"),
+    history_limit: Optional[int] = Query(None, description="Limit for scan history"),
     current_user: User = Depends(get_current_active_user)
 ):
     """Get vulnerability by id."""
-    return v2_get_vulnerability_by_id(vuln_id, vuln_by_id_request, current_user)
+    request = VulnByIdRequest(history=history, history_limit=history_limit)
+    return v2_get_vulnerability_by_id(vuln_id, request, current_user)
 
-@api_router.post(
+@api_router.get(
     "/v2/vulnerability_by_id/{vulnerability_id}",
     dependencies=[Depends(get_current_active_user)],
     response_model=Union[
@@ -1629,10 +1631,17 @@ async def call_get_vulnerability_by_id(
     tags=["Vulnerabilities"],
 )
 async def get_vulnerability_by_source_id_route(
-    vulnerability_id: str,
-    request: Optional[GetVulnerabilityByIdRequest] = Body(default=None),
+    vulnerability_id: str = Path(..., description="The ID of the vulnerability"),
+    scan_source: Optional[str] = Query(None, description="Scan source (e.g. shodan)"),
+    history: Optional[bool] = Query(False, description="Include ticket history"),
+    history_limit: Optional[int] = Query(10, description="Limit for scan history"),
     current_user: User = Depends(get_current_active_user),
 ):
+    request = GetVulnerabilityByIdRequest(
+        scan_source=scan_source,
+        history=history,
+        history_limit=history_limit
+    )
     return get_vulnerability_by_scan_source_and_id(
         vulnerability_id=vulnerability_id,
         request=request,


### PR DESCRIPTION

## 🗣 Description ##
Update the two vulnerabilities/id endpoints so that users can request historical data for VS vulnerabilities. They can request this data with the history boolean, and request a specific number of historical scanst with the history_limit parameter.
## 💭 Motivation and context ##
This change will allow the frontend to add additional data to the vuln details page, but only when the frontend user requests it. 

## 🧪 Testing ##
Tested locally


## ✅ Pre-approval checklist ##


- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
