### PR TITLE
CRASM-3026: Fix checkUserExpiration lambda

### DIFF
--- a/backend/src/xfd_django/xfd_api/auth.py
+++ b/backend/src/xfd_django/xfd_api/auth.py
@@ -383,6 +383,7 @@ async def process_user(decoded_token):
 
     # Update common fields
     user.last_logged_in = datetime.now()
+    user.notified_30_at = None
     user.cognito_username = decoded_token.get("cognito:username")
     user.cognito_use_case_description = decoded_token.get("nickname")
     user.cognito_email_verified = decoded_token.get("email_verified")

--- a/backend/src/xfd_django/xfd_api/auth.py
+++ b/backend/src/xfd_django/xfd_api/auth.py
@@ -383,7 +383,7 @@ async def process_user(decoded_token):
 
     # Update common fields
     user.last_logged_in = datetime.now()
-    user.notified_30_at = None
+    user.last_notified_30 = None
     user.cognito_username = decoded_token.get("cognito:username")
     user.cognito_use_case_description = decoded_token.get("nickname")
     user.cognito_email_verified = decoded_token.get("email_verified")

--- a/backend/src/xfd_django/xfd_api/auth_saml.py
+++ b/backend/src/xfd_django/xfd_api/auth_saml.py
@@ -257,7 +257,7 @@ def _upsert_user(identity: Dict[str, Any]) -> User:
     user.cognito_email_verified = True
     user.cognito_groups = groups
     user.last_logged_in = datetime.now(timezone.utc)
-    user.notified_30_at = None
+    user.last_notified_30 = None
 
     # Update login block status and save the user
     update_login_block_status(user)

--- a/backend/src/xfd_django/xfd_api/auth_saml.py
+++ b/backend/src/xfd_django/xfd_api/auth_saml.py
@@ -257,6 +257,7 @@ def _upsert_user(identity: Dict[str, Any]) -> User:
     user.cognito_email_verified = True
     user.cognito_groups = groups
     user.last_logged_in = datetime.now(timezone.utc)
+    user.notified_30_at = None
 
     # Update login block status and save the user
     update_login_block_status(user)

--- a/backend/src/xfd_django/xfd_api/tasks/checkUserExpiration.py
+++ b/backend/src/xfd_django/xfd_api/tasks/checkUserExpiration.py
@@ -6,6 +6,7 @@ import os
 
 # Third-Party Libraries
 import django
+from django.db.models.query import Q
 from django.utils.timezone import now
 
 # Django setup
@@ -23,15 +24,16 @@ LOGGER = logging.getLogger(__name__)
 
 
 def check_user_expiration():
-    """Check user inactivity and take actions: notify (30 days), deactivate (45 days), and delete (90 days)."""
+    """Check user inactivity and take actions: notify (30 days) and delete (45 days)."""
     today = now()
     cutoff_30_days = today - timedelta(days=30)
     cutoff_45_days = today - timedelta(days=45)
-    cutoff_90_days = today - timedelta(days=90)
 
     # Users to notify (30 days of inactivity)
     users_to_notify = User.objects.filter(
-        last_logged_in__lt=cutoff_30_days, last_logged_in__gte=cutoff_45_days
+        last_logged_in__lt=cutoff_30_days,
+        last_logged_in__gte=cutoff_45_days,
+        last_notified_30__isnull=True,
     )
 
     # Notify users of inactivity (30 days)
@@ -40,7 +42,7 @@ def check_user_expiration():
         body = """
         Hello {first_name} {last_name},
 
-        Your Cyber Hygiene Dashboard account has been inactive for over 30 days. If your account reaches 90 days of inactivity,
+        Your Cyber Hygiene Dashboard account has been inactive for over 30 days. If your account reaches 45 days of inactivity,
         you will need to submit a new account approval request.
 
         Thank you,
@@ -53,40 +55,21 @@ def check_user_expiration():
         )
         send_email(user.email, subject, body)
         LOGGER.info("30-day inactivity notice sent to %s.", user.email)
+        user.last_notified_30 = now()
+        user.save(update_fields=["last_notified_30"])
 
-    # Users to deactivate (45 days of inactivity)
-    users_to_deactivate = User.objects.filter(
-        last_logged_in__lt=cutoff_45_days, last_logged_in__gte=cutoff_90_days
+    # Users to remove (45 days of inactivity)
+    users_to_remove = User.objects.filter(
+        Q(last_logged_in__lt=cutoff_45_days)
+        | Q(last_logged_in__isnull=True, created_at__lt=cutoff_45_days)
     )
 
-    for user in users_to_deactivate:
+    for user in users_to_remove:
         subject = "Account Deactivation Notice"
         body = """
         Hello {first_name} {last_name},
 
