### PR TITLE
3358 - Fix inconsistent messaging in manage orgs table - region filter 

### DIFF
--- a/backend/src/xfd_django/xfd_api/helpers/filter_helpers.py
+++ b/backend/src/xfd_django/xfd_api/helpers/filter_helpers.py
@@ -274,8 +274,7 @@ def apply_organization_filters(base_q, filters: dict):
             try:
                 region_list = [int(r) for r in region_id if r is not None and r != ""]
                 q &= Q(region_id__in=region_list)
-            except ValueError as e:
-                LOGGER.exception(e)
+            except ValueError:
                 # Region Ids must be integers, forcing no results query
                 q &= Q(region_id__in=[-1])
     return q

--- a/backend/src/xfd_django/xfd_api/helpers/filter_helpers.py
+++ b/backend/src/xfd_django/xfd_api/helpers/filter_helpers.py
@@ -271,6 +271,11 @@ def apply_organization_filters(base_q, filters: dict):
     if region_id:
         if not isinstance(region_id, list):
             region_id = [region_id]
-        q &= Q(region_id__in=[int(r) for r in region_id if r is not None and r != ""])
-
+            try:
+                region_list = [int(r) for r in region_id if r is not None and r != ""]
+                q &= Q(region_id__in=region_list)
+            except ValueError as e:
+                LOGGER.exception(e)
+                # Region Ids must be integers, forcing no results query
+                q &= Q(region_id__in=[-1])
     return q


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
- Updates apply_organization_filter used by /v2/organizations/search to except the value error thrown when attempting to coerce an invalid value to number and then return and empty query.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
- Resolves CRASM-3358

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
- Navigate to Admin Tools -> Manage Organizations
- Click Filters => Change to "Region"
- Enter `0?asd` or `1a12312321` or `😄😄😄😄` and see that the requested change is made. Instead of showing the error banner, the message `No rows` is displayed in the table


## 📷 Screenshots (if appropriate) ##
<img width="1412" height="1138" alt="Screenshot 2025-11-25 at 9 47 58 AM" src="https://github.com/user-attachments/assets/c403c0dc-b91b-4faa-91e6-26a95b566622" />
<img width="1418" height="1137" alt="Screenshot 2025-11-25 at 9 48 31 AM" src="https://github.com/user-attachments/assets/80818ed7-1580-490e-86dc-644350e714b0" />
<img width="1418" height="1138" alt="Screenshot 2025-11-25 at 9 47 20 AM" src="https://github.com/user-attachments/assets/a2c847a6-0004-478a-833e-63064e52388b" />



## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [x] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
