### PR TITLE
update VS scan to flag cidrs and ips as retired 

### DIFF
--- a/backend/src/xfd_django/xfd_api/tasks/asm_sync.py
+++ b/backend/src/xfd_django/xfd_api/tasks/asm_sync.py
@@ -19,7 +19,6 @@ from xfd_mini_dl.models import (
     Cidr,
     CidrOrgs,
     DataSource,
-    Ip,
     IpsSubs,
     Organization,
     SubDomains,
@@ -110,8 +109,9 @@ def flag_asset_changes():
 
 
 def flag_cidr_changes():
-    """Mark Cidrs that were not seen in the last scan as not current,
-    and return (organization_id, cidr_id) for cidrorgs that were closed.
+    """Mark Cidrs that were not seen in the last scan as not current.
+
+    return (organization_id, cidr_id) for cidrorgs that were closed.
     """
     cutoff_date = timezone.now().date() - datetime.timedelta(days=3)
 
@@ -119,7 +119,9 @@ def flag_cidr_changes():
     cidrorgs_to_close = CidrOrgs.objects.filter(last_seen__lt=cutoff_date)
 
     # Capture their (org_id, cidr_id) before updating
-    closed_pairs = cidrorgs_to_close.values_list("organization_id", "cidr_id").distinct()
+    closed_pairs = cidrorgs_to_close.values_list(
+        "organization_id", "cidr_id"
+    ).distinct()
 
     # Mark them as not current
     cidrorgs_to_close.update(current=False)
@@ -139,6 +141,7 @@ def flag_cidr_changes():
     Cidr.objects.filter(cidrorgs__current=True).distinct().update(retired=False)
 
     return list(closed_pairs)
+
 
 def enumerate_subs(org_list=None):
     """Query roots and identify related subdomains."""

--- a/backend/src/xfd_django/xfd_api/tasks/asm_sync.py
+++ b/backend/src/xfd_django/xfd_api/tasks/asm_sync.py
@@ -92,7 +92,7 @@ def main(event):
 def flag_asset_changes():
     """Mark Ips and Subdomains that are were not seen in the last scan as not current."""
     cutoff_date = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
-        days=15
+        days=90
     )
 
     SubDomains.objects.filter(Q(last_seen__lt=cutoff_date)).exclude(
@@ -101,7 +101,7 @@ def flag_asset_changes():
 
     IpsSubs.objects.filter(last_seen__lt=cutoff_date).update(current=False)
 
-    Ip.objects.filter(last_seen_timestamp__lt=cutoff_date).update(current=False)
+    # Ip.objects.filter(last_seen_timestamp__lt=cutoff_date).update(current=False)
 
     # Ip.objects.filter(
     #     (Q(sub_domains__current=False) | Q(sub_domains__isnull=True)) &  # No current subdomains or no subdomains at all
@@ -110,26 +110,35 @@ def flag_asset_changes():
 
 
 def flag_cidr_changes():
-    """Mark Cidrs that are were not seen in the last scan as not current."""
-    # Get all CidrOrgs where the last_seen date is older than 3 days
+    """Mark Cidrs that were not seen in the last scan as not current,
+    and return (organization_id, cidr_id) for cidrorgs that were closed.
+    """
     cutoff_date = timezone.now().date() - datetime.timedelta(days=3)
 
-    CidrOrgs.objects.filter(last_seen__lt=cutoff_date).update(current=False)
+    # Find CidrOrgs that will be closed
+    cidrorgs_to_close = CidrOrgs.objects.filter(last_seen__lt=cutoff_date)
+
+    # Capture their (org_id, cidr_id) before updating
+    closed_pairs = cidrorgs_to_close.values_list("organization_id", "cidr_id").distinct()
+
+    # Mark them as not current
+    cidrorgs_to_close.update(current=False)
+
+    # Keep others marked current
     CidrOrgs.objects.filter(last_seen__gte=cutoff_date).update(current=True)
-    # Step 1: Get all Cidr objects that:
-    # - Have no associated CidrOrgs at all, or
-    # - Have associated CidrOrgs, but all of them have current=False or current is null
+
+    # Retire cidrs that no longer have current orgs
     cidrs_to_retire = Cidr.objects.filter(
         Q(cidrorgs__isnull=True)
-        | Q(cidrorgs__current=False)  # No CidrOrgs associated
-        | Q(cidrorgs__current__isnull=True)  # Associated CidrOrgs are not current
+        | Q(cidrorgs__current=False)
+        | Q(cidrorgs__current__isnull=True)
     ).distinct()
-
-    # Step 2: Update the retired field to True for those Cidr objects
     cidrs_to_retire.update(retired=True)
 
-    Cidr.objects.filter(Q(cidrorgs__current=True)).distinct().update(retired=False)
+    # Unretire cidrs that still have current orgs
+    Cidr.objects.filter(cidrorgs__current=True).distinct().update(retired=False)
 
+    return list(closed_pairs)
 
 def enumerate_subs(org_list=None):
     """Query roots and identify related subdomains."""

--- a/backend/src/xfd_django/xfd_api/tasks/utils/link_ips_to_cidrs.py
+++ b/backend/src/xfd_django/xfd_api/tasks/utils/link_ips_to_cidrs.py
@@ -1,14 +1,17 @@
+"""Functions to manage asset relationships."""
+# Third-Party Libraries
 from django.db import connections
-from xfd_mini_dl.models import CidrOrgs # replace 'your_app' with your app name
+from xfd_mini_dl.models import CidrOrgs  # replace 'your_app' with your app name
+
 
 def bulk_assign_ips_to_cidrs(batch_size: int = 1000):
     """
     Assign IPs to their smallest current CIDR per organization in batches.
+
     - First unlinks IPs from non-current CIDRs
     - Then processes IPs without from_cidr in batches
     - Updates origin_cidr_id, from_cidr, and retired flags
     """
-
     # Step 1: Unlink IPs from non-current CIDRs
     with connections["mini_data_lake"].cursor() as cursor:
         unlink_query = """
@@ -20,11 +23,15 @@ def bulk_assign_ips_to_cidrs(batch_size: int = 1000):
             WHERE ip.origin_cidr_id = co.cidr_id
             AND ip.organization_id = co.organization_id
             AND co.current = FALSE;
-        """
+        """  # nosec B608
         cursor.execute(unlink_query)
 
     # Step 2: Process IPs org by org
-    org_ids = CidrOrgs.objects.filter(current=True).values_list('organization_id', flat=True).distinct()
+    org_ids = (
+        CidrOrgs.objects.filter(current=True)
+        .values_list("organization_id", flat=True)
+        .distinct()
+    )
 
     for org_id in org_ids:
         last_ip_id = None
@@ -42,7 +49,7 @@ def bulk_assign_ips_to_cidrs(batch_size: int = 1000):
                     ip_batch AS (
                         SELECT id AS ip_id, ip
                         FROM ip
-                        WHERE organization_id = %s 
+                        WHERE organization_id = %s
                         AND (from_cidr IS NULL OR from_cidr = FALSE)
                         {"AND id > %s" if last_ip_id else ""}
                         ORDER BY id ASC
@@ -63,12 +70,12 @@ def bulk_assign_ips_to_cidrs(batch_size: int = 1000):
                     FROM ip_to_update
                     WHERE ip.id = ip_to_update.ip_id
                     RETURNING ip.id;
-                """
+                """  # nosec B608
 
                 params = [str(org_id), str(org_id)]
                 if last_ip_id:
                     params.append(str(last_ip_id))
-                params.append(batch_size)
+                params.append(str(batch_size))
 
                 cursor.execute(query, params)
                 updated_rows = cursor.fetchall()
@@ -76,4 +83,6 @@ def bulk_assign_ips_to_cidrs(batch_size: int = 1000):
                 if not updated_rows:
                     break  # No more IPs to process in this org
 
-                last_ip_id = updated_rows[-1][0]  # last processed IP ID for keyset pagination
+                last_ip_id = updated_rows[-1][
+                    0
+                ]  # last processed IP ID for keyset pagination

--- a/backend/src/xfd_django/xfd_api/tasks/utils/link_ips_to_cidrs.py
+++ b/backend/src/xfd_django/xfd_api/tasks/utils/link_ips_to_cidrs.py
@@ -1,0 +1,79 @@
+from django.db import connections
+from xfd_mini_dl.models import CidrOrgs # replace 'your_app' with your app name
+
+def bulk_assign_ips_to_cidrs(batch_size: int = 1000):
+    """
+    Assign IPs to their smallest current CIDR per organization in batches.
+    - First unlinks IPs from non-current CIDRs
+    - Then processes IPs without from_cidr in batches
+    - Updates origin_cidr_id, from_cidr, and retired flags
+    """
+
+    # Step 1: Unlink IPs from non-current CIDRs
+    with connections["mini_data_lake"].cursor() as cursor:
+        unlink_query = """
+            UPDATE ip
+            SET origin_cidr_id = NULL,
+                from_cidr = NULL,
+                retired = NULL
+            FROM cidr_orgs co
+            WHERE ip.origin_cidr_id = co.cidr_id
+            AND ip.organization_id = co.organization_id
+            AND co.current = FALSE;
+        """
+        cursor.execute(unlink_query)
+
+    # Step 2: Process IPs org by org
+    org_ids = CidrOrgs.objects.filter(current=True).values_list('organization_id', flat=True).distinct()
+
+    for org_id in org_ids:
+        last_ip_id = None
+
+        while True:
+            with connections["mini_data_lake"].cursor() as cursor:
+                query = f"""
+                    WITH org_cidrs AS (
+                        SELECT c.id AS cidr_id, c.network::cidr AS network
+                        FROM cidr c
+                        JOIN cidr_orgs co ON co.cidr_id = c.id
+                        WHERE co.current = TRUE AND co.organization_id = %s
+                        ORDER BY masklen(c.network::cidr) ASC
+                    ),
+                    ip_batch AS (
+                        SELECT id AS ip_id, ip
+                        FROM ip
+                        WHERE organization_id = %s 
+                        AND (from_cidr IS NULL OR from_cidr = FALSE)
+                        {"AND id > %s" if last_ip_id else ""}
+                        ORDER BY id ASC
+                        LIMIT %s
+                    ),
+                    ip_to_update AS (
+                        SELECT ip_batch.ip_id,
+                               (SELECT cidr_id
+                                FROM org_cidrs
+                                WHERE ip_batch.ip::inet << org_cidrs.network
+                                LIMIT 1) AS cidr_id
+                        FROM ip_batch
+                    )
+                    UPDATE ip
+                    SET origin_cidr_id = ip_to_update.cidr_id,
+                        from_cidr = CASE WHEN ip_to_update.cidr_id IS NOT NULL THEN TRUE ELSE FALSE END,
+                        retired = CASE WHEN ip_to_update.cidr_id IS NULL THEN TRUE ELSE FALSE END
+                    FROM ip_to_update
+                    WHERE ip.id = ip_to_update.ip_id
+                    RETURNING ip.id;
+                """
+
+                params = [str(org_id), str(org_id)]
+                if last_ip_id:
+                    params.append(str(last_ip_id))
+                params.append(batch_size)
+
+                cursor.execute(query, params)
+                updated_rows = cursor.fetchall()
+
+                if not updated_rows:
+                    break  # No more IPs to process in this org
+
+                last_ip_id = updated_rows[-1][0]  # last processed IP ID for keyset pagination

--- a/backend/src/xfd_django/xfd_api/tasks/vulnScanningSync.py
+++ b/backend/src/xfd_django/xfd_api/tasks/vulnScanningSync.py
@@ -10,6 +10,8 @@ from logging import FileHandler
 import os
 
 # Third-Party Libraries
+from xfd_api.tasks.asm_sync import flag_cidr_changes
+from xfd_api.tasks.utils.link_ips_to_cidrs import bulk_assign_ips_to_cidrs
 from xfd_api.tasks.refresh_material_views import handler as refresh_materialized_views
 from xfd_api.tasks.syncdb_task import synchronize
 from xfd_api.tasks.utils.datetime_utils import freeze_window
@@ -118,6 +120,12 @@ def main():  # pylint: disable=R0915
     # Load request data
     org_id_dict = fetch_orgs_from_redshift()
     # org_id_dict = fetch_org_id_dict_fast()
+
+    # Close unseen cidrs
+    flag_cidr_changes()
+
+    # Flag ips related to closed cidrs:
+    bulk_assign_ips_to_cidrs()
 
     # Process Vulnerability Scans
     fetch_vuln_scans_from_redshift(ps_start_dt, ps_end_dt, org_id_dict)

--- a/backend/src/xfd_django/xfd_api/tasks/vulnScanningSync.py
+++ b/backend/src/xfd_django/xfd_api/tasks/vulnScanningSync.py
@@ -11,10 +11,10 @@ import os
 
 # Third-Party Libraries
 from xfd_api.tasks.asm_sync import flag_cidr_changes
-from xfd_api.tasks.utils.link_ips_to_cidrs import bulk_assign_ips_to_cidrs
 from xfd_api.tasks.refresh_material_views import handler as refresh_materialized_views
 from xfd_api.tasks.syncdb_task import synchronize
 from xfd_api.tasks.utils.datetime_utils import freeze_window
+from xfd_api.tasks.utils.link_ips_to_cidrs import bulk_assign_ips_to_cidrs
 from xfd_api.tasks.utils.mdl_insert_utils import fill_cidr_live_ips_bulk_update
 from xfd_api.tasks.utils.vs_host_scans import create_daily_host_summary
 from xfd_api.tasks.utils.vs_port_scans import (


### PR DESCRIPTION
update VS scan to flag cidrs and ips as retired when they are no longer seen

## 🗣 Description ##
When a cidr block is no longer attributed to a stakeholder by VS we need to flag it as no longer current so we stop counting and attributing findings to it. This PR flags these cidrs as not current and if no organization claims them sets the cidr to retired. It also flags the ips as retired

flag_cidr_changes diagram:
<img width="461" height="361" alt="image" src="https://github.com/user-attachments/assets/cea52f37-1f06-4172-903c-1f5b5ff7acb1" />

bulk_assign_ips_to_cidrs diagram:
<img width="440" height="287" alt="image" src="https://github.com/user-attachments/assets/c5a6e7cb-8cc0-456f-b816-44957baeb289" />

## 💭 Motivation and context ##
We want to only track. assets owned by an organization and match VS as closely as possible.

## 🧪 Testing ##
Tested with some local tests, though haven't been able to test how long it takes, on our live db with far more assets

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