-        Your Cyber Hygiene Dashboard account has been inactive for over 45 days. If your account reaches 90 days of inactivity,
-        you will need to submit a new account approval request.
-
-        Thank you,
-        The Cyber Hygiene (CyHy) Team
-        CISA Vulnerability Management
-        Cybersecurity and Infrastructure Security Agency (CISA)
-        Email: vulnerability@cisa.dhs.gov
-        """.format(
-            first_name=user.first_name, last_name=user.last_name
-        )
-        # Send inactivity notification
-        send_email(user.email, subject, body)
-
-    # Users to remove (90 days of inactivity)
-    users_to_remove = User.objects.filter(last_logged_in__lt=cutoff_90_days)
-
-    for user in users_to_remove:
-        subject = "Account Removal Notice"
-        body = """
-        Hello {first_name} {last_name},
-
-        Your Cyber Hygiene Dashboard account has been inactive for over 90 days and has been removed.
+        Your Cyber Hygiene Dashboard account has been inactive for over 45 days and has been removed.
         You will need to recreate your account if you wish to use our services again.
 
         Thank you,
@@ -104,7 +87,7 @@ def check_user_expiration():
         try:
             user.delete()
             LOGGER.info(
-                "Removed user %s from the database due to 90 days of inactivity.",
+                "Removed user %s from the database due to 45 days of inactivity.",
                 user.email,
             )
         except Exception as e:
@@ -117,8 +100,8 @@ def run_test_expiration_flow(email: str):
 
     - Only called when STAGE == 'staging'
     - Create a new user with the given email
-    - Simulate 30/45/90 day inactivity by updating last_logged_in and calling
-      check_user_expiration() three times
+    - Simulate 30/45 day inactivity by updating last_logged_in and calling
+      check_user_expiration() two times
     - Ensure the user gets deleted; if not, try once more and then raise an error
     """
     if not email:
@@ -136,7 +119,6 @@ def run_test_expiration_flow(email: str):
     # NOTE: We use +1 day to satisfy the strict `<` comparisons in check_user_expiration
     thirty_plus = baseline_now - timedelta(days=31)  # > 30 days inactive
     fortyfive_plus = baseline_now - timedelta(days=46)  # > 45 days inactive
-    ninety_plus = baseline_now - timedelta(days=91)  # > 90 days inactive
 
     # 1) Create user as ~30-day inactive and run
     user = User.objects.create(
@@ -152,13 +134,6 @@ def run_test_expiration_flow(email: str):
     if User.objects.filter(id=user.id).exists():
         user = User.objects.get(id=user.id)
         user.last_logged_in = fortyfive_plus
-        user.save(update_fields=["last_logged_in"])
-        check_user_expiration()
-
-    # 3) If still exists, move them to ~90+ days inactive and run again
-    if User.objects.filter(id=user.id).exists():
-        user = User.objects.get(id=user.id)
-        user.last_logged_in = ninety_plus
         user.save(update_fields=["last_logged_in"])
         check_user_expiration()
 

--- a/backend/src/xfd_django/xfd_api/tasks/checkUserExpiration.py
+++ b/backend/src/xfd_django/xfd_api/tasks/checkUserExpiration.py
@@ -65,7 +65,7 @@ def check_user_expiration():
     )
 
     for user in users_to_remove:
-        subject = "Account Deactivation Notice"
+        subject = "Account Removal Notice"
         body = """
         Hello {first_name} {last_name},
 

--- a/backend/src/xfd_django/xfd_api/tasks/checkUserExpiration.py
+++ b/backend/src/xfd_django/xfd_api/tasks/checkUserExpiration.py
@@ -5,8 +5,6 @@ import logging
 import os
 
 # Third-Party Libraries
-import boto3
-from botocore.exceptions import ClientError
 import django
 from django.utils.timezone import now
 
@@ -19,10 +17,6 @@ django.setup()
 # Third-Party Libraries
 from xfd_api.helpers.email import send_email
 from xfd_mini_dl.models import User
-
-# AWS Configuration
-cognito_client = boto3.client("cognito-idp", region_name=os.getenv("AWS_REGION"))
-user_pool_id = os.getenv("VITE_USER_POOL_ID")
 
 # Configure logging
 LOGGER = logging.getLogger(__name__)
