### PR TITLE
Update custom adotLayerArn to add a default adot arn if gov adot arn …

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -11,8 +11,8 @@ custom:
     us-east-2: arn:aws:lambda:us-east-2:615299751070:layer:AWSOpenTelemetryDistroPython:13
     us-west-1: arn:aws:lambda:us-west-1:615299751070:layer:AWSOpenTelemetryDistroPython:20
     us-west-2: arn:aws:lambda:us-west-2:615299751070:layer:AWSOpenTelemetryDistroPython:20
-    us-gov-east-1: ${ssm:/crossfeed/${self:provider.stage}/adot_python_layer_arn}
-    us-gov-west-1: ${ssm:/crossfeed/${self:provider.stage}/adot_python_layer_arn}
+    us-gov-east-1: ${ssm:/crossfeed/${self:provider.stage}/adot_python_layer_arn, ''}
+    us-gov-west-1: ${ssm:/crossfeed/${self:provider.stage}/adot_python_layer_arn, ''}
   customDomain:
     domainName: ${file(env.yml):${self:provider.stage}.DOMAIN, ''}
     basePath: ''


### PR DESCRIPTION


<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This change updates the serverless.yml configuration so that the GovCloud ADOT layer ARNs (us-gov-east-1 and us-gov-west-1) include a safe default ('') if the expected SSM parameter is not found. On the commercial side, Serverless was attempting to resolve these GovCloud SSM parameters during commands like sls create_domain, which caused failures even though those values are irrelevant outside GovCloud. Adding the default prevents resolution errors while preserving the correct behavior in GovCloud environments.

## 💭 Motivation and context ##

Prevent Serverless variable resolution from blocking non-GovCloud operations.

Ensure sls create_domain and other commands can run successfully in commercial AWS partitions without requiring unused GovCloud SSM parameters.

Preserve the existing SSM lookup logic for GovCloud deployments so that the correct layer ARN is still fetched at deploy time.



## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [x] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
