### PR TITLE
update queries to query min and max within the last 120 days

### DIFF
--- a/backend/src/xfd_django/xfd_api/tasks/utils/vs_host_scans.py
+++ b/backend/src/xfd_django/xfd_api/tasks/utils/vs_host_scans.py
@@ -43,16 +43,44 @@ def create_daily_host_summary(org_id_dict, summary_date=None):
         COUNT(DISTINCT ip) AS scanned_asset_count,
 
         -- PORTSCAN timestamps
-        MIN(CASE WHEN POSITION('\"PORTSCAN\":\"' IN ls) > 0
-                THEN CAST(SPLIT_PART(SPLIT_PART(ls, '\"PORTSCAN\":\"', 2), '\"', 1) AS TIMESTAMPTZ) END) AS port_scan_min_timestamp,
-        MAX(CASE WHEN POSITION('\"PORTSCAN\":\"' IN ls) > 0
-                THEN CAST(SPLIT_PART(SPLIT_PART(ls, '\"PORTSCAN\":\"', 2), '\"', 1) AS TIMESTAMPTZ) END) AS port_scan_max_timestamp,
+        MIN(
+            CASE
+                WHEN POSITION('\"PORTSCAN\":\"' IN ls) > 0 THEN
+                    CASE
+                        WHEN CAST(SPLIT_PART(SPLIT_PART(ls, '\"PORTSCAN\":\"', 2), '\"', 1) AS TIMESTAMPTZ) >= GETDATE() - INTERVAL '120 days' THEN
+                        CAST(SPLIT_PART(SPLIT_PART(ls, '\"PORTSCAN\":\"', 2), '\"', 1) AS TIMESTAMPTZ)
+                    END
+            END
+        ) AS port_scan_min_timestamp,
+        MAX(
+            CASE
+                WHEN POSITION('\"PORTSCAN\":\"' IN ls) > 0 THEN
+                    CASE
+                        WHEN CAST(SPLIT_PART(SPLIT_PART(ls, '\"PORTSCAN\":\"', 2), '\"', 1) AS TIMESTAMPTZ) >= GETDATE() - INTERVAL '120 days' THEN
+                        CAST(SPLIT_PART(SPLIT_PART(ls, '\"PORTSCAN\":\"', 2), '\"', 1) AS TIMESTAMPTZ)
+                    END
+            END
+        ) AS port_scan_max_timestamp,
 
         -- VULNSCAN timestamps
-        MIN(CASE WHEN POSITION('\"VULNSCAN\":\"' IN ls) > 0
-                THEN CAST(SPLIT_PART(SPLIT_PART(ls, '\"VULNSCAN\":\"', 2), '\"', 1) AS TIMESTAMPTZ) END) AS vuln_scan_min_timestamp,
-        MAX(CASE WHEN POSITION('\"VULNSCAN\":\"' IN ls) > 0
-                THEN CAST(SPLIT_PART(SPLIT_PART(ls, '\"VULNSCAN\":\"', 2), '\"', 1) AS TIMESTAMPTZ) END) AS vuln_scan_max_timestamp,
+        MIN(
+            CASE
+                WHEN POSITION('\"VULNSCAN\":\"' IN ls) > 0 THEN
+                    CASE
+                        WHEN CAST(SPLIT_PART(SPLIT_PART(ls, '\"VULNSCAN\":\"', 2), '\"', 1) AS TIMESTAMPTZ) >= GETDATE() - INTERVAL '120 days' THEN
+                        CAST(SPLIT_PART(SPLIT_PART(ls, '\"VULNSCAN\":\"', 2), '\"', 1) AS TIMESTAMPTZ)
+                    END
+            END
+        ) AS vuln_scan_min_timestamp,
+        MAX(
+            CASE
+                WHEN POSITION('\"VULNSCAN\":\"' IN ls) > 0 THEN
+                    CASE
+                        WHEN CAST(SPLIT_PART(SPLIT_PART(ls, '\"VULNSCAN\":\"', 2), '\"', 1) AS TIMESTAMPTZ) >= GETDATE() - INTERVAL '120 days' THEN
+                        CAST(SPLIT_PART(SPLIT_PART(ls, '\"VULNSCAN\":\"', 2), '\"', 1) AS TIMESTAMPTZ)
+                    END
+            END
+        ) AS vuln_scan_max_timestamp,
 
         -- NETSCAN1 timestamps
         MIN(CASE WHEN POSITION('\"NETSCAN1\":\"' IN ls) > 0


### PR DESCRIPTION
Update queries to query min and max within the last 120 days for port scans and vuln scans
## 🗣 Description ##
The min and max queries for min and max scan date for port and vuln scans were including hosts that were no longer activie so hadn't been scanned in years. This adjusts the query to ignore any hosts that haven't been scanned in the last 120 days
## 💭 Motivation and context ##
There is a rationale for not scanning if the host is inactive, but we don't want to display the oldest scan if the host has simply been inactive. This change makes sure we see the most current scanning range, reflecting current state of the hosts.
## 🧪 Testing ##
Query was tested against redshift database


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