@@ -37,103 +31,169 @@ def check_user_expiration():
 
     # Users to notify (30 days of inactivity)
     users_to_notify = User.objects.filter(
-        lastLoggedIn__lt=cutoff_30_days, lastLoggedIn__gte=cutoff_45_days
+        last_logged_in__lt=cutoff_30_days, last_logged_in__gte=cutoff_45_days
     )
 
     # Notify users of inactivity (30 days)
     for user in users_to_notify:
         subject = "Account Inactivity Notice"
         body = """
-        Hello {firstName} {lastName},
+        Hello {first_name} {last_name},
 
-        Your account has been inactive for over 30 days. If your account reaches 45 days of inactivity,
-        your password will be reset, requiring action to reactivate your account.
+        Your Cyber Hygiene Dashboard account has been inactive for over 30 days. If your account reaches 90 days of inactivity,
+        you will need to submit a new account approval request.
 
         Thank you,
-        The CyHy Dashboard Team
+        The Cyber Hygiene (CyHy) Team
+        CISA Vulnerability Management
+        Cybersecurity and Infrastructure Security Agency (CISA)
+        EMAIL: vulnerability@cisa.dhs.gov
         """.format(
-            firstName=user.firstName, lastName=user.lastName
+            first_name=user.first_name, last_name=user.last_name
         )
         send_email(user.email, subject, body)
         LOGGER.info("30-day inactivity notice sent to %s.", user.email)
 
     # Users to deactivate (45 days of inactivity)
     users_to_deactivate = User.objects.filter(
-        lastLoggedIn__lt=cutoff_45_days, lastLoggedIn__gte=cutoff_90_days
+        last_logged_in__lt=cutoff_45_days, last_logged_in__gte=cutoff_90_days
     )
 
     for user in users_to_deactivate:
         subject = "Account Deactivation Notice"
         body = """
-        Hello {firstName} {lastName},
+        Hello {first_name} {last_name},
 
-        Your account has been inactive for over 45 days. As a result, your password has been reset.
-        You will need to set a new password the next time you log in. If your account reaches 90 days of inactivity,
-        it will be removed, requiring action to recreate your account.
+        Your Cyber Hygiene Dashboard account has been inactive for over 45 days. If your account reaches 90 days of inactivity,
+        you will need to submit a new account approval request.
 
         Thank you,
-        The CyHy Dashboard Team
+        The Cyber Hygiene (CyHy) Team
+        CISA Vulnerability Management
+        Cybersecurity and Infrastructure Security Agency (CISA)
+        EMAIL: vulnerability@cisa.dhs.gov
         """.format(
-            firstName=user.firstName, lastName=user.lastName
+            first_name=user.first_name, last_name=user.last_name
         )
         # Send inactivity notification
         send_email(user.email, subject, body)
 
-        # Reset the user's password
-        try:
-            cognito_client.admin_set_user_password(
-                UserPoolId=user_pool_id,
-                Username=user.cognito_id,
-                Password=os.getenv("VITE_RANDOM_PASSWORD"),
-                Permanent=False,
-            )
-            LOGGER.info(
-                "Password reset for user %s due to 45 days of inactivity.", user.email
-            )
-        except ClientError as e:
-            LOGGER.error("Error resetting password for %s: %s", user.email, e)
-
     # Users to remove (90 days of inactivity)
-    users_to_remove = User.objects.filter(lastLoggedIn__lt=cutoff_90_days)
+    users_to_remove = User.objects.filter(last_logged_in__lt=cutoff_90_days)
 
     for user in users_to_remove:
         subject = "Account Removal Notice"
         body = """
-        Hello {firstName} {lastName},
+        Hello {first_name} {last_name},
 
-        Your account has been inactive for over 90 days and has been removed.
+        Your Cyber Hygiene Dashboard account has been inactive for over 90 days and has been removed.
         You will need to recreate your account if you wish to use our services again.
 
         Thank you,
-        The CyHy Dashboard Team
+        The Cyber Hygiene (CyHy) Team
+        CISA Vulnerability Management
+        Cybersecurity and Infrastructure Security Agency (CISA)
+        EMAIL: vulnerability@cisa.dhs.gov
         """.format(
-            firstName=user.firstName, lastName=user.lastName
+            first_name=user.first_name, last_name=user.last_name
         )
         # Notify user of account removal
         send_email(user.email, subject, body)
 
-        # Remove the user from Cognito and the database
+        # Remove the user from the database
         try:
-            # Remove from Cognito
-            cognito_client.admin_delete_user(
-                UserPoolId=user_pool_id,
-                Username=user.cognito_id,
-            )
-            LOGGER.info("Removed user %s from Cognito.", user.email)
-
-            # Remove from database
             user.delete()
             LOGGER.info(
                 "Removed user %s from the database due to 90 days of inactivity.",
                 user.email,
             )
-        except ClientError as e:
+        except Exception as e:
             LOGGER.error("Error removing user %s: %s", user.email, e)
+
+
+def run_test_expiration_flow(email: str):
+    """
+    Test-only helper.
+
+    - Only called when STAGE == 'staging'
+    - Create a new user with the given email
+    - Simulate 30/45/90 day inactivity by updating last_logged_in and calling
+      check_user_expiration() three times
+    - Ensure the user gets deleted; if not, try once more and then raise an error
+    """
+    if not email:
+        raise ValueError("Test mode requires an 'email' field in the event payload.")
+
+    # Must be a brand new email so we don't mess with real users
+    if User.objects.filter(email=email).exists():
+        raise RuntimeError(
+            "Test user email {} already exists in the database.".format(email)
+        )
+
+    # Use a fixed "now" baseline so our 30/45/90 calculations are consistent
+    baseline_now = now()
+
+    # NOTE: We use +1 day to satisfy the strict `<` comparisons in check_user_expiration
+    thirty_plus = baseline_now - timedelta(days=31)  # > 30 days inactive
+    fortyfive_plus = baseline_now - timedelta(days=46)  # > 45 days inactive
+    ninety_plus = baseline_now - timedelta(days=91)  # > 90 days inactive
+
+    # 1) Create user as ~30-day inactive and run
+    user = User.objects.create(
+        first_name="Test",
+        last_name="User",
+        email=email,
+        last_logged_in=thirty_plus,
+    )
+
+    check_user_expiration()
+
+    # 2) If still exists, move them to ~45+ days inactive and run again
+    if User.objects.filter(id=user.id).exists():
+        user = User.objects.get(id=user.id)
+        user.last_logged_in = fortyfive_plus
+        user.save(update_fields=["last_logged_in"])
+        check_user_expiration()
+
+    # 3) If still exists, move them to ~90+ days inactive and run again
+    if User.objects.filter(id=user.id).exists():
+        user = User.objects.get(id=user.id)
+        user.last_logged_in = ninety_plus
+        user.save(update_fields=["last_logged_in"])
+        check_user_expiration()
+
+    # 4) Verify deletion – if still present, try once more then raise
+    if User.objects.filter(id=user.id).exists():
+        # One more attempt to let the expiration logic clean up
+        user = User.objects.get(id=user.id)
+        user.delete()
+        if User.objects.filter(id=user.id).exists():
+            raise RuntimeError(
+                "Test user {} was not deleted by expiration logic.".format(email)
+            )
 
 
 def handler(event, context):
     """AWS Lambda handler for checking user expiration."""
     try:
