### PR TITLE
CRASM-3233: Update logging configuration for cloudwatch split

### DIFF
--- a/backend/src/xfd_django/xfd_django/asgi.py
+++ b/backend/src/xfd_django/xfd_django/asgi.py
@@ -93,7 +93,7 @@ def get_application() -> FastAPI:
     # Third-Party Libraries
     from xfd_api.views import api_router  # pylint: disable=C0415
 
-    app = FastAPI(title=settings.PROJECT_NAME, debug=settings.DEBUG)
+    app = FastAPI(title=settings.PROJECT_NAME, debug=settings.DEBUG, log_config=None)
 
     # Create one pooled client on startup
     @app.on_event("startup")

--- a/backend/src/xfd_django/xfd_django/settings.py
+++ b/backend/src/xfd_django/xfd_django/settings.py
@@ -17,6 +17,7 @@ import os
 
 # Python built-in
 from pathlib import Path
+from typing import Any, Dict
 
 # Third-Party Libraries
 from django.contrib.messages import constants as messages
@@ -143,7 +144,7 @@ LANGUAGE_CODE = "en-us"
 LOGGING_LEVEL = "DEBUG" if DEBUG else "INFO"
 ROOT_LEVEL = "INFO"
 # Logging configuration
-handlers = {
+handlers: Dict[str, Any] = {
     "console": {
         "level": LOGGING_LEVEL,
         "class": "logging.StreamHandler",
@@ -169,7 +170,7 @@ if IS_LAMBDA and not IS_LOCAL:
                 "boto3_client": logs_client,
                 "log_group_name": "cyhy-{}-backend-api".format(STAGE),
                 "stream_name": "{machine_name}/{logger_name}/{process_id}",
-                "use_queues": "False",
+                "use_queues": False,
             },
             "requests_cloudwatch": {
                 "level": "INFO",
@@ -178,7 +179,7 @@ if IS_LAMBDA and not IS_LOCAL:
                 "boto3_client": logs_client,
                 "log_group_name": "cyhy-{}-backend-api-requests".format(STAGE),
                 "stream_name": "{machine_name}/{logger_name}/{process_id}",
-                "use_queues": "False",
+                "use_queues": False,
             },
         }
     )

--- a/backend/src/xfd_django/xfd_django/settings.py
+++ b/backend/src/xfd_django/xfd_django/settings.py
@@ -152,6 +152,20 @@ handlers: Dict[str, Any] = {
     }
 }
 
+
+def _env_handlers(requests: bool = False) -> list[str]:
+    """
+    Return appropriate logging handlers based on environment.
+
+    - Uses CloudWatch if running in Lambda and not local.
+    - Otherwise falls back to console logging.
+    - `requests=True` will select the requests-specific CloudWatch handler.
+    """
+    if IS_LAMBDA and not IS_LOCAL:
+        return ["requests_cloudwatch"] if requests else ["app_cloudwatch"]
+    return ["console"]
+
+
 # Add CloudWatch handlers if in Lambda
 if IS_LAMBDA and not IS_LOCAL:
     # Third-Party Libraries
