### PR TITLE
Update ssvc extract to loop through dicts: CRASM-3229

### DIFF
--- a/backend/src/xfd_django/xfd_api/helpers/redshift_helpers.py
+++ b/backend/src/xfd_django/xfd_api/helpers/redshift_helpers.py
@@ -6,7 +6,10 @@ Redshift or CVE JSON feeds.
 # Standard Python Libraries
 from datetime import datetime
 import json
+import logging
 from typing import Any, Dict, List, Optional
+
+LOGGER = logging.getLogger(__name__)
 
 
 def safe_json_loads(raw_text: Optional[str]) -> Optional[Any]:
@@ -126,6 +129,7 @@ def extract_ssvc(adp_items: Optional[List[Dict[str, Any]]]) -> Dict[str, Optiona
         "adp_date_updated": None,
     }
     if not adp_items:
+        LOGGER.warning("No adp_items found. Returning empty SSVC response.")
         return result
 
     for adp_item in adp_items:
@@ -159,7 +163,7 @@ def extract_ssvc(adp_items: Optional[List[Dict[str, Any]]]) -> Dict[str, Optiona
             result["adp_date_updated"] = str(
                 adp_item.get("providerMetadata", {}).get("dateUpdated") or ""
             )
-
+            LOGGER.info("SSVC data identified and returned.")
             return result  # stop once we found the right SSVC block
 
     # No SSVC found at all

--- a/backend/src/xfd_django/xfd_api/helpers/redshift_helpers.py
+++ b/backend/src/xfd_django/xfd_api/helpers/redshift_helpers.py
@@ -128,35 +128,41 @@ def extract_ssvc(adp_items: Optional[List[Dict[str, Any]]]) -> Dict[str, Optiona
     if not adp_items:
         return result
 
-    adp_item = adp_items[0]  # latest already chosen in SQL
-    result["adp_provider"] = str(
-        adp_item.get("providerMetadata", {}).get("shortName") or ""
-    )
-    result["adp_title"] = str(adp_item.get("title") or "")
+    for adp_item in adp_items:
+        metrics_list = adp_item.get("metrics") or []
+        for metric_item in metrics_list:
+            other = metric_item.get("other") or {}
+            if str(other.get("type") or "").lower() != "ssvc":
+                continue
 
-    metrics_list = adp_item.get("metrics") or []
-    for metric_item in metrics_list:
-        other = metric_item.get("other") or {}
-        if str(other.get("type") or "").lower() != "ssvc":
-            continue
-        content = other.get("content") or {}
-        result["ssvc_version"] = str(content.get("version") or "")
-        result["ssvc_timestamp"] = str(content.get("timestamp") or "")
-        options_list = content.get("options") or []
-        for option_item in options_list:
-            # option_item is like {"Exploitation": "none"} etc.
-            for option_key, option_value in option_item.items():
-                key_normalized = str(option_key).strip().lower().replace(" ", "_")
-                if key_normalized == "exploitation":
-                    result["exploitation"] = str(option_value)
-                elif key_normalized == "automatable":
-                    result["automatable"] = str(option_value)
-                elif key_normalized == "technical_impact":
-                    result["technical_impact"] = str(option_value)
-        break  # only the first SSVC block
-    result["adp_date_updated"] = str(
-        adp_item.get("providerMetadata", {}).get("dateUpdated") or ""
-    )
+            # Found SSVC block — extract
+            content = other.get("content") or {}
+            result["ssvc_version"] = str(content.get("version") or "")
+            result["ssvc_timestamp"] = str(content.get("timestamp") or "")
+            options_list = content.get("options") or []
+            for option_item in options_list:
+                # option_item is like {"Exploitation": "none"}
+                for option_key, option_value in option_item.items():
+                    key_normalized = str(option_key).strip().lower().replace(" ", "_")
+                    if key_normalized == "exploitation":
+                        result["exploitation"] = str(option_value)
+                    elif key_normalized == "automatable":
+                        result["automatable"] = str(option_value)
+                    elif key_normalized == "technical_impact":
+                        result["technical_impact"] = str(option_value)
+
+            # Fill in metadata from this same ADP item
+            result["adp_provider"] = str(
+                adp_item.get("providerMetadata", {}).get("shortName") or ""
+            )
+            result["adp_title"] = str(adp_item.get("title") or "")
+            result["adp_date_updated"] = str(
+                adp_item.get("providerMetadata", {}).get("dateUpdated") or ""
+            )
+
+            return result  # stop once we found the right SSVC block
+
+    # No SSVC found at all
     return result
 
 

--- a/frontend/src/pages/Vulnerability/SsvcSection.tsx
+++ b/frontend/src/pages/Vulnerability/SsvcSection.tsx
@@ -115,9 +115,6 @@ export const SsvcSection: React.FC<HasSsvcProps> = ({
             <Typography variant="largeBody">
               <b>Updated:</b> {formatDate(modified_at) || 'Date not found'}
             </Typography>
-            <Typography>
-              SSVC and KEV, plus CVSS and CWE if not provided by the CNA.
-            </Typography>
           </Grid>
           {noTableData && noTitleData ? (
             <></>


### PR DESCRIPTION
Update SSVC extract to loop through dicts to identify the right dictionary

## 🗣 Description ##
The current ssvc extraction functionality assumes SSVC data is in the first dictionary in the list returned from redshift. This is not always the case. This PR ensures the function loops through the response until it finds SSVC data. 
## 💭 Motivation and context ##
We are failing to extract and save all SSVC data, this change ensures we identify it if it is available for a give CVE in redshift. This results in frontend widgets to not populate with correct SSVC data. 
## 🧪 Testing ##
Will need to test in staging to validate

## ✅ Pre-approval checklist ##

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