+        stage = os.getenv("STAGE", "").lower()
+
+        # Test mode: event contains {"Test": true, "email": "..."} and STAGE=staging
+        if isinstance(event, dict) and event.get("Test"):
+            if stage != "staging":
+                return {
+                    "status_code": 403,
+                    "body": "Test mode is only allowed when STAGE=staging.",
+                }
+
+            email = event.get("email")
+            run_test_expiration_flow(email)
+            return {
+                "status_code": 200,
+                "body": "Test expiration flow executed for {}.".format(email),
+            }
+
+        # Normal scheduled behavior
         check_user_expiration()
         return {
             "status_code": 200,

--- a/backend/src/xfd_django/xfd_api/tests/test_check_user_expiration.py
+++ b/backend/src/xfd_django/xfd_api/tests/test_check_user_expiration.py
@@ -1,0 +1,218 @@
+"""Tests for checkUserExpiration Lambda task."""
+# Standard Python Libraries
+from datetime import timedelta
+
+# Third-Party Libraries
+import pytest
+from django.utils import timezone
+
+from xfd_mini_dl.models import User
+from xfd_api.tasks import checkUserExpiration
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
+def test_check_user_expiration_sends_emails_and_deletes(monkeypatch):
+    """Users in each inactivity band get the right email behavior and 90+ day users are deleted."""
+    # Freeze "now" in the task module
+    frozen_now = timezone.now()
+
+    # Patch the now() used inside checkUserExpiration
+    monkeypatch.setattr(checkUserExpiration, "now", lambda: frozen_now)
+
+    # Capture emails instead of actually sending
+    emails_sent = []
+
+    def fake_send_email(to_addr, subject, body):
+        emails_sent.append({"to": to_addr, "subject": subject, "body": body})
+
+    monkeypatch.setattr(checkUserExpiration, "send_email", fake_send_email)
+
+    # Create users in different inactivity windows
+    # 20 days inactive -> should get NO email
+    user_20 = User.objects.create(
+        first_name="Twenty",
+        last_name="Days",
+        email="20@example.com",
+        last_logged_in=frozen_now - timedelta(days=20),
+    )
+
+    # 35 days inactive -> 30-day notice
+    user_35 = User.objects.create(
+        first_name="ThirtyFive",
+        last_name="Days",
+        email="35@example.com",
+        last_logged_in=frozen_now - timedelta(days=35),
+    )
+
+    # 60 days inactive -> 45-day notice
+    user_60 = User.objects.create(
+        first_name="Sixty",
+        last_name="Days",
+        email="60@example.com",
+        last_logged_in=frozen_now - timedelta(days=60),
+    )
+
+    # 120 days inactive -> 90-day notice + deletion
+    user_120 = User.objects.create(
+        first_name="OneTwenty",
+        last_name="Days",
+        email="120@example.com",
+        last_logged_in=frozen_now - timedelta(days=120),
+    )
+
+    # Run the task
+    checkUserExpiration.check_user_expiration()
+
+    # Reload from DB / assert existence or deletion
+    assert User.objects.filter(id=user_20.id).exists()  # recent user should remain
+    assert User.objects.filter(id=user_35.id).exists()  # 30–45 day user should remain
+    assert User.objects.filter(id=user_60.id).exists()  # 45–90 day user should remain
+    assert not User.objects.filter(id=user_120.id).exists()  # 90+ day user should be deleted
+
+    # Verify emails
+    # We expect 3 emails: one for 35-day, one for 60-day, one for 120-day
+    assert len(emails_sent) == 3
+
+    # Get emails by recipient to make assertions easier
+    emails_by_to = {e["to"]: e for e in emails_sent}
+
+    # 20-day user should not receive an email
+    assert "20@example.com" not in emails_by_to
+
+    # 30–45 day user should get inactivity notice
+    assert "35@example.com" in emails_by_to
+    assert emails_by_to["35@example.com"]["subject"] == "Account Inactivity Notice"
+    assert "inactive for over 30 days" in emails_by_to["35@example.com"]["body"]
+
+    # 45–90 day user should get deactivation notice
+    assert "60@example.com" in emails_by_to
+    assert emails_by_to["60@example.com"]["subject"] == "Account Deactivation Notice"
+    assert "inactive for over 45 days" in emails_by_to["60@example.com"]["body"]
+
+    # 90+ day user should get removal notice
+    assert "120@example.com" in emails_by_to
+    assert emails_by_to["120@example.com"]["subject"] == "Account Removal Notice"
+    assert "inactive for over 90 days and has been removed" in emails_by_to[
+        "120@example.com"
+    ]["body"]
+
+
+def test_handler_success(monkeypatch):
+    """Handler should call check_user_expiration and return 200 on success."""
+    called = {"count": 0}
+
+    def fake_check():
+        called["count"] += 1
+
+    monkeypatch.setattr(checkUserExpiration, "check_user_expiration", fake_check)
+
+    response = checkUserExpiration.handler(event={}, context={})
+
+    assert called["count"] == 1
+    assert response["status_code"] == 200
+    assert "completed successfully" in response["body"]
+
+
+def test_handler_failure(monkeypatch):
+    """Handler should return 500 when check_user_expiration raises."""
+    def fake_check():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(checkUserExpiration, "check_user_expiration", fake_check)
+
+    response = checkUserExpiration.handler(event={}, context={})
+
+    assert response["status_code"] == 500
+    assert "boom" in response["body"]
+
+@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
+def test_handler_test_mode_staging_creates_and_deletes_user(monkeypatch):
+    """In staging, Test=true should create a user, run 30/45/90 flow, send emails, and delete the user."""
+    monkeypatch.setenv("STAGE", "staging")
+
+    fixed_now = timezone.now()
+    monkeypatch.setattr(checkUserExpiration, "now", lambda: fixed_now)
+
+    emails = []
+
+    def fake_send_email(to_addr, subject, body):
+        emails.append({"to": to_addr, "subject": subject, "body": body})
+
+    monkeypatch.setattr(checkUserExpiration, "send_email", fake_send_email)
+
+    event = {"Test": True, "email": "uat@example.com"}
+
+    response = checkUserExpiration.handler(event=event, context={})
+
+    assert response["status_code"] == 200
+    assert "uat@example.com" in response["body"]
+
+    # User should have been created and then deleted
+    assert not User.objects.filter(email="uat@example.com").exists()
+
+    # Should have sent 3 emails (30, 45, 90)
+    assert len(emails) == 3
+    subjects = {e["subject"] for e in emails}
+    assert "Account Inactivity Notice" in subjects
+    assert "Account Deactivation Notice" in subjects
+    assert "Account Removal Notice" in subjects
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
+def test_handler_test_mode_existing_email_raises(monkeypatch):
+    """If the test email already exists, handler should return 500."""
+    monkeypatch.setenv("STAGE", "staging")
+
+    # Create an existing user with that email
+    User.objects.create(
+        first_name="Existing",
+        last_name="User",
+        email="uat@example.com",
+        last_logged_in=timezone.now(),
+    )
+
+    emails = []
+
+    def fake_send_email(to_addr, subject, body):
+        emails.append({"to": to_addr, "subject": subject, "body": body})
+
+    monkeypatch.setattr(checkUserExpiration, "send_email", fake_send_email)
+
+    event = {"Test": True, "email": "uat@example.com"}
+
+    response = checkUserExpiration.handler(event=event, context={})
+
+    # Because _run_test_expiration_flow raises, handler returns 500
+    assert response["status_code"] == 500
+    assert "already exists" in response["body"]
+    # No test emails should have been sent
+    assert emails == []
+
+
+def test_handler_test_mode_forbidden_when_not_staging(monkeypatch):
+    """When STAGE!=staging, Test=true should return 403 and not run the flow."""
+    monkeypatch.setenv("STAGE", "production")
+
+    called = {"count": 0}
+
+    def fake_check():
+        called["count"] += 1
+
+    # Ensure normal path isn't accidentally called for Test=true
+    monkeypatch.setattr(checkUserExpiration, "check_user_expiration", fake_check)
+
+    emails = []
+
+    def fake_send_email(to_addr, subject, body):
+        emails.append({"to": to_addr, "subject": subject, "body": body})
+
+    monkeypatch.setattr(checkUserExpiration, "send_email", fake_send_email)
+
+    event = {"Test": True, "email": "uat@example.com"}
+
+    response = checkUserExpiration.handler(event=event, context={})
+
+    assert response["status_code"] == 403
+    assert "only allowed" in response["body"]
+    assert called["count"] == 0
+    assert emails == []

--- a/backend/src/xfd_django/xfd_api/tests/test_check_user_expiration.py
+++ b/backend/src/xfd_django/xfd_api/tests/test_check_user_expiration.py
@@ -105,7 +105,7 @@ def test_check_user_expiration_does_not_repeat_30_day_email(monkeypatch):
     checkUserExpiration.check_user_expiration()
 
     assert User.objects.filter(id=user.id).exists()
-    assert emails_sent == []
+    assert not emails_sent
 
 
 def test_handler_success(monkeypatch):

--- a/backend/src/xfd_django/xfd_api/tests/test_check_user_expiration.py
+++ b/backend/src/xfd_django/xfd_api/tests/test_check_user_expiration.py
@@ -3,11 +3,10 @@
 from datetime import timedelta
 
 # Third-Party Libraries
-import pytest
 from django.utils import timezone
-
-from xfd_mini_dl.models import User
+import pytest
 from xfd_api.tasks import checkUserExpiration
+from xfd_mini_dl.models import User
 
 
 @pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
@@ -67,7 +66,9 @@ def test_check_user_expiration_sends_emails_and_deletes(monkeypatch):
     assert User.objects.filter(id=user_20.id).exists()  # recent user should remain
     assert User.objects.filter(id=user_35.id).exists()  # 30–45 day user should remain
     assert User.objects.filter(id=user_60.id).exists()  # 45–90 day user should remain
-    assert not User.objects.filter(id=user_120.id).exists()  # 90+ day user should be deleted
+    assert not User.objects.filter(
+        id=user_120.id
+    ).exists()  # 90+ day user should be deleted
 
     # Verify emails
     # We expect 3 emails: one for 35-day, one for 60-day, one for 120-day
@@ -92,9 +93,10 @@ def test_check_user_expiration_sends_emails_and_deletes(monkeypatch):
     # 90+ day user should get removal notice
     assert "120@example.com" in emails_by_to
     assert emails_by_to["120@example.com"]["subject"] == "Account Removal Notice"
-    assert "inactive for over 90 days and has been removed" in emails_by_to[
-        "120@example.com"
-    ]["body"]
+    assert (
+        "inactive for over 90 days and has been removed"
+        in emails_by_to["120@example.com"]["body"]
+    )
 
 
 def test_handler_success(monkeypatch):
@@ -115,6 +117,7 @@ def test_handler_success(monkeypatch):
 
 def test_handler_failure(monkeypatch):
     """Handler should return 500 when check_user_expiration raises."""
+
     def fake_check():
         raise RuntimeError("boom")
 
@@ -124,6 +127,7 @@ def test_handler_failure(monkeypatch):
 
     assert response["status_code"] == 500
     assert "boom" in response["body"]
+
 
 @pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
 def test_handler_test_mode_staging_creates_and_deletes_user(monkeypatch):

--- a/backend/src/xfd_django/xfd_api/tests/test_check_user_expiration.py
+++ b/backend/src/xfd_django/xfd_api/tests/test_check_user_expiration.py
@@ -71,7 +71,7 @@ def test_check_user_expiration_sends_30_once_and_deletes_at_45(monkeypatch):
 
     assert "60@example.com" in by_to
     assert len(by_to["60@example.com"]) == 1
-    assert by_to["60@example.com"][0]["subject"] == "Account Deactivation Notice"
+    assert by_to["60@example.com"][0]["subject"] == "Account Removal Notice"
     assert "inactive for over 45 days" in by_to["60@example.com"][0]["body"]
 
     # last_notified_30 should have been set for user_35
@@ -169,7 +169,7 @@ def test_handler_test_mode_staging_creates_and_deletes_user(monkeypatch):
     assert len(emails) == 2
     subjects = {e["subject"] for e in emails}
     assert "Account Inactivity Notice" in subjects
-    assert "Account Deactivation Notice" in subjects
+    assert "Account Removal Notice" in subjects
 
 
 @pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])

