### PR TITLE
Add Cloudwatch to Playwright.tf 

### DIFF
--- a/infrastructure/playwright.tf
+++ b/infrastructure/playwright.tf
@@ -126,7 +126,7 @@ resource "aws_ecs_task_definition" "playwright_worker" {
       logConfiguration = {
         logDriver = "awslogs",
         options = {
-          awslogs-group         = var.worker_ecs_log_group_name,
+          awslogs-group         = var.cloudwatch_log_group_name,
           awslogs-region        = var.aws_region,
           awslogs-stream-prefix = "playwright"
         }


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Add the Cloudwatch logging group to the Playwright worker ECS task. 

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This is needed to be able to debug why the Playwright Regression Testing is failing in Github Actions but works in terminal.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

N/A
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
