### PR TITLE
stringify uuids: CRASM-3365

### DIFF
--- a/backend/src/xfd_django/xfd_api/api_methods/scan.py
+++ b/backend/src/xfd_django/xfd_api/api_methods/scan.py
@@ -163,7 +163,7 @@ def create_scan(scan_data: NewScan, current_user):  # pylint: disable=R0912, R09
                 _log_data = {
                     "event": "scan_date_validation_rejected",
                     "reason": "missing_start_or_end",
-                    "user_id": getattr(current_user, "id", None),
+                    "user_id": str(getattr(current_user, "id", None)),
                     "scan_name": scan_data.name,
                     "arguments": args,
                     "status": "failure",
@@ -179,7 +179,7 @@ def create_scan(scan_data: NewScan, current_user):  # pylint: disable=R0912, R09
                 _log_data = {
                     "event": "scan_date_validation_rejected",
                     "reason": "multi_scan_with_date_range",
-                    "user_id": getattr(current_user, "id", None),
+                    "user_id": str(getattr(current_user, "id", None)),
                     "scan_name": scan_data.name,
                     "status": "failure",
                 }
@@ -200,7 +200,7 @@ def create_scan(scan_data: NewScan, current_user):  # pylint: disable=R0912, R09
                             {
                                 "event": "scan_date_validation_rejected",
                                 "reason": "start_after_end",
-                                "user_id": getattr(current_user, "id", None),
+                                "user_id": str(getattr(current_user, "id", None)),
                                 "scan_name": scan_data.name,
                                 "start_datetime": str(parsed_start),
                                 "end_datetime": str(parsed_end),
@@ -221,7 +221,7 @@ def create_scan(scan_data: NewScan, current_user):  # pylint: disable=R0912, R09
                             {
                                 "event": "scan_date_validation_rejected",
                                 "reason": "date_range_too_large",
-                                "user_id": getattr(current_user, "id", None),
+                                "user_id": str(getattr(current_user, "id", None)),
                                 "scan_name": scan_data.name,
                                 "start_datetime": str(parsed_start),
                                 "end_datetime": str(parsed_end),
@@ -241,7 +241,7 @@ def create_scan(scan_data: NewScan, current_user):  # pylint: disable=R0912, R09
                     json.dumps(
                         {
                             "event": "scan_date_validation_success",
-                            "user_id": getattr(current_user, "id", None),
+                            "user_id": str(getattr(current_user, "id", None)),
                             "scan_name": scan_data.name,
                             "start_datetime": str(parsed_start),
                             "end_datetime": str(parsed_end),
@@ -258,7 +258,7 @@ def create_scan(scan_data: NewScan, current_user):  # pylint: disable=R0912, R09
                     json.dumps(
                         {
                             "event": "scan_date_validation_error",
-                            "user_id": getattr(current_user, "id", None),
+                            "user_id": str(getattr(current_user, "id", None)),
                             "scan_name": scan_data.name,
                             "provided_start": start_dt,
                             "provided_end": end_dt,


### PR DESCRIPTION
stringify uuids before running json_dumps

## 🗣 Description ##
UUIDs in the logs added to a recent PR are causing the scan_creaation functionality to fail. This PR converts them to strings first so the failure no longer occurs
## 💭 Motivation and context ##
We need to fix this so we can launch new scans. Currently they will always fail to be created due to the new logs.

## 🧪 Testing ##
Tested locally


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
