### PR TITLE
Change the IP Address link to stay in the same tab in Vuln Details 2794

### DIFF
--- a/frontend/src/pages/Vulnerability/OverviewSection.tsx
+++ b/frontend/src/pages/Vulnerability/OverviewSection.tsx
@@ -88,8 +88,6 @@ export const transformVulnerability = (
       <Link
         component={RouterLink}
         to={`/inventory/domain/${vulnerability.domain.id}`}
-        target="_blank"
-        rel="noopener noreferrer"
       >
         {vulnerability.domain.ip}
       </Link>


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
Change the IP Address link to stay in the same tab in Vuln Details
CRASM-2794
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
Going from the IP Address link in the Vulnerability Details page takes you to the Domain Details page. But when you click on the Return to Results link in the Domain Details page, it will not take you back anywhere if IP Address opens in the a new tab. Therefore, the IP Address link should not open in a new tab so that a user can go back and forth.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
After clicking on the IP from the IP Address link in Vulnerability Details, click on the "Return to Results" link in Domain Details and make sure it takes you back to that previous Vulnerability Details page.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


## 📷 Screenshots (if appropriate) ##

Clicking on the highlighted portion now brings you directly to Domain Details without opening a new tab
<img width="1180" height="529" alt="image" src="https://github.com/user-attachments/assets/b40ac515-3cd7-43b1-9764-71af4fec9160" />

So that when you click "Back to Results" it will bring you back to that same page
<img width="1236" height="882" alt="image" src="https://github.com/user-attachments/assets/06c3826c-ee2e-47f7-9bf9-7006751cd47f" />


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
