### PR TITLE
Add logic to handle longer running tests on the frontend.

### DIFF
--- a/playwright/run_playwright_tests.sh
+++ b/playwright/run_playwright_tests.sh
@@ -80,12 +80,39 @@ if [[ -z "$TASK_ARN" || "$TASK_ARN" == "None" ]]; then
 fi
 
 echo "✅ ECS Task ARN: $TASK_ARN"
-echo "⏳ Waiting for ECS task to finish..."
 
-aws ecs wait tasks-stopped \
-  --cluster "$CLUSTER_NAME" \
-  --tasks "$TASK_ARN" \
-  --region "$AWS_REGION"
+echo "⏳ Waiting for ECS task to finish..."
+# ⏱️ Custom wait for ECS task to stop
+MAX_WAIT_MINUTES=30
+SLEEP_INTERVAL=10
+MAX_ATTEMPTS=$((MAX_WAIT_MINUTES * 60 / SLEEP_INTERVAL))
+ATTEMPT=0
+
+echo "⏳ Waiting up to $MAX_WAIT_MINUTES minutes for ECS task to stop..."
+
+while [[ $ATTEMPT -lt $MAX_ATTEMPTS ]]; do
+  STATUS=$(aws ecs describe-tasks \
+    --cluster "$CLUSTER_NAME" \
+    --tasks "$TASK_ARN" \
+    --region "$AWS_REGION" \
+    --query 'tasks[0].lastStatus' \
+    --output text)
+
+  if [[ "$STATUS" == "STOPPED" ]]; then
+    echo "✅ ECS task has stopped."
+    break
+  fi
+
+  sleep "$SLEEP_INTERVAL"
+  ((ATTEMPT++))
+done
+
+if [[ "$STATUS" != "STOPPED" ]]; then
+  echo "❌ ECS task did not stop within $MAX_WAIT_MINUTES minutes." >&2
+  exit 1
+fi
+
+
 
 echo "✅ Task stopped. Checking exit code..."
 


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

It looks like some of the new tests are running longer than the default ecs wait timer can handle. Tests continued to run in AWS, but the wait timer ran out. As a result we are getting the error: `Waiter TasksStopped failed: Max attempts exceeded` when running frontend tests.  This PR adds logic to handle the longer running tests. 

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This change is needed to increase the length of time the ecs task will wait before timing out. 
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

This change was tested by running the new logic in the `run_playwright_tests.sh` locally, to ensure that we are getting the expected results. This way we could test the changes locally before we bring them into the workflow.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