--- a/backend/src/xfd_django/xfd_api/tests/test_check_user_expiration.py
+++ b/backend/src/xfd_django/xfd_api/tests/test_check_user_expiration.py
@@ -10,15 +10,11 @@ from xfd_mini_dl.models import User
 
 
 @pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
-def test_check_user_expiration_sends_emails_and_deletes(monkeypatch):
-    """Users in each inactivity band get the right email behavior and 90+ day users are deleted."""
-    # Freeze "now" in the task module
+def test_check_user_expiration_sends_30_once_and_deletes_at_45(monkeypatch):
+    """Test check user expiration sends 30 days once and deletes at 45."""
     frozen_now = timezone.now()
-
-    # Patch the now() used inside checkUserExpiration
     monkeypatch.setattr(checkUserExpiration, "now", lambda: frozen_now)
 
-    # Capture emails instead of actually sending
     emails_sent = []
 
     def fake_send_email(to_addr, subject, body):
@@ -26,8 +22,7 @@ def test_check_user_expiration_sends_emails_and_deletes(monkeypatch):
 
     monkeypatch.setattr(checkUserExpiration, "send_email", fake_send_email)
 
-    # Create users in different inactivity windows
-    # 20 days inactive -> should get NO email
+    # 20 days inactive -> no email, not deleted
     user_20 = User.objects.create(
         first_name="Twenty",
         last_name="Days",
@@ -35,15 +30,16 @@ def test_check_user_expiration_sends_emails_and_deletes(monkeypatch):
         last_logged_in=frozen_now - timedelta(days=20),
     )
 
