### PR TITLE
Add recent up host count to the host summary: CRASM-3162

### DIFF
--- a/backend/src/xfd_django/xfd_api/api_methods/stats.py
+++ b/backend/src/xfd_django/xfd_api/api_methods/stats.py
@@ -900,6 +900,7 @@ SUMMARY_CONFIG = {
             "up_host_count",
             "down_host_count",
             "scanned_asset_count",
+            "recent_up_hosts_count",
         ],
     },
     "port": {

--- a/backend/src/xfd_django/xfd_api/schema_models/stat_schema.py
+++ b/backend/src/xfd_django/xfd_api/schema_models/stat_schema.py
@@ -231,6 +231,7 @@ class HostScanSummaryResponse(BaseModel):
     up_host_count: Optional[int] = 0
     down_host_count: Optional[int] = 0
     scanned_asset_count: Optional[int] = 0
+    recent_up_hosts_count: Optional[int] = 0
     port_scan_min_timestamp: Optional[datetime] = None
     port_scan_max_timestamp: Optional[datetime] = None
     vuln_scan_min_timestamp: Optional[datetime] = None
@@ -346,6 +347,7 @@ class HostScanSummaryV2Response(BaseModel):
     up_host_count: Optional[int] = 0
     down_host_count: Optional[int] = 0
     scanned_asset_count: Optional[int] = 0
+    recent_up_hosts_count: Optional[int] = 0
     port_scan_min_timestamp: Optional[datetime] = None
     port_scan_max_timestamp: Optional[datetime] = None
     vuln_scan_min_timestamp: Optional[datetime] = None
@@ -422,6 +424,7 @@ class VsTrendCondensedResponse(BaseModel):
     host_summary_up_host_count: Optional[List[int]] = []
     host_summary_down_host_count: Optional[List[int]] = []
     host_summary_scanned_asset_count: Optional[List[int]] = []
+    host_summary_recent_up_hosts_count: Optional[List[int]] = []
 
     port_scan_summary_id: Optional[List[int]] = []
     port_scan_summary_start_date: Optional[List[datetime]] = []
@@ -562,6 +565,7 @@ class HostSummaryModel(BaseSummaryModel):
     up_host_count: Optional[int]
     down_host_count: Optional[int]
     scanned_asset_count: Optional[int]
+    recent_up_hosts_count: Optional[int]
     port_scan_min_timestamp: Optional[datetime]
     port_scan_max_timestamp: Optional[datetime]
     vuln_scan_min_timestamp: Optional[datetime]

--- a/backend/src/xfd_django/xfd_api/tasks/refresh_vs_summaries.py
+++ b/backend/src/xfd_django/xfd_api/tasks/refresh_vs_summaries.py
@@ -54,6 +54,7 @@ def build_fake_host_summaries():
                 + host_ready_count
             )
             up_host_count = total_count - random.randint(0, 1500)
+            recent_up_count = abs(up_host_count - random.randint(0, 100))
             down_host_count = total_count - up_host_count
 
             HostSummary.objects.update_or_create(
@@ -69,6 +70,7 @@ def build_fake_host_summaries():
                     "up_host_count": up_host_count,
                     "down_host_count": down_host_count,
                     "scanned_asset_count": total_count,
+                    "recent_up_hosts_count": recent_up_count,
                     "port_scan_min_timestamp": random_past_datetime(25, 60),
                     "port_scan_max_timestamp": random_past_datetime(1, 5),
                     "vuln_scan_min_timestamp": random_past_datetime(25, 60),

--- a/backend/src/xfd_django/xfd_api/tasks/utils/vs_host_scans.py
+++ b/backend/src/xfd_django/xfd_api/tasks/utils/vs_host_scans.py
@@ -92,8 +92,24 @@ def create_daily_host_summary(org_id_dict, summary_date=None):
         MIN(CASE WHEN POSITION('\"NETSCAN2\":\"' IN ls) > 0
                 THEN CAST(SPLIT_PART(SPLIT_PART(ls, '\"NETSCAN2\":\"', 2), '\"', 1) AS TIMESTAMPTZ) END) AS net_scan2_min_timestamp,
         MAX(CASE WHEN POSITION('\"NETSCAN2\":\"' IN ls) > 0
-                THEN CAST(SPLIT_PART(SPLIT_PART(ls, '\"NETSCAN2\":\"', 2), '\"', 1) AS TIMESTAMPTZ) END) AS net_scan2_max_timestamp
+                THEN CAST(SPLIT_PART(SPLIT_PART(ls, '\"NETSCAN2\":\"', 2), '\"', 1) AS TIMESTAMPTZ) END) AS net_scan2_max_timestamp,
 