@@ -201,32 +215,24 @@ LOGGING = {
     "loggers": {
         # Catch-all for your project namespace
         "xfd": {
-            "handlers": (
-                ["app_cloudwatch"] if IS_LAMBDA and not IS_LOCAL else ["console"]
-            ),
+            "handlers": _env_handlers(),
             "level": LOGGING_LEVEL,
             "propagate": False,
         },
         # Explicitly route sibling loggers (your modules) into CloudWatch
         "xfd_api": {
-            "handlers": (
-                ["app_cloudwatch"] if IS_LAMBDA and not IS_LOCAL else ["console"]
-            ),
+            "handlers": _env_handlers(),
             "level": LOGGING_LEVEL,
             "propagate": False,
         },
         "xfd_mini_dl": {
-            "handlers": (
-                ["app_cloudwatch"] if IS_LAMBDA and not IS_LOCAL else ["console"]
-            ),
+            "handlers": _env_handlers(),
             "level": LOGGING_LEVEL,
             "propagate": False,
         },
         # Request logs stay separate
         "fastapi.requests": {
-            "handlers": (
-                ["requests_cloudwatch"] if IS_LAMBDA and not IS_LOCAL else ["console"]
-            ),
+            "handlers": _env_handlers(),
             "level": "INFO",
             "propagate": False,
         },

--- a/backend/src/xfd_django/xfd_django/settings.py
+++ b/backend/src/xfd_django/xfd_django/settings.py
@@ -167,21 +167,25 @@ if IS_LAMBDA and not IS_LOCAL:
                 "class": "watchtower.CloudWatchLogHandler",
                 "formatter": "standard",
                 "boto3_client": logs_client,
-                "log_group_name": "crossfeed-{}-backend-api".format(STAGE),
+                "log_group_name": "cyhy-{}-backend-api".format(STAGE),
+                "stream_name": "{machine_name}/{logger_name}/{process_id}",
+                "use_queues": "False",
             },
             "requests_cloudwatch": {
                 "level": "INFO",
                 "class": "watchtower.CloudWatchLogHandler",
                 "formatter": "standard",
                 "boto3_client": logs_client,
-                "log_group_name": "crossfeed-{}-backend-api-requests".format(STAGE),
+                "log_group_name": "cyhy-{}-backend-api-requests".format(STAGE),
+                "stream_name": "{machine_name}/{logger_name}/{process_id}",
+                "use_queues": "False",
             },
         }
     )
 
 LOGGING = {
     "version": 1,
-    "disable_existing_loggers": True,
+    "disable_existing_loggers": False,
     "formatters": {
         "standard": {
             "format": "%(levelname)s [%(name)s:%(funcName)s:line %(lineno)d] - %(message)s",
@@ -190,11 +194,11 @@ LOGGING = {
     },
     "handlers": handlers,
     "root": {
-        # Root always logs to console so Fargate/ECS and Lambda prints still go somewhere
-        "handlers": ["console"],
-        "level": ROOT_LEVEL,
+        "handlers": ["console"] if not IS_LAMBDA else [],
+        "level": "WARNING" if IS_LAMBDA else ROOT_LEVEL,
     },
     "loggers": {
+        # Catch-all for your project namespace
         "xfd": {
             "handlers": (
                 ["app_cloudwatch"] if IS_LAMBDA and not IS_LOCAL else ["console"]
@@ -202,6 +206,22 @@ LOGGING = {
             "level": LOGGING_LEVEL,
             "propagate": False,
         },
+        # Explicitly route sibling loggers (your modules) into CloudWatch
+        "xfd_api": {
+            "handlers": (
+                ["app_cloudwatch"] if IS_LAMBDA and not IS_LOCAL else ["console"]
+            ),
+            "level": LOGGING_LEVEL,
+            "propagate": False,
+        },
+        "xfd_mini_dl": {
+            "handlers": (
+                ["app_cloudwatch"] if IS_LAMBDA and not IS_LOCAL else ["console"]
+            ),
+            "level": LOGGING_LEVEL,
+            "propagate": False,
+        },
+        # Request logs stay separate
         "fastapi.requests": {
             "handlers": (
                 ["requests_cloudwatch"] if IS_LAMBDA and not IS_LOCAL else ["console"]
@@ -213,6 +233,7 @@ LOGGING = {
 }
 
 # Apply the logging configuration
+LOGGING_CONFIG = None
 logging.config.dictConfig(LOGGING)
 
 TIME_ZONE = "UTC"

--- a/backend/src/xfd_django/xfd_django/settings.py
+++ b/backend/src/xfd_django/xfd_django/settings.py
@@ -198,6 +198,8 @@ if IS_LAMBDA and not IS_LOCAL:
         }
     )
 
+# TODO: CRASM-3282
+# Consider using JSON formatter instead
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Updated Django config to None so our custom configuration isn't overwritten and then explicitly bound each piece to the specific log group we want.

Also clean up the old /aws/lambda/.. group to not have any duplicates and ensure the stream names are unique and well-named.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
Conflicting Django configurations were overriding my updates so not taking effect.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Passes pre-commit and githb checks. Tested in LZ staging.

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [x] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