-    # 35 days inactive -> 30-day notice
+    # 35 days inactive -> should get 30-day notice once, not deleted
     user_35 = User.objects.create(
         first_name="ThirtyFive",
         last_name="Days",
         email="35@example.com",
         last_logged_in=frozen_now - timedelta(days=35),
+        last_notified_30=None,
     )
 
-    # 60 days inactive -> 45-day notice
+    # 60 days inactive -> should get deletion notice and be deleted
     user_60 = User.objects.create(
         first_name="Sixty",
         last_name="Days",
@@ -51,56 +47,69 @@ def test_check_user_expiration_sends_emails_and_deletes(monkeypatch):
         last_logged_in=frozen_now - timedelta(days=60),
     )
 
-    # 120 days inactive -> 90-day notice + deletion
-    user_120 = User.objects.create(
-        first_name="OneTwenty",
-        last_name="Days",
-        email="120@example.com",
-        last_logged_in=frozen_now - timedelta(days=120),
-    )
-
-    # Run the task
     checkUserExpiration.check_user_expiration()
 
-    # Reload from DB / assert existence or deletion
-    assert User.objects.filter(id=user_20.id).exists()  # recent user should remain
-    assert User.objects.filter(id=user_35.id).exists()  # 30–45 day user should remain
-    assert User.objects.filter(id=user_60.id).exists()  # 45–90 day user should remain
-    assert not User.objects.filter(
-        id=user_120.id
-    ).exists()  # 90+ day user should be deleted
+    assert User.objects.filter(id=user_20.id).exists()
+    assert User.objects.filter(id=user_35.id).exists()
+    assert not User.objects.filter(id=user_60.id).exists()
 