+        SUM(
+            CASE
+                WHEN POSITION('\"up\":true' IN json_serialize(state)) > 0
+                    AND POSITION('\"VULNSCAN\":\"' IN ls) > 0
+                    AND TRY_CAST(
+                            TRIM(
+                                SPLIT_PART(
+                                    SPLIT_PART(ls, '\"VULNSCAN\":\"', 2),
+                                    '\"',
+                                    1
+                                )
+                            ) AS TIMESTAMPTZ
+                        ) >= GETDATE() - INTERVAL '11 days'
+                THEN 1 ELSE 0
+            END
+        ) AS recent_up_hosts_count,
     FROM (
         SELECT
             owner,
@@ -150,6 +166,7 @@ def create_daily_host_summary(org_id_dict, summary_date=None):
                     "net_scan1_max_timestamp": row["net_scan1_max_timestamp"],
                     "net_scan2_min_timestamp": row["net_scan2_min_timestamp"],
                     "net_scan2_max_timestamp": row["net_scan2_max_timestamp"],
+                    "recent_up_hosts_count": row["recent_up_hosts_count"],
                 },
             )
         except Organization.DoesNotExist:

--- a/backend/src/xfd_django/xfd_api/tasks/utils/vs_host_scans.py
+++ b/backend/src/xfd_django/xfd_api/tasks/utils/vs_host_scans.py
@@ -98,15 +98,17 @@ def create_daily_host_summary(org_id_dict, summary_date=None):
             CASE
                 WHEN POSITION('\"up\":true' IN json_serialize(state)) > 0
                     AND POSITION('\"VULNSCAN\":\"' IN ls) > 0
-                    AND TRY_CAST(
-                            TRIM(
-                                SPLIT_PART(
-                                    SPLIT_PART(ls, '\"VULNSCAN\":\"', 2),
-                                    '\"',
-                                    1
-                                )
-                            ) AS TIMESTAMPTZ
-                        ) >= GETDATE() - INTERVAL '11 days'
+                    AND DATE_TRUNC('day',
+                            TRY_CAST(
+                                TRIM(
+                                    SPLIT_PART(
+                                        SPLIT_PART(ls, '\"VULNSCAN\":\"', 2),
+                                        '\"',
+                                        1
+                                    )
+                                ) AS TIMESTAMPTZ
+                            )
+                        ) >= DATE_TRUNC('day', GETDATE() - INTERVAL '11 days')
                 THEN 1 ELSE 0
             END
         ) AS recent_up_hosts_count,

--- a/backend/src/xfd_django/xfd_api/tests/test_stats.py
+++ b/backend/src/xfd_django/xfd_api/tests/test_stats.py
@@ -539,6 +539,7 @@ def test_vs_trends_success():
         up_host_count=8,
         down_host_count=3,
         scanned_asset_count=11,
+        recent_up_hosts_count=8,
     )
 
     PortScanSummary.objects.create(
@@ -649,6 +650,7 @@ def test_vs_condensed_trends_success():
         up_host_count=10,
         down_host_count=2,
         scanned_asset_count=12,
+        recent_up_hosts_count=9,
     )
 
     PortScanSummary.objects.create(
@@ -1040,6 +1042,7 @@ def test_stats_compare_success():
         up_host_count=8,
         down_host_count=3,
         scanned_asset_count=11,
+        recent_up_hosts_count=7,
     )
 
     HostSummary.objects.create(
@@ -1054,6 +1057,7 @@ def test_stats_compare_success():
         up_host_count=9,
         down_host_count=2,
         scanned_asset_count=13,
+        recent_up_hosts_count=7,
     )
 
     payload = {

--- a/backend/src/xfd_django/xfd_mini_dl/models.py
+++ b/backend/src/xfd_django/xfd_mini_dl/models.py
@@ -2673,6 +2673,11 @@ class HostSummary(models.Model):
         blank=True,
         help_text="Timestamp of the most recent net_scan2 run on a host owned by the org.",
     )
+    recent_up_hosts_count = models.IntegerField(
+        null=True,
+        blank=True,
+        help_text="Count of Ip addresses that are up and have been scanned in the last 11 days.",
+    )
 
     class Meta:
         """The Meta class for HostSummary."""

--- a/frontend/src/types/vuln-scan-stats.ts
+++ b/frontend/src/types/vuln-scan-stats.ts
@@ -87,6 +87,7 @@ export interface HostSummaries {
   up_host_count?: number | null;
   down_host_count?: number | null;
   scanned_asset_count?: number | null;
+  recent_up_hosts_count?: number | null;
 }
 
 export interface PortScanSummaries {


### PR DESCRIPTION
Add recent up host count to the host summary


## 🗣 Description ##
Updates the host summary query to pull a count of hosts with a state of "up" and have had a vuln scan in the last 11 days.
Also updates the host summary model to store this value and the API to return this value to the frontend.
## 💭 Motivation and context ##
This new value is needed so it can replace the current scanned host count, as that value is already present elsewhere on the VS dashboard and is redundent.

## 🧪 Testing ##
API and storage tested locally. Query has been tested against redshift, but will need to be tested with the full redshift query in lz staging


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
-