### PR TITLE
Update SAML cert env vars and usage to read from env var

### DIFF
--- a/backend/src/xfd_django/env.json
+++ b/backend/src/xfd_django/env.json
@@ -47,6 +47,8 @@
   "READ_ONLY_DB_PASSWORD": "",
   "READ_ONLY_DB_USER": "",
   "REPORTS_BUCKET_NAME": "crossfeed-local-reports",
+  "SAML_SP_CERT": "",
+  "SAML_SP_PRIVATE_KEY": "",
   "SLS_LAMBDA_PREFIX": "crossfeed-dev",
   "STAGE": "dev",
   "VITE_COGNITO_CALLBACK_URL": "http://localhost/okta-callback",

--- a/backend/src/xfd_django/xfd_api/auth_saml.py
+++ b/backend/src/xfd_django/xfd_api/auth_saml.py
@@ -49,15 +49,8 @@ FRONTEND_DOMAIN = (
 OKTA_METADATA_URL = os.getenv("OKTA_SAML_METADATA_URL")
 
 IS_LOCAL = _env_truthy(os.getenv("IS_LOCAL"))
-SAML_SP_CERT_PATH = os.getenv("SAML_SP_CERT_PATH")
-SAML_SP_PRIVATE_KEY_PATH = os.getenv("SAML_SP_PRIVATE_KEY_PATH")
-WANT_NAMEID_ENCRYPTED = _env_truthy(os.getenv("WANT_NAMEID_ENCRYPTED"))  # optional
-
-
-def _read_text_file(path: str) -> str:
-    """Read and return the contents of a text file."""
-    with open(path, encoding="utf-8") as f:
-        return f.read().strip()
+SAML_SP_CERT = os.getenv("SAML_SP_CERT")
+SAML_SP_PRIVATE_KEY = os.getenv("SAML_SP_PRIVATE_KEY")
 
 
 # =============================================================================
@@ -127,20 +120,14 @@ def _build_sp_settings() -> Dict[str, Any]:
     if IS_LOCAL:
         LOGGER.info("SAML encryption DISABLED (local).")
     else:
-        if SAML_SP_CERT_PATH:
-            try:
-                sp_cert = _read_text_file(SAML_SP_CERT_PATH)
-                sp_settings["sp"]["x509cert"] = sp_cert
-                if SAML_SP_PRIVATE_KEY_PATH:
-                    sp_key = _read_text_file(SAML_SP_PRIVATE_KEY_PATH)
-                    sp_settings["sp"]["privateKey"] = sp_key
-                sp_settings["security"]["wantAssertionsEncrypted"] = True
-                sp_settings["security"]["wantNameIdEncrypted"] = WANT_NAMEID_ENCRYPTED
-                LOGGER.info("SAML encryption ENABLED (cert present).")
-            except FileNotFoundError:
-                LOGGER.warning(
-                    "SAML_SP_CERT_PATH set but file not found; continuing without encryption.",
-                )
+        if SAML_SP_CERT:
+            # Cert/key are provided directly via environment (PEM strings)
+            sp_settings["sp"]["x509cert"] = SAML_SP_CERT.strip()
+            if SAML_SP_PRIVATE_KEY:
+                sp_settings["sp"]["privateKey"] = SAML_SP_PRIVATE_KEY.strip()
+            sp_settings["security"]["wantAssertionsEncrypted"] = True
+            sp_settings["security"]["wantNameIdEncrypted"] = True
+            LOGGER.info("SAML encryption ENABLED (inline cert/key configured).")
         else:
             LOGGER.info("No SP cert configured; encryption NOT advertised.")
 

--- a/backend/src/xfd_django/xfd_api/auth_saml.py
+++ b/backend/src/xfd_django/xfd_api/auth_saml.py
@@ -127,6 +127,7 @@ def _build_sp_settings() -> Dict[str, Any]:
                 sp_settings["sp"]["privateKey"] = SAML_SP_PRIVATE_KEY.strip()
             sp_settings["security"]["wantAssertionsEncrypted"] = True
             sp_settings["security"]["wantNameIdEncrypted"] = True
+            sp_settings["security"]["authnRequestsSigned"] = True
             LOGGER.info("SAML encryption ENABLED (inline cert/key configured).")
         else:
             LOGGER.info("No SP cert configured; encryption NOT advertised.")

--- a/backend/src/xfd_django/xfd_api/tests/test_auth_saml.py
+++ b/backend/src/xfd_django/xfd_api/tests/test_auth_saml.py
@@ -458,8 +458,8 @@ def test_metadata_local_no_encryption_keydescriptor(
             "BACKEND_DOMAIN": "http://localhost:3000",
             "FRONTEND_DOMAIN": "http://localhost",
             "OKTA_SAML_METADATA_URL": "https://idp.example.com/metadata",
-            "SAML_SP_CERT_PATH": None,
-            "SAML_SP_PRIVATE_KEY_PATH": None,
+            "SAML_SP_CERT": None,
+            "SAML_SP_PRIVATE_KEY": None,
         },
     )
 
@@ -480,8 +480,6 @@ def test_metadata_prod_with_encryption_descriptor_using_cert_only(
         "MIIFakeCertPEMForTestOnly==\n"
         "-----END CERTIFICATE-----\n"
     )
-    cert_path = tmp_path / "sp.crt"
-    cert_path.write_text(sp_cert_pem)
 
     client, _, _ = _mount_client(
         monkeypatch,
@@ -490,8 +488,9 @@ def test_metadata_prod_with_encryption_descriptor_using_cert_only(
             "BACKEND_DOMAIN": "https://sp.example.gov",
             "FRONTEND_DOMAIN": "https://spa.example.gov",
             "OKTA_SAML_METADATA_URL": "https://idp.example.com/metadata",
-            "SAML_SP_CERT_PATH": str(cert_path),
-            "SAML_SP_PRIVATE_KEY_PATH": None,
+            # NEW: use inline cert/key env vars instead of *_PATH
+            "SAML_SP_CERT": sp_cert_pem,
+            "SAML_SP_PRIVATE_KEY": None,
         },
     )
 
@@ -515,8 +514,8 @@ def test_metadata_no_encryption_when_cert_missing(
             "BACKEND_DOMAIN": "https://sp.example.gov",
             "FRONTEND_DOMAIN": "https://spa.example.gov",
             "OKTA_SAML_METADATA_URL": "https://idp.example.com/metadata",
-            "SAML_SP_CERT_PATH": None,
-            "SAML_SP_PRIVATE_KEY_PATH": None,
+            "SAML_SP_CERT": None,
+            "SAML_SP_PRIVATE_KEY": None,
         },
     )
 


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
Related to CRASM-2906 Cognito Removal. Update env vars for encryption deployments.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
Update usage for env vars from file path to env vars.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
Test in DMZ once env vars are set. 
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