-    # Verify emails
-    # We expect 3 emails: one for 35-day, one for 60-day, one for 120-day
-    assert len(emails_sent) == 3
+    # Should have sent:
+    # - one 30-day notice to user_35
+    # - one 45-day removal notice to user_60
+    assert len(emails_sent) == 2
 
-    # Get emails by recipient to make assertions easier
-    emails_by_to = {e["to"]: e for e in emails_sent}
+    by_to = {}
+    for e in emails_sent:
+        by_to.setdefault(e["to"], []).append(e)
 
-    # 20-day user should not receive an email
-    assert "20@example.com" not in emails_by_to
+    assert "20@example.com" not in by_to
 
-    # 30–45 day user should get inactivity notice
-    assert "35@example.com" in emails_by_to
-    assert emails_by_to["35@example.com"]["subject"] == "Account Inactivity Notice"
-    assert "inactive for over 30 days" in emails_by_to["35@example.com"]["body"]
+    assert "35@example.com" in by_to
+    assert len(by_to["35@example.com"]) == 1
+    assert by_to["35@example.com"][0]["subject"] == "Account Inactivity Notice"
+    assert "inactive for over 30 days" in by_to["35@example.com"][0]["body"]
 
-    # 45–90 day user should get deactivation notice
-    assert "60@example.com" in emails_by_to
-    assert emails_by_to["60@example.com"]["subject"] == "Account Deactivation Notice"
-    assert "inactive for over 45 days" in emails_by_to["60@example.com"]["body"]
+    assert "60@example.com" in by_to
+    assert len(by_to["60@example.com"]) == 1
+    assert by_to["60@example.com"][0]["subject"] == "Account Deactivation Notice"
+    assert "inactive for over 45 days" in by_to["60@example.com"][0]["body"]
 
