### PR TITLE
Fix data parsing in redshift cve sync

### DIFF
--- a/backend/src/xfd_django/xfd_api/schema_models/vulnerability.py
+++ b/backend/src/xfd_django/xfd_api/schema_models/vulnerability.py
@@ -232,9 +232,9 @@ class CveFullResponse(BaseModel):
     assigner: Optional[str] = None
     title: Optional[str] = None
 
-    cna_source_json: Optional[Dict[str, Any]] = None
-    cna_affected_json: Optional[Dict[str, Any]] = None
-    cna_problem_types_json: Optional[Dict[str, Any]] = None
+    cna_source_json: Optional[Any] = None
+    cna_affected_json: Optional[Any] = None
+    cna_problem_types_json: Optional[Any] = None
 
     ssvc: Optional[CveSsvcResponse] = None
 

--- a/backend/src/xfd_django/xfd_api/tasks/redshift_cve_scan.py
+++ b/backend/src/xfd_django/xfd_api/tasks/redshift_cve_scan.py
@@ -1,5 +1,6 @@
 """Sync CVE/SSVC from Redshift (AE feed) into MDL."""
 # Standard Python Libraries
+import json
 import logging
 import os
 import sys
@@ -43,6 +44,16 @@ def handler(event):
         return {"statusCode": 500, "body": str(e)}
 
 
+def parse_json(value):
+    """Parse json strings into json objects."""
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except Exception:
+            return value  # fallback to raw if invalid JSON
+    return value
+
+
 def parse_redshift_row(row: dict[str, Any]) -> dict[str, Any]:
     """Parse a Redshift row (dict) into a structured dict for CveModel."""
     return {
@@ -70,23 +81,15 @@ def parse_redshift_row(row: dict[str, Any]) -> dict[str, Any]:
 def create_or_update_cve(parsed: dict) -> CveModel:
     """Create or minimally patch a CveModel record (supports CVSS v3 + v4)."""
     weaknesses_list = extract_weaknesses_from_problem_types(
-        parsed["problem_types_json"]
+        parse_json(parsed["problem_types_json"])
     )
 
-    description_text = (
-        pick_english_description(parsed["descriptions_json"])
-        if isinstance(parsed["descriptions_json"], list)
-        else None
-    )
-    reference_urls_list = (
-        extract_references(parsed["references_json"])
-        if isinstance(parsed["references_json"], list)
-        else []
-    )
+    description_text = pick_english_description(parse_json(parsed["descriptions_json"]))
+    reference_urls_list = extract_references(parse_json(parsed["references_json"]))
 
     # NEW: dict result with both versions possible
     cvss_results: dict[str, dict[str, Optional[Any]]] = extract_cvss(
-        parsed["metrics_json"] if isinstance(parsed["metrics_json"], list) else []
+        parse_json(parsed["metrics_json"])
     )
     v3 = cvss_results.get("v3", {}) or {}
     v4 = cvss_results.get("v4", {}) or {}
@@ -192,7 +195,7 @@ def patch_cvss(cve_object, cvss_results: dict[str, dict[str, Optional[Any]]]) ->
 
 def upsert_ssvc(cve_object, adp_json):
     """Upsert SSVC data into CveSsvc model."""
-    ssvc = extract_ssvc(adp_json if isinstance(adp_json, list) else [])
+    ssvc = extract_ssvc(parse_json(adp_json))
     exploitation = (ssvc.get("exploitation") or "").lower() or None
     automatable = (ssvc.get("automatable") or "").lower() or None
     technical_impact = (ssvc.get("technical_impact") or "").lower() or None
@@ -214,7 +217,9 @@ def upsert_ssvc(cve_object, adp_json):
 
 def upsert_cve_from_redshift_row(row: Dict[str, Any]) -> None:
     """Parse a Redshift result row (dict), upsert the CVE, then upsert SSVC."""
-    parsed = parse_redshift_row(row)  # parse_redshift_row should accept a dict now
+    parsed = parse_redshift_row(
+        parse_json(row)
+    )  # parse_redshift_row should accept a dict now
     if not parsed.get("cve_name"):
         return
     with transaction.atomic():


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
Update redshift parsing to first load any json-strings into JSON objects before wrangling.

## 💭 Motivation and context ##

When testing with the real redshift connection we were parsing different data types compared to the JSON sample data in development.

## 🧪 Testing ##

Passes pre-commit and github checks. Tested in LZ staging.

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [x] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
