### PR TITLE
Refactor Overflow and Height Logic in FilterDrawerV2 (CRASM-3180)

### DIFF
--- a/frontend/src/components/FilterDrawer/FilterDrawerV2.tsx
+++ b/frontend/src/components/FilterDrawer/FilterDrawerV2.tsx
@@ -181,12 +181,7 @@ export const FilterDrawer: FC<
           top: isMobile ? 0 : topOffset - 84,
           height: isMobile ? '100%' : `calc(100% - (${topOffset}px - 84px))`,
           minHeight: `calc(100% - ${topOffset}px)`,
-          zIndex: (theme) => theme.zIndex.appBar,
-          msOverflowStyle: 'none',
-          scrollbarWidth: 'none',
-          '&::-webkit-scrollbar': {
-            display: 'none'
-          }
+          zIndex: (theme) => theme.zIndex.appBar
         }
       }}
     >

--- a/frontend/src/components/FilterDrawer/FilterDrawerV2.tsx
+++ b/frontend/src/components/FilterDrawer/FilterDrawerV2.tsx
@@ -176,10 +176,10 @@ export const FilterDrawer: FC<
         '& .MuiDrawer-paper': {
           position: 'fixed',
           width: drawerWidth,
-          overflow: 'visible',
+          overflow: 'auto',
           backgroundColor: 'neutrals.white',
           top: isMobile ? 0 : topOffset - 84,
-          height: isMobile ? '100%' : 'auto',
+          height: isMobile ? '100%' : `calc(100% - (${topOffset}px - 84px))`,
           minHeight: `calc(100% - ${topOffset}px)`,
           zIndex: (theme) => theme.zIndex.appBar,
           msOverflowStyle: 'none',

--- a/frontend/src/components/__tests__/__snapshots__/layout.spec.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/layout.spec.tsx.snap
@@ -113,7 +113,7 @@ exports[`Layout component > matches snapshot 1`] = `
     class="css-170g0n7"
   >
     <div
-      class="MuiDrawer-root MuiDrawer-anchorLeft MuiDrawer-docked css-aiqi88-MuiDrawer-docked"
+      class="MuiDrawer-root MuiDrawer-anchorLeft MuiDrawer-docked css-x0avkh-MuiDrawer-docked"
     >
       <div
         class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation0 MuiDrawer-paper MuiDrawer-paperAnchorLeft MuiDrawer-paperAnchorDockedLeft css-1lwhjos-MuiPaper-root-MuiDrawer-paper"

--- a/frontend/src/components/__tests__/__snapshots__/layout.spec.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/layout.spec.tsx.snap
@@ -113,7 +113,7 @@ exports[`Layout component > matches snapshot 1`] = `
     class="css-170g0n7"
   >
     <div
-      class="MuiDrawer-root MuiDrawer-anchorLeft MuiDrawer-docked css-x0avkh-MuiDrawer-docked"
+      class="MuiDrawer-root MuiDrawer-anchorLeft MuiDrawer-docked css-zdu6sp-MuiDrawer-docked"
     >
       <div
         class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation0 MuiDrawer-paper MuiDrawer-paperAnchorLeft MuiDrawer-paperAnchorDockedLeft css-1lwhjos-MuiPaper-root-MuiDrawer-paper"


### PR DESCRIPTION
- Addition of Beta Banner resulted in the pushing of the filter "Reset" button out of  viewport.

<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
- Set overflow to auto allow scrolling when content exceeds filter drawer height due to dynamic topOffset (i.e., the beta banner).
- Adjust height to include topOffset in calculation to prevent content being pushed out of view.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
- Closes CRASM-3180
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
- tested locally.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


## 📷 Screenshots (if appropriate) ##

<img width="2032" height="1167" alt="Screenshot 2025-09-12 at 4 57 06 PM" src="https://github.com/user-attachments/assets/04a99c48-7492-47de-8a6a-ac157e3d28c6" />
<img width="2032" height="1167" alt="Screenshot 2025-09-12 at 4 57 13 PM" src="https://github.com/user-attachments/assets/129d77a6-62bc-4dba-a02b-08a15d944bd3" />
<img width="2032" height="1167" alt="Screenshot 2025-09-12 at 4 59 12 PM" src="https://github.com/user-attachments/assets/c99a23eb-30ed-494e-8392-31344fc5fedc" />


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [x] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Revert dependencies to default branches.
- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release (necessary if and only if the version was bumped).