-    # 90+ day user should get removal notice
-    assert "120@example.com" in emails_by_to
-    assert emails_by_to["120@example.com"]["subject"] == "Account Removal Notice"
-    assert (
-        "inactive for over 90 days and has been removed"
-        in emails_by_to["120@example.com"]["body"]
+    # last_notified_30 should have been set for user_35
+    user_35.refresh_from_db()
+    assert user_35.last_notified_30 is not None
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
+def test_check_user_expiration_does_not_repeat_30_day_email(monkeypatch):
+    """Test check user expiration does not repeat 30 day email."""
+    frozen_now = timezone.now()
+    monkeypatch.setattr(checkUserExpiration, "now", lambda: frozen_now)
+
+    emails_sent = []
+
+    def fake_send_email(to_addr, subject, body):
+        """Test fake send email."""
+        emails_sent.append({"to": to_addr, "subject": subject, "body": body})
+
+    monkeypatch.setattr(checkUserExpiration, "send_email", fake_send_email)
+
+    # In the 30–45 window, but already notified
+    user = User.objects.create(
+        first_name="Already",
+        last_name="Notified",
+        email="already@example.com",
+        last_logged_in=frozen_now - timedelta(days=35),
+        last_notified_30=frozen_now - timedelta(days=1),
     )
+
+    checkUserExpiration.check_user_expiration()
+
+    assert User.objects.filter(id=user.id).exists()
+    assert emails_sent == []
 
 
 def test_handler_success(monkeypatch):
-    """Handler should call check_user_expiration and return 200 on success."""
+    """Test handler success."""
     called = {"count": 0}
 
     def fake_check():
@@ -116,7 +125,7 @@ def test_handler_success(monkeypatch):
 
 
 def test_handler_failure(monkeypatch):
-    """Handler should return 500 when check_user_expiration raises."""
+    """Test handler failure."""
 
     def fake_check():
         raise RuntimeError("boom")
@@ -131,7 +140,7 @@ def test_handler_failure(monkeypatch):
 
 @pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
 def test_handler_test_mode_staging_creates_and_deletes_user(monkeypatch):
-    """In staging, Test=true should create a user, run 30/45/90 flow, send emails, and delete the user."""
+    """Test handler test mode staging."""
     monkeypatch.setenv("STAGE", "staging")
 
     fixed_now = timezone.now()
@@ -151,23 +160,23 @@ def test_handler_test_mode_staging_creates_and_deletes_user(monkeypatch):
     assert response["status_code"] == 200
     assert "uat@example.com" in response["body"]
 
-    # User should have been created and then deleted
+    # User should have been created and then deleted at 45
     assert not User.objects.filter(email="uat@example.com").exists()
 
-    # Should have sent 3 emails (30, 45, 90)
-    assert len(emails) == 3
+    # With delete-at-45 logic, test flow should trigger exactly:
+    # - 30-day notice
+    # - 45-day deletion notice
+    assert len(emails) == 2
     subjects = {e["subject"] for e in emails}
     assert "Account Inactivity Notice" in subjects
     assert "Account Deactivation Notice" in subjects
-    assert "Account Removal Notice" in subjects
 
 
 @pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
 def test_handler_test_mode_existing_email_raises(monkeypatch):
-    """If the test email already exists, handler should return 500."""
+    """Test handler test mode existing email raises."""
     monkeypatch.setenv("STAGE", "staging")
 
-    # Create an existing user with that email
     User.objects.create(
         first_name="Existing",
         last_name="User",
@@ -183,18 +192,15 @@ def test_handler_test_mode_existing_email_raises(monkeypatch):
     monkeypatch.setattr(checkUserExpiration, "send_email", fake_send_email)
 
     event = {"Test": True, "email": "uat@example.com"}
-
     response = checkUserExpiration.handler(event=event, context={})
 
-    # Because _run_test_expiration_flow raises, handler returns 500
     assert response["status_code"] == 500
     assert "already exists" in response["body"]
-    # No test emails should have been sent
     assert not emails
 
 
 def test_handler_test_mode_forbidden_when_not_staging(monkeypatch):
-    """When STAGE!=staging, Test=true should return 403 and not run the flow."""
+    """Test handler test mode forbidden environments."""
     monkeypatch.setenv("STAGE", "production")
 
     called = {"count": 0}
@@ -202,7 +208,6 @@ def test_handler_test_mode_forbidden_when_not_staging(monkeypatch):
     def fake_check():
         called["count"] += 1
 
-    # Ensure normal path isn't accidentally called for Test=true
     monkeypatch.setattr(checkUserExpiration, "check_user_expiration", fake_check)
 
     emails = []
@@ -213,7 +218,6 @@ def test_handler_test_mode_forbidden_when_not_staging(monkeypatch):
     monkeypatch.setattr(checkUserExpiration, "send_email", fake_send_email)
 
     event = {"Test": True, "email": "uat@example.com"}
-
     response = checkUserExpiration.handler(event=event, context={})
 
     assert response["status_code"] == 403

--- a/backend/src/xfd_django/xfd_api/tests/test_check_user_expiration.py
+++ b/backend/src/xfd_django/xfd_api/tests/test_check_user_expiration.py
@@ -190,7 +190,7 @@ def test_handler_test_mode_existing_email_raises(monkeypatch):
     assert response["status_code"] == 500
     assert "already exists" in response["body"]
     # No test emails should have been sent
-    assert emails == []
+    assert not emails
 
 
 def test_handler_test_mode_forbidden_when_not_staging(monkeypatch):
@@ -219,4 +219,4 @@ def test_handler_test_mode_forbidden_when_not_staging(monkeypatch):
     assert response["status_code"] == 403
     assert "only allowed" in response["body"]
     assert called["count"] == 0
-    assert emails == []
+    assert not emails

--- a/backend/src/xfd_django/xfd_mini_dl/models.py
+++ b/backend/src/xfd_django/xfd_mini_dl/models.py
@@ -1570,6 +1570,12 @@ class User(AutoLengthCheckModel):
         choices=UserType.choices,
         default=UserType.STANDARD,
     )
+    last_notified_30 = models.DateTimeField(
+        db_column="last_notified_30",
+        blank=True,
+        null=True,
+        help_text="Datetime a user was notified for 30 days not logged in.",
+    )
 
     def save(self, *args, **kwargs):
         """Save user with full_name."""


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Fix the failing checkUserExpiration by:
- adjusting column names from camel-case to snake-case
- removing all references to Cognito
- There's no password to reset anymore (no cognito), so the 45 day mark is another warning just like the 30 day
- Adding pytests
- Add ability for AWS admins to test the lambda by passing an object: {"Test: "true, "email": "testemail"}. The testEmail must not already exist in the database and will create a user and update the last_logged_in to simulate all 3 emails then deletion of the user
- Add database field to ensure 30-day email only gets sent once


## 💭 Motivation and context ##

The checkUserExpiration email was not working properly.

## 🧪 Testing ##

Passes pre-commit and pytests. Created more tests to confirm future functionality. Added ability to UAT test as AWS admin.

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [x] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
