### PR TITLE
Update serverless.yml defining the selected layers for the functions and modify the functions to the selected layer that comes from serverless

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -13,6 +13,7 @@ custom:
     us-west-2: arn:aws:lambda:us-west-2:615299751070:layer:AWSOpenTelemetryDistroPython:20
     us-gov-east-1: ${ssm:/crossfeed/${self:provider.stage}/adot_python_layer_arn, ''}
     us-gov-west-1: ${ssm:/crossfeed/${self:provider.stage}/adot_python_layer_arn, ''}
+  adotLayerArnSelected: ${self:custom.adotLayerArn[${self:provider.region}]}
   customDomain:
     domainName: ${file(env.yml):${self:provider.stage}.DOMAIN, ''}
     basePath: ''

--- a/backend/src/api/functions.yml
+++ b/backend/src/api/functions.yml
@@ -2,7 +2,7 @@
 api:
     handler: src.xfd_django.xfd_django.asgi.handler
     layers:
-        - ${self:custom.adotLayerArn.${self:provider.region}}
+        - ${self:custom.adotLayerArnSelected}
 
     # NEW: ADOT auto-instrumentation + trace stitching to X-Ray
     environment:

--- a/backend/src/tasks/functions.yml
+++ b/backend/src/tasks/functions.yml
@@ -4,7 +4,7 @@ scheduler:
   # functions below for usage of the anchor.
   <<: &adot
     layers:
-      - ${self:custom.adotLayerArn.${self:provider.region}}
+      - ${self:custom.adotLayerArnSelected}
     environment:
       AWS_LAMBDA_EXEC_WRAPPER: /opt/otel-instrument
       OTEL_PROPAGATORS: xray,tracecontext,baggage


### PR DESCRIPTION


<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR updates all function definitions to reference custom.adotLayerArnSelected instead of directly interpolating ${self:custom.adotLayerArn.${self:provider.region}}. The new adotLayerArnSelected key is defined in serverless.yml using bracket syntax, which safely resolves the ARN for the active AWS region. This ensures reliable layer selection even for regions with hyphenated names (e.g., us-gov-east-1), which previously caused parsing issues in Serverless.

## 💭 Motivation and context ##

The prior inline lookup (${self:custom.adotLayerArn.${self:provider.region}}) did not resolve correctly in Serverless because dot-notation with nested interpolations breaks on hyphenated keys.

This caused functions to deploy without the ADOT instrumentation layer, even though the ARNs were defined.

By introducing custom.adotLayerArnSelected and referencing it everywhere, we guarantee:

Correct resolution for both commercial and GovCloud regions.

Cleaner, more maintainable function configs (single source of truth for ADOT layer ARN).

Instrumentation via ADOT is reliably applied, enabling trace stitching to CloudWatch and X-Ray as expected.

This change removes a subtle but critical blocker to verifying that ADOT is actually deployed and active on Lambda functions.


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [x] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Revert dependencies to default branches.
- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release (necessary if and only if the version was bumped).
