### PR TITLE
Hot Fix: Fix vulnerability details SSVC dates and catch nulls

### DIFF
--- a/frontend/src/pages/Risk/utils.ts
+++ b/frontend/src/pages/Risk/utils.ts
@@ -13,6 +13,7 @@ export const getAllVulnColor = () => {
   return '#ce80ed';
 };
 export const getSeverityColor = ({ id }: { id: string }) => {
+  id = id.charAt(0).toUpperCase() + id.slice(1).toLowerCase();
   if (id === 'N/A' || id === '') return '';
   else if (id === 'Low') return '#FFB38A';
   else if (id === 'Medium') return '#EC7633';

--- a/frontend/src/pages/Vulnerability/CveSection.tsx
+++ b/frontend/src/pages/Vulnerability/CveSection.tsx
@@ -12,12 +12,75 @@ import {
   TableRow,
   Typography
 } from '@mui/material';
-import {
-  // Cpe as ProductInfoType,
-  Vulnerability as VulnerabilityType
-} from 'types';
-import nvd from 'assets/nvd.jpeg';
+import { Vulnerability as VulnerabilityType } from 'types';
 import { getSeverityColor } from 'pages/Risk/utils';
+
+type CvssSubSectionProps = {
+  title: string;
+  source?: string | null;
+  severity?: string | null;
+  vector?: string | null;
+  version?: string | null;
+};
+
+const CvssSubSection: React.FC<CvssSubSectionProps> = ({
+  title,
+  severity,
+  version,
+  vector
+}) => {
+  if (!severity && !version && !vector) return null;
+  return (
+    <Box mb={3}>
+      <Typography fontWeight="500" pb={1}>
+        {title}
+      </Typography>
+      <Grid container spacing={1}>
+        <Grid size={{ xs: 12, sm: 3 }}>
+          <Typography variant="subtitle2" fontWeight="600">
+            Base Severity
+          </Typography>
+          {severity ? (
+            <Box
+              component="span"
+              sx={{
+                borderBottom: `4px solid ${getSeverityColor({ id: severity })}`,
+                display: 'inline-block',
+                lineHeight: 1,
+                pb: '2px'
+              }}
+            >
+              {severity}
+            </Box>
+          ) : (
+            'None'
+          )}
+        </Grid>
+        <Grid size={{ xs: 12, sm: 2 }}>
+          <Typography variant="subtitle2" fontWeight="600">
+            Version
+          </Typography>
+          <Typography variant="caption" fontWeight="regular">
+            {version}
+          </Typography>
+        </Grid>
+        <Grid size={{ xs: 12, sm: 6 }}>
+          <Typography variant="subtitle2" fontWeight="600">
+            Vector
+          </Typography>
+          <Typography
+            display="inline"
+            variant="caption"
+            fontWeight="regular"
+            sx={{ overflowWrap: 'break-word' }}
+          >
+            {vector}
+          </Typography>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+};
 
 // interface GroupedByVendor {
 //   [key: string]: ProductInfoType[];
@@ -89,202 +152,24 @@ export const CveSection: React.FC<HasCVEProps> = ({
   const SeverityMetricsSection = () => {
     return (
       <Box>
-        <Typography fontWeight="500" pb={2}>
-          CVSS 4.x Severity & Metrics
-        </Typography>
-        <Grid container spacing={1} mb={0}>
-          <Grid size={{ xs: 12, sm: 3 }}>
-            <Box
-              component="img"
-              sx={{ height: 25, width: 30 }}
-              alt="NVD"
-              src={nvd}
-            />
-            <Typography
-              display="inline"
-              variant="subtitle2"
-              sx={{ verticalAlign: 'top' }}
-              fontWeight="600"
-            >
-              NIST
-            </Typography>
-            <Typography
-              variant="subtitle2"
-              fontWeight="regular"
-              sx={{ verticalAlign: 'top' }}
-            >
-              {vulnerability?.cve_full?.cvss_v4_source != null
-                ? vulnerability?.cve_full?.cvss_v4_source
-                    .split('@')[0]
-                    .toUpperCase()
-                : null}
-            </Typography>
-          </Grid>
-          <Grid size={{ xs: 12, sm: 3 }}>
-            <Typography variant="subtitle2" fontWeight="600">
-              Base Severity
-            </Typography>
-            {vulnerability?.cve_full?.cvss_v4_base_severity ? (
-              <Box
-                component="span"
-                sx={{
-                  borderBottom: `4px solid ${getSeverityColor({
-                    id: vulnerability?.cve_full?.cvss_v4_base_severity
-                  })}`,
-                  display: 'inline-block',
-                  lineHeight: 1,
-                  pb: '2px'
-                }}
-              >
-                {vulnerability?.cve_full?.cvss_v4_base_severity}
-              </Box>
-            ) : (
-              'N/A'
-            )}
-          </Grid>
-          <Grid size={{ xs: 12, sm: 6 }}>
-            <Typography variant="subtitle2" fontWeight="600">
-              Vector
-            </Typography>
-            <Typography
-              display="inline"
-              variant="caption"
-              fontWeight="regular"
-              sx={{ overflowWrap: 'break-word' }}
-            >
-              {vulnerability?.cve_full?.cvss_v4_vector_string}
-            </Typography>
-          </Grid>
-        </Grid>
-        <Typography fontWeight="500" pb={2}>
-          CVSS 3.x Severity & Metrics
-        </Typography>
-        <Grid container spacing={1}>
-          <Grid size={{ xs: 12, sm: 3 }}>
-            <Box
-              component="img"
-              sx={{ height: 25, width: 30 }}
-              alt="NVD"
-              src={nvd}
-            />
-            <Typography
-              display="inline"
-              variant="subtitle2"
-              sx={{ verticalAlign: 'top' }}
-              fontWeight="600"
-            >
-              NIST
-            </Typography>
-            <Typography
-              variant="subtitle2"
-              fontWeight="regular"
-              sx={{ verticalAlign: 'top' }}
-            >
-              {vulnerability?.cve_full?.cvss_v3_source != null
-                ? vulnerability?.cve_full?.cvss_v3_source
-                    .split('@')[0]
-                    .toUpperCase()
-                : null}
-            </Typography>
-          </Grid>
-          <Grid size={{ xs: 12, sm: 3 }}>
-            <Typography variant="subtitle2" fontWeight="600">
-              Base Severity
-            </Typography>
-            {vulnerability?.cve_full?.cvss_v3_base_severity ? (
-              <Box
-                component="span"
-                sx={{
-                  borderBottom: `4px solid ${getSeverityColor({
-                    id: vulnerability?.cve_full?.cvss_v3_base_severity
-                  })}`,
-                  display: 'inline-block',
-                  lineHeight: 1,
-                  pb: '2px'
-                }}
-              >
-                {vulnerability?.cve_full?.cvss_v3_base_severity}
-              </Box>
-            ) : (
-              'N/A'
-            )}
-          </Grid>
-          <Grid size={{ xs: 12, sm: 6 }}>
-            <Typography variant="subtitle2" fontWeight="600">
-              Vector
-            </Typography>
-            <Typography
-              display="inline"
-              variant="caption"
-              fontWeight="regular"
-              sx={{ overflowWrap: 'break-word' }}
-            >
-              {vulnerability?.cve_full?.cvss_v3_vector_string}
-            </Typography>
-          </Grid>
-        </Grid>
-        <Typography fontWeight="500" py={2}>
-          CVSS 2.0 Severity & Metrics
-        </Typography>
-        <Grid container spacing={2}>
-          <Grid size={{ xs: 12, sm: 3 }}>
-            <Box
-              component="img"
-              sx={{ height: 25, width: 30 }}
-              alt="NVD"
-              src={nvd}
-            />
-            <Typography
-              variant="subtitle2"
-              display="inline"
-              sx={{ verticalAlign: 'top' }}
-              fontWeight="600"
-            >
-              NIST
-            </Typography>
-            <Typography
-              variant="subtitle2"
-              fontWeight="regular"
-              sx={{ verticalAlign: 'top' }}
-            >
-              {vulnerability?.cve_full?.cvss_v2_source != null
-                ? vulnerability?.cve_full?.cvss_v2_source
-                    .split('@')[0]
-                    .toUpperCase()
-                : null}
-            </Typography>
-          </Grid>
-          <Grid size={{ xs: 12, sm: 3 }}>
-            <Typography variant="subtitle2" fontWeight="600">
-              Base Severity
-            </Typography>
-            {vulnerability?.cve_full?.cvss_v2_base_severity ? (
-              <Box
-                component="span"
-                sx={{
-                  borderBottom: `4px solid ${getSeverityColor({
-                    id: vulnerability?.cve_full?.cvss_v2_base_severity
-                  })}`,
-                  display: 'inline-block',
-                  lineHeight: 1,
-                  pb: '2px'
-                }}
-              >
-                {vulnerability?.cve_full?.cvss_v2_base_severity}
-              </Box>
-            ) : (
-              'N/A'
-            )}
-          </Grid>
-          <Grid size={{ xs: 12, sm: 6 }}>
-            <Typography variant="subtitle2" fontWeight="600">
-              Vector
-            </Typography>
-            <Typography display="inline" variant="caption" fontWeight="regular">
-              {vulnerability?.cve_full?.cvss_v2_vector_string}
-            </Typography>
-          </Grid>
-        </Grid>
+        <CvssSubSection
+          title="CVSS 4.x Severity & Metrics"
+          severity={vulnerability?.cve_full?.cvss_v4_base_severity}
+          version={vulnerability?.cve_full?.cvss_v4_version}
+          vector={vulnerability?.cve_full?.cvss_v4_vector_string}
+        />
+        <CvssSubSection
+          title="CVSS 3.x Severity & Metrics"
+          severity={vulnerability?.cve_full?.cvss_v3_base_severity}
+          version={vulnerability?.cve_full?.cvss_v3_version}
+          vector={vulnerability?.cve_full?.cvss_v3_vector_string}
+        />
+        <CvssSubSection
+          title="CVSS 2.0 Severity & Metrics"
+          severity={vulnerability?.cve_full?.cvss_v2_base_severity}
+          version={vulnerability?.cve_full?.cvss_v2_version}
+          vector={vulnerability?.cve_full?.cvss_v2_vector_string}
+        />
       </Box>
     );
   };

--- a/frontend/src/pages/Vulnerability/SsvcSection.tsx
+++ b/frontend/src/pages/Vulnerability/SsvcSection.tsx
@@ -59,7 +59,7 @@ export const SsvcSection: React.FC<HasSsvcProps> = ({
                 {vulnerability.cve_full?.ssvc?.ssvc_version || 'unknown'}
               </TableCell>
               <TableCell>
-                {formatDate(vulnerability.cve_full?.ssvc?.updated_at) ||
+                {formatDate(vulnerability.cve_full?.ssvc?.ssvc_timestamp) ||
                   'Date not found'}
               </TableCell>
             </TableRow>
@@ -100,7 +100,7 @@ export const SsvcSection: React.FC<HasSsvcProps> = ({
           <Grid size={{ xs: 12 }} mb={2}>
             <Typography variant="largeBody">
               <b>Updated:</b>{' '}
-              {formatDate(vulnerability.cve_full?.ssvc?.updated_at) ||
+              {formatDate(vulnerability.cve_full?.modified_at) ||
                 'Date not found'}
             </Typography>
             <Typography>

--- a/frontend/src/pages/Vulnerability/SsvcSection.tsx
+++ b/frontend/src/pages/Vulnerability/SsvcSection.tsx
@@ -37,31 +37,51 @@ export const SsvcSection: React.FC<HasSsvcProps> = ({
                 '& th': { backgroundColor: '#07648D', color: 'white' }
               }}
             >
-              <TableCell>Exploitation</TableCell>
-              <TableCell>Automatable</TableCell>
-              <TableCell>Technical Impact</TableCell>
-              <TableCell>Version</TableCell>
-              <TableCell>Date Accessed</TableCell>
+              {vulnerability.cve_full?.ssvc?.exploitation && (
+                <TableCell>Exploitation</TableCell>
+              )}
+              {vulnerability.cve_full?.ssvc?.automatable && (
+                <TableCell>Automatable</TableCell>
+              )}
+              {vulnerability.cve_full?.ssvc?.technical_impact && (
+                <TableCell>Technical Impact</TableCell>
+              )}
+              {vulnerability.cve_full?.ssvc?.ssvc_version && (
+                <TableCell>Version</TableCell>
+              )}
+              {vulnerability.cve_full?.ssvc?.ssvc_timestamp && (
+                <TableCell>Date Accessed</TableCell>
+              )}
             </TableRow>
           </TableHead>
           <TableBody>
             <TableRow>
-              <TableCell>
-                {vulnerability.cve_full?.ssvc?.exploitation || 'none'}
-              </TableCell>
-              <TableCell>
-                {vulnerability.cve_full?.ssvc?.automatable || 'unknown'}
-              </TableCell>
-              <TableCell>
-                {vulnerability.cve_full?.ssvc?.technical_impact || 'unknown'}
-              </TableCell>
-              <TableCell>
-                {vulnerability.cve_full?.ssvc?.ssvc_version || 'unknown'}
-              </TableCell>
-              <TableCell>
-                {formatDate(vulnerability.cve_full?.ssvc?.ssvc_timestamp) ||
-                  'Date not found'}
-              </TableCell>
+              {vulnerability.cve_full?.ssvc?.exploitation && (
+                <TableCell>
+                  {vulnerability.cve_full?.ssvc?.exploitation}
+                </TableCell>
+              )}
+              {vulnerability.cve_full?.ssvc?.automatable && (
+                <TableCell>
+                  {vulnerability.cve_full?.ssvc?.automatable || 'unknown'}
+                </TableCell>
+              )}
+              {vulnerability.cve_full?.ssvc?.technical_impact && (
+                <TableCell>
+                  {vulnerability.cve_full?.ssvc?.technical_impact || 'unknown'}
+                </TableCell>
+              )}
+              {vulnerability.cve_full?.ssvc?.ssvc_version && (
+                <TableCell>
+                  {vulnerability.cve_full?.ssvc?.ssvc_version || 'unknown'}
+                </TableCell>
+              )}
+              {vulnerability.cve_full?.ssvc?.ssvc_timestamp && (
+                <TableCell>
+                  {formatDate(vulnerability.cve_full?.ssvc?.ssvc_timestamp) ||
+                    'Date not found'}
+                </TableCell>
+              )}
             </TableRow>
           </TableBody>
         </Table>

--- a/frontend/src/pages/Vulnerability/SsvcSection.tsx
+++ b/frontend/src/pages/Vulnerability/SsvcSection.tsx
@@ -68,18 +68,17 @@ export const SsvcSection: React.FC<HasSsvcProps> = ({
               )}
               {vulnerability.cve_full?.ssvc?.technical_impact && (
                 <TableCell>
-                  {vulnerability.cve_full?.ssvc?.technical_impact || 'unknown'}
+                  {vulnerability.cve_full?.ssvc?.technical_impact}
                 </TableCell>
               )}
               {vulnerability.cve_full?.ssvc?.ssvc_version && (
                 <TableCell>
-                  {vulnerability.cve_full?.ssvc?.ssvc_version || 'unknown'}
+                  {vulnerability.cve_full?.ssvc?.ssvc_version}
                 </TableCell>
               )}
               {vulnerability.cve_full?.ssvc?.ssvc_timestamp && (
                 <TableCell>
-                  {formatDate(vulnerability.cve_full?.ssvc?.ssvc_timestamp) ||
-                    'Date not found'}
+                  {formatDate(vulnerability.cve_full?.ssvc?.ssvc_timestamp)}
                 </TableCell>
               )}
             </TableRow>

--- a/frontend/src/pages/Vulnerability/Vulnerability.tsx
+++ b/frontend/src/pages/Vulnerability/Vulnerability.tsx
@@ -22,11 +22,7 @@ import {
 import { tableCellClasses } from '@mui/material/TableCell';
 import { getSeverityColor } from 'pages/Risk/utils';
 import { useAuthContext } from 'context';
-import {
-  Cve as CveType,
-  Service,
-  Vulnerability as VulnerabilityType
-} from 'types';
+import { Service, Vulnerability as VulnerabilityType } from 'types';
 import { CveSection } from './CveSection';
 import { XpanseSection } from './XpanseSection';
 import { SsvcSection } from './SsvcSection';


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
Fix vulnerability details SSVC dates and catch nulls
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
Due to the new endpoint and data changes for CVE and SSVC, there were discrepencies noticed in staging with the data.
This will catch newfound nulls and change the SSVC dates to the correct ones.

- This will hide the whole CVSS section if there is no data for a particular CVSS version.
- This will also hide columns in the SSVC section if there is no value for it.
- I also noticed in staging that the severity string was coming in all capitalized now so this will also convert that string.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
Check the code and then in staging
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate) ##

Note: Unable to screenshot SSVC data due to not having data locally
<img width="1094" height="427" alt="image" src="https://github.com/user-attachments/assets/4035bada-e93c-43ac-8daf-c4abde5afddf" />

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
