### PR TITLE
Remove Playwright container 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -168,20 +168,6 @@ services:
     networks:
       - backend
 
-  playwright:
-    container_name: playwright
-    image: mcr.microsoft.com/playwright:v1.50.1-jammy
-    working_dir: /workspace
-    volumes:
-      - ./playwright:/workspace
-      - ~/.cache:/root/.cache  # Cache Playwright browser downloads
-    env_file:
-      ./playwright/.env
-    environment:
-      - HOME=/root
-    command: >
-      /bin/bash -c "npm ci && npx playwright install --with-deps && npx playwright test"
-
 volumes:
   postgres-data:
   es-data:

--- a/playwright/README.md
+++ b/playwright/README.md
@@ -2,10 +2,9 @@
 
 ## **Overview**
 
-This project uses **Playwright** for automated end-to-end testing. The Playwright testing workflow operates in three distinct modes:
+This project uses **Playwright** for automated end-to-end testing. The Playwright testing workflow operates in two distinct modes:
 
 1. **Local Testing via Terminal** - Running tests directly from the terminal.
-2. **Local Testing via Docker** - Running tests within a Docker container locally.
 3. **AWS Regression Workflow** - Running tests on AWS ECS and uploading results to an S3 bucket.
 
 This README will guide you through setting up, configuring, and running Playwright tests in each mode, as well as handling the deployment process for AWS.
@@ -20,7 +19,6 @@ This README will guide you through setting up, configuring, and running Playwrig
 - [Local Testing via Terminal](#local-testing-via-terminal)
   - [Environment Variables for Local Testing](#environment-variables-for-local-testing)
   - [Environment Variables for Local Testing in VS Code](#environment-variables-for-local-testing-in-vs-code)
-- [Local Testing via Docker](#local-testing-via-docker)
 - [GitHub Actions Testing with Amazon ECS](#github-actions-testing-with-amazon-ecs)
 - [Logging into Crossfeed and Preserving Browser State](#logging-into-crossfeed-and-preserving-browser-state)
 - [Adding Test Cases](#adding-test-cases)
@@ -32,9 +30,9 @@ This README will guide you through setting up, configuring, and running Playwrig
 
 ## Playwright configuration for Crossfeed
 
-Since Playwright is intended to run in 3 different modes `[localhost, local Docker, GitHub Actions/AWS]`, a configuration tool at `utils/env.ts` is created to help set default URLs and headless mode options.
+Since Playwright is intended to run in 2 different modes `[localhost, GitHub Actions/AWS]`, a configuration tool at `utils/env.ts` is created to help set default URLs and headless mode options.
 
- Environment variables pertinent to Playwright are located in `xfd/playwright/.env` and are prefixed with `PW_*`. A blank dummy file is included in the repository to satisfy linters and checkers. This file can be used to set variables for running Playwright in localhost or Docker, but do not check in that file. It is excluded by .gitignore, but be careful when checking in code.
+ Environment variables pertinent to Playwright are located in `xfd/playwright/.env` and are prefixed with `PW_*`. A blank dummy file is included in the repository to satisfy linters and checkers. This file can be used to set variables for running Playwright in localhost, but do not check in that file. It is excluded by .gitignore, but be careful when checking in code.
 
 Some environment variables values are defined in this README, but information that is secret will not be shared in this document. Ask the automated testing team for the values to continue setting up the configuration.
 
@@ -89,28 +87,6 @@ If you are using testing in VS Code using the Playwright extension, add the foll
         "PW_CI": "false"
 }
 ```
-
-## **Local Testing via Docker**
-
-For running in a Dockerized environment, the following variable should be set in the `xfd/playwright/.env`
-
-```env
-PW_XFD_URL=http://frontend:3000
-PW_XFD_USERNAME
-PW_XFD_PASSWORD
-PW_XFD_2FA_ISSUER
-PW_XFD_2FA_SECRET
-PW_XFD_USER_ROLE
-PW_XFD_LOGIN
-PW_HEADLESS=true
-PW_CI=false
-```
-
-This mode is intended to kick off as part of the build process. A docker container will be created using the same Playwright test.
-
-A wait feature will listen for the frontend to begin accepting requests, as the frontend will take longer to compile than Playwright to be ready for testing. When a code 200 is received from the frontend, the Playwright tests will begin.
-
-For this Dockerized environment, `PW_HEADLESS` must be set to true and `PW_CI` must be set to false.
 
 ## **GitHub Actions Testing with Amazon ECS**
 

--- a/playwright/global-setup.ts
+++ b/playwright/global-setup.ts
@@ -28,33 +28,6 @@ let totp = new OTPAuth.TOTP({
 
 const axios = require('axios');
 
-const waitForFrontend = async (url, timeout = 600000, checkInterval = 5000) => {
-  const startTime = Date.now();
-  while (Date.now() - startTime < timeout) {
-    try {
-      const response = await axios.get(url);
-      // Log the status code to ensure the server responds correctly
-      console.log(`Frontend is ready with status code: ${response.status}`);
-      return; // If the request succeeds, we know the server is up
-    } catch (error) {
-      // Check if the error is related to a failed HTTP request (e.g., connection refused, status code not 2xx)
-      if (error.response) {
-        console.log(
-          `Frontend not ready yet. Status: ${error.response.status}. Retrying...`
-        );
-      } else {
-        console.log('Error occurred while checking frontend:', error);
-        break;
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, checkInterval)); // Wait before retrying
-    }
-  }
-  throw new Error(
-    `Frontend did not become ready within ${timeout / 1000} seconds.`
-  );
-};
-
 async function globalSetup(config: FullConfig) {
   const baseUrl = determineUrl();
   console.log(`Base URL: ${baseUrl}`);
@@ -67,7 +40,6 @@ async function globalSetup(config: FullConfig) {
   const page = await browser.newPage();
 
   //Log in with credentials.
-  await waitForFrontend(baseUrl);
   await page.goto(baseUrl, {
     waitUntil: 'domcontentloaded',
     timeout: 60000


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Remove the Playwright Docker container from the build process, update the global setup script to no longer need to wait for the frontend, and update documentation.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Some recent changes to Crossfeed broke the Playwright container. To simplify the build process and improve reliability, just remove the Playwright container and update the code base. 

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
This was tested by rebuilding Crossfeed and ensuring everything still works, and that the `npx playwright test` command run in the local terminal still works as expected. 

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.


