### PR TITLE
3133-Hide export button unless ONE org is selected /inventory

### DIFF
--- a/frontend/src/components/ImportExport/ImportExport.tsx
+++ b/frontend/src/components/ImportExport/ImportExport.tsx
@@ -21,7 +21,10 @@ interface ImportProps<T> {
 export interface ExportProps<T> {
   name: string;
   fieldsToExport?: string[];
-  getDataToExport: () => Partial<T>[] | Promise<Partial<T>[]> | Promise<string>;
+  getDataToExport: () =>
+    | Partial<T>[]
+    | Promise<Partial<T>[]>
+    | Promise<string | null>;
 }
 
 export const Import = <T extends object>(props: ImportProps<T>) => {
@@ -152,6 +155,7 @@ export const exportCSV = async <T extends object>(
   const filename = `${props.name}-${new Date().toISOString()}`;
   setLoading((l) => l + 1);
   const data = await props.getDataToExport();
+  if (data == null) return;
 
   if (typeof data === 'string') {
     const link = document.createElement('a');

--- a/frontend/src/pages/Search/Inventory.tsx
+++ b/frontend/src/pages/Search/Inventory.tsx
@@ -58,7 +58,14 @@ export const DashboardUI: React.FC<ContextType & { location: any }> = (
 
   const advanceFiltersReq = filters.length > 1 || searchTerm !== ''; //Prevents a user from saving a search without advanced filters
 
-  const fetchDomainsExport = async (): Promise<string> => {
+  const allowExport =
+    filters?.find((filter) => filter.field === 'organization_id')?.values
+      ?.length == 1;
+
+  console.log(filters?.find((filter) => filter.field === 'organization_id'));
+  console.log('Allow Export', allowExport);
+
+  const fetchDomainsExport = async (): Promise<string | null> => {
     try {
       const body: any = {
         current,
@@ -79,7 +86,7 @@ export const DashboardUI: React.FC<ContextType & { location: any }> = (
       return url!;
     } catch (e) {
       console.error(e);
-      return '';
+      return null;
     }
   };
   const userLevel = useUserLevel().userLevel;
@@ -269,6 +276,8 @@ export const DashboardUI: React.FC<ContextType & { location: any }> = (
               </FormControl>
             </Stack>
             <Button
+              hidden={!allowExport}
+              // disabled={!allowExport}
               variant="outlined"
               onClick={() =>
                 exportCSV(


### PR DESCRIPTION
…r occurs

<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
- Added flag to hide export button on search tab in /inventory unless one and only one organization is selected in filters
- Updated export to csv functionality to not download the file unless it is a valid csv file retrieved from server. 

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Resolves CRASM-3133

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate) ##

### One org selected
<img width="1761" height="1135" alt="Screenshot 2025-09-04 at 12 31 36 PM" src="https://github.com/user-attachments/assets/c7aa3eba-9948-4985-84b7-e92cab1c5bbc" />

### No org selected
<img width="1761" height="1138" alt="Screenshot 2025-09-04 at 12 32 15 PM" src="https://github.com/user-attachments/assets/9c728d6a-b9b9-48de-8762-7eed5c855935" />


### 2+ org selected
<img width="1765" height="1134" alt="Screenshot 2025-09-04 at 12 32 46 PM" src="https://github.com/user-attachments/assets/bb13d97a-5e47-4ba4-8dec-694ae8a2ae33" />



## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
