### PR TITLE
Removal of Export from OrgMembers Table and Added OrgMembers Unit Test CRASM-3448

### DIFF
--- a/frontend/src/pages/Organization/OrgMembers.tsx
+++ b/frontend/src/pages/Organization/OrgMembers.tsx
@@ -133,7 +133,13 @@ export const OrgMembers: React.FC<OrgMemberProps> = ({
           columns={userRoleColumns}
           slots={{ toolbar: CustomToolbar }}
           slotProps={{
-            toolbar: { exportTitle: organization?.name + ' Members' } as any,
+            toolbar: {
+              disableExport:
+                user?.user_type === 'globalAdmin' ||
+                user?.user_type === 'regionalAdmin' ||
+                user?.user_type === 'globalView',
+              exportTitle: organization?.name + ' Members'
+            } as any,
             basePopper: {
               placement: 'bottom-start'
             }

--- a/frontend/src/pages/Organization/OrgMembers.tsx
+++ b/frontend/src/pages/Organization/OrgMembers.tsx
@@ -134,10 +134,7 @@ export const OrgMembers: React.FC<OrgMemberProps> = ({
           slots={{ toolbar: CustomToolbar }}
           slotProps={{
             toolbar: {
-              disableExport:
-                user?.user_type === 'globalAdmin' ||
-                user?.user_type === 'regionalAdmin' ||
-                user?.user_type === 'globalView',
+              disableExport: true,
               exportTitle: organization?.name + ' Members'
             } as any,
             basePopper: {

--- a/frontend/src/tests/pages/Organization/OrgMembers.test.tsx
+++ b/frontend/src/tests/pages/Organization/OrgMembers.test.tsx
@@ -1,0 +1,499 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from 'test-utils';
+import OrgMembers from '../../../pages/Organization/OrgMembers';
+import { Organization, Role } from 'types';
+import * as logger from '@/utils/logger';
+
+// Mock the logger
+vi.mock('@/utils/logger', () => ({
+  logger: {
+    error: vi.fn()
+  }
+}));
+
+// Mock CustomToolbar to check if disableExport prop is passed correctly
+vi.mock('components/DataGrid/CustomToolbar', () => ({
+  default: ({ disableExport, exportTitle }: any) => (
+    <div data-testid="custom-toolbar">
+      <span data-testid="disable-export">{String(disableExport)}</span>
+      <span data-testid="export-title">{exportTitle}</span>
+      {!disableExport && <button data-testid="export-button">Export</button>}
+    </div>
+  )
+}));
+
+// Mock the dialogs
+vi.mock('components/Dialog/ConfirmDialog', () => ({
+  default: ({ isOpen, onConfirm, onCancel, title }: any) =>
+    isOpen ? (
+      <div data-testid="confirm-dialog">
+        <p>{title}</p>
+        <button onClick={onConfirm} data-testid="confirm-button">
+          Confirm
+        </button>
+        <button onClick={onCancel} data-testid="cancel-button">
+          Cancel
+        </button>
+      </div>
+    ) : null
+}));
+
+vi.mock('components/Dialog/InfoDialog', () => ({
+  default: ({ isOpen, handleClick, title }: any) =>
+    isOpen ? (
+      <div data-testid="info-dialog">
+        {title}
+        <button onClick={handleClick} data-testid="info-ok-button">
+          OK
+        </button>
+      </div>
+    ) : null
+}));
+
+describe('OrgMembers Component', () => {
+  const mockOrganization: Organization = {
+    id: 'org-123',
+    name: 'Test Organization',
+    acronym: 'TEST',
+    root_domains: ['example.com'],
+    ip_blocks: [],
+    is_passive: false,
+    pending_domains: [],
+    type: 'federal',
+    user_roles: []
+  };
+
+  const mockUserRoles: Role[] = [
+    {
+      id: 'role-1',
+      created_at: '2023-01-01T00:00:00Z',
+      updated_at: '2023-01-01T00:00:00Z',
+      role: 'admin',
+      approved: true,
+      user: {
+        id: 'user-1',
+        created_at: '2023-01-01T00:00:00Z',
+        updated_at: '2023-01-01T00:00:00Z',
+        first_name: 'Jane',
+        last_name: 'Doe',
+        full_name: 'Jane Doe',
+        email: 'jane.doe@example.com',
+        user_type: 'standard',
+        invite_pending: false,
+        roles: [],
+        isRegistered: true,
+        apiKeys: [],
+        date_accepted_terms: '2023-01-01T00:00:00Z',
+        accepted_terms_version: 'v1',
+        last_logged_in: '2023-01-01T00:00:00Z',
+        first_login: false
+      },
+      organization: mockOrganization
+    },
+    {
+      id: 'role-2',
+      created_at: '2023-01-01T00:00:00Z',
+      updated_at: '2023-01-01T00:00:00Z',
+      role: 'user',
+      approved: true,
+      user: {
+        id: 'user-2',
+        created_at: '2023-01-01T00:00:00Z',
+        updated_at: '2023-01-01T00:00:00Z',
+        first_name: 'John',
+        last_name: 'Smith',
+        full_name: 'John Smith',
+        email: 'john.smith@example.com',
+        user_type: 'standard',
+        invite_pending: false,
+        roles: [],
+        isRegistered: true,
+        apiKeys: [],
+        date_accepted_terms: '2023-01-01T00:00:00Z',
+        accepted_terms_version: 'v1',
+        last_logged_in: '2023-01-01T00:00:00Z',
+        first_login: false
+      },
+      organization: mockOrganization
+    }
+  ];
+
+  const mockSetUserRoles = vi.fn();
+  const mockApiPost = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Export functionality based on user type', () => {
+    it('should disable export for globalAdmin users', () => {
+      render(
+        <OrgMembers
+          organization={mockOrganization}
+          userRoles={mockUserRoles}
+          setUserRoles={mockSetUserRoles}
+        />,
+        {
+          authContext: {
+            user: {
+              id: 'admin-1',
+              user_type: 'globalAdmin',
+              email: 'admin@example.com',
+              first_name: 'Global',
+              last_name: 'Admin',
+              full_name: 'Global Admin',
+              created_at: '2023-01-01T00:00:00Z',
+              updated_at: '2023-01-01T00:00:00Z',
+              invite_pending: false,
+              roles: [],
+              isRegistered: true,
+              apiKeys: [],
+              date_accepted_terms: '2023-01-01T00:00:00Z',
+              accepted_terms_version: 'v1',
+              last_logged_in: '2023-01-01T00:00:00Z',
+              first_login: false
+            },
+            apiPost: mockApiPost
+          }
+        }
+      );
+
+      const disableExportValue = screen.getByTestId('disable-export');
+      expect(disableExportValue.textContent).toBe('true');
+      expect(screen.queryByTestId('export-button')).not.toBeInTheDocument();
+    });
+
+    it('should disable export for regionalAdmin users', () => {
+      render(
+        <OrgMembers
+          organization={mockOrganization}
+          userRoles={mockUserRoles}
+          setUserRoles={mockSetUserRoles}
+        />,
+        {
+          authContext: {
+            user: {
+              id: 'admin-2',
+              user_type: 'regionalAdmin',
+              email: 'regional@example.com',
+              first_name: 'Regional',
+              last_name: 'Admin',
+              full_name: 'Regional Admin',
+              created_at: '2023-01-01T00:00:00Z',
+              updated_at: '2023-01-01T00:00:00Z',
+              invite_pending: false,
+              roles: [],
+              isRegistered: true,
+              apiKeys: [],
+              date_accepted_terms: '2023-01-01T00:00:00Z',
+              accepted_terms_version: 'v1',
+              last_logged_in: '2023-01-01T00:00:00Z',
+              first_login: false
+            },
+            apiPost: mockApiPost
+          }
+        }
+      );
+
+      const disableExportValue = screen.getByTestId('disable-export');
+      expect(disableExportValue.textContent).toBe('true');
+      expect(screen.queryByTestId('export-button')).not.toBeInTheDocument();
+    });
+
+    it('should disable export for globalView users', () => {
+      render(
+        <OrgMembers
+          organization={mockOrganization}
+          userRoles={mockUserRoles}
+          setUserRoles={mockSetUserRoles}
+        />,
+        {
+          authContext: {
+            user: {
+              id: 'viewer-1',
+              user_type: 'globalView',
+              email: 'viewer@example.com',
+              first_name: 'Global',
+              last_name: 'Viewer',
+              full_name: 'Global Viewer',
+              created_at: '2023-01-01T00:00:00Z',
+              updated_at: '2023-01-01T00:00:00Z',
+              invite_pending: false,
+              roles: [],
+              isRegistered: true,
+              apiKeys: [],
+              date_accepted_terms: '2023-01-01T00:00:00Z',
+              accepted_terms_version: 'v1',
+              last_logged_in: '2023-01-01T00:00:00Z',
+              first_login: false
+            },
+            apiPost: mockApiPost
+          }
+        }
+      );
+
+      const disableExportValue = screen.getByTestId('disable-export');
+      expect(disableExportValue.textContent).toBe('true');
+      expect(screen.queryByTestId('export-button')).not.toBeInTheDocument();
+    });
+
+    it('should enable export for standard users', () => {
+      render(
+        <OrgMembers
+          organization={mockOrganization}
+          userRoles={mockUserRoles}
+          setUserRoles={mockSetUserRoles}
+        />,
+        {
+          authContext: {
+            user: {
+              id: 'user-1',
+              user_type: 'standard',
+              email: 'user@example.com',
+              first_name: 'Standard',
+              last_name: 'User',
+              full_name: 'Standard User',
+              created_at: '2023-01-01T00:00:00Z',
+              updated_at: '2023-01-01T00:00:00Z',
+              invite_pending: false,
+              roles: [],
+              isRegistered: true,
+              apiKeys: [],
+              date_accepted_terms: '2023-01-01T00:00:00Z',
+              accepted_terms_version: 'v1',
+              last_logged_in: '2023-01-01T00:00:00Z',
+              first_login: false
+            },
+            apiPost: mockApiPost
+          }
+        }
+      );
+
+      const disableExportValue = screen.getByTestId('disable-export');
+      expect(disableExportValue.textContent).toBe('false');
+      expect(screen.getByTestId('export-button')).toBeInTheDocument();
+    });
+  });
+
+  describe('Component rendering', () => {
+    it('should render member table with correct data', () => {
+      render(
+        <OrgMembers
+          organization={mockOrganization}
+          userRoles={mockUserRoles}
+          setUserRoles={mockSetUserRoles}
+        />
+      );
+
+      expect(screen.getByText('Jane Doe')).toBeInTheDocument();
+      expect(screen.getByText('john.smith@example.com')).toBeInTheDocument();
+    });
+
+    it('should render export title with organization name', () => {
+      render(
+        <OrgMembers
+          organization={mockOrganization}
+          userRoles={mockUserRoles}
+          setUserRoles={mockSetUserRoles}
+        />
+      );
+
+      const exportTitle = screen.getByTestId('export-title');
+      expect(exportTitle.textContent).toBe('Test Organization Members');
+    });
+
+    it('should render remove buttons for each member', () => {
+      render(
+        <OrgMembers
+          organization={mockOrganization}
+          userRoles={mockUserRoles}
+          setUserRoles={mockSetUserRoles}
+        />
+      );
+
+      // More specific selector to avoid matching other "Remove" text
+      const removeButtons = screen.getAllByRole('button', { name: /Remove/ });
+      expect(removeButtons.length).toBe(mockUserRoles.length);
+    });
+  });
+
+  describe('Remove user functionality', () => {
+    it('should open confirm dialog when remove button is clicked', async () => {
+      render(
+        <OrgMembers
+          organization={mockOrganization}
+          userRoles={mockUserRoles}
+          setUserRoles={mockSetUserRoles}
+        />,
+        {
+          authContext: {
+            apiPost: mockApiPost
+          }
+        }
+      );
+
+      const removeButtons = screen.getAllByLabelText(/Remove Jane Doe/);
+      fireEvent.click(removeButtons[0]);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('confirm-dialog')).toBeInTheDocument();
+      });
+    });
+
+    it('should call API and show success dialog on user removal', async () => {
+      mockApiPost.mockResolvedValueOnce({});
+
+      render(
+        <OrgMembers
+          organization={mockOrganization}
+          userRoles={mockUserRoles}
+          setUserRoles={mockSetUserRoles}
+        />,
+        {
+          authContext: {
+            apiPost: mockApiPost
+          }
+        }
+      );
+
+      // Click remove button
+      const removeButtons = screen.getAllByLabelText(/Remove Jane Doe/);
+      fireEvent.click(removeButtons[0]);
+
+      // Wait for confirm dialog
+      await waitFor(() => {
+        expect(screen.getByTestId('confirm-dialog')).toBeInTheDocument();
+      });
+
+      // Click confirm button
+      const confirmButton = screen.getByTestId('confirm-button');
+      fireEvent.click(confirmButton);
+
+      // Verify API was called
+      await waitFor(() => {
+        expect(mockApiPost).toHaveBeenCalledWith(
+          expect.stringContaining('org-123'),
+          { body: {} }
+        );
+      });
+
+      // Verify success dialog appears
+      await waitFor(() => {
+        expect(screen.getByTestId('info-dialog')).toBeInTheDocument();
+      });
+    });
+
+    it('should handle API error during user removal', async () => {
+      const mockError = new Error('API Error');
+      mockApiPost.mockRejectedValueOnce(mockError);
+
+      render(
+        <OrgMembers
+          organization={mockOrganization}
+          userRoles={mockUserRoles}
+          setUserRoles={mockSetUserRoles}
+        />,
+        {
+          authContext: {
+            apiPost: mockApiPost
+          }
+        }
+      );
+
+      // Click remove button
+      const removeButtons = screen.getAllByLabelText(/Remove Jane Doe/);
+      fireEvent.click(removeButtons[0]);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('confirm-dialog')).toBeInTheDocument();
+      });
+
+      // Click confirm button
+      const confirmButton = screen.getByTestId('confirm-button');
+      fireEvent.click(confirmButton);
+
+      // Verify error was logged
+      await waitFor(() => {
+        expect(logger.logger.error).toHaveBeenCalledWith(
+          'OrgMembers.removeUser failed:',
+          expect.objectContaining({
+            error: mockError,
+            organizationId: 'org-123',
+            roleId: 'role-1'
+          })
+        );
+      });
+    });
+
+    it('should close dialogs when cancel is clicked', async () => {
+      render(
+        <OrgMembers
+          organization={mockOrganization}
+          userRoles={mockUserRoles}
+          setUserRoles={mockSetUserRoles}
+        />,
+        {
+          authContext: {
+            apiPost: mockApiPost
+          }
+        }
+      );
+
+      // Open confirm dialog
+      const removeButtons = screen.getAllByLabelText(/Remove Jane Doe/);
+      fireEvent.click(removeButtons[0]);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('confirm-dialog')).toBeInTheDocument();
+      });
+
+      // Click cancel
+      const cancelButton = screen.getByTestId('cancel-button');
+      fireEvent.click(cancelButton);
+
+      // Verify dialog is closed
+      await waitFor(() => {
+        expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('GlobalView user restrictions', () => {
+    it('should disable row selection for globalView users', () => {
+      const { container } = render(
+        <OrgMembers
+          organization={mockOrganization}
+          userRoles={mockUserRoles}
+          setUserRoles={mockSetUserRoles}
+        />,
+        {
+          authContext: {
+            user: {
+              id: 'viewer-1',
+              user_type: 'globalView',
+              email: 'viewer@example.com',
+              first_name: 'Global',
+              last_name: 'Viewer',
+              full_name: 'Global Viewer',
+              created_at: '2023-01-01T00:00:00Z',
+              updated_at: '2023-01-01T00:00:00Z',
+              invite_pending: false,
+              roles: [],
+              isRegistered: true,
+              apiKeys: [],
+              date_accepted_terms: '2023-01-01T00:00:00Z',
+              accepted_terms_version: 'v1',
+              last_logged_in: '2023-01-01T00:00:00Z',
+              first_login: false
+            }
+          }
+        }
+      );
+
+      // DataGrid with disableRowSelectionOnClick should be rendered
+      const dataGrid = container.querySelector('.MuiDataGrid-root');
+      expect(dataGrid).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/tests/pages/Organization/OrgMembers.test.tsx
+++ b/frontend/src/tests/pages/Organization/OrgMembers.test.tsx
@@ -238,7 +238,7 @@ describe('OrgMembers Component', () => {
       expect(screen.queryByTestId('export-button')).not.toBeInTheDocument();
     });
 
-    it('should enable export for standard users', () => {
+    it('should disable export for standard users', () => {
       render(
         <OrgMembers
           organization={mockOrganization}
@@ -271,8 +271,8 @@ describe('OrgMembers Component', () => {
       );
 
       const disableExportValue = screen.getByTestId('disable-export');
-      expect(disableExportValue.textContent).toBe('false');
-      expect(screen.getByTestId('export-button')).toBeInTheDocument();
+      expect(disableExportValue.textContent).toBe('true');
+      expect(screen.queryByTestId('export-button')).not.toBeInTheDocument();
     });
   });
 
@@ -611,9 +611,9 @@ describe('OrgMembers Component', () => {
       // Component should still render
       expect(screen.getByText('Jane Doe')).toBeInTheDocument();
 
-      // Export should be enabled when user is undefined (default behavior)
+      // Export should be disabled for all users, including undefined
       const disableExportValue = screen.getByTestId('disable-export');
-      expect(disableExportValue.textContent).toBe('false');
+      expect(disableExportValue.textContent).toBe('true');
     });
   });
 });

--- a/frontend/src/tests/pages/Organization/OrgMembers.test.tsx
+++ b/frontend/src/tests/pages/Organization/OrgMembers.test.tsx
@@ -496,4 +496,124 @@ describe('OrgMembers Component', () => {
       expect(dataGrid).toBeInTheDocument();
     });
   });
+
+  describe('Edge cases', () => {
+    it('should handle empty user roles array', () => {
+      render(
+        <OrgMembers
+          organization={mockOrganization}
+          userRoles={[]}
+          setUserRoles={mockSetUserRoles}
+        />
+      );
+
+      // Should still render the table
+      const dataGrid = screen.getByRole('grid');
+      expect(dataGrid).toBeInTheDocument();
+
+      // Should not have any remove buttons
+      const removeButtons = screen.queryAllByRole('button', { name: /Remove/ });
+      expect(removeButtons.length).toBe(0);
+    });
+
+    it('should update userRoles after successful removal', async () => {
+      mockApiPost.mockResolvedValueOnce({});
+
+      render(
+        <OrgMembers
+          organization={mockOrganization}
+          userRoles={mockUserRoles}
+          setUserRoles={mockSetUserRoles}
+        />,
+        {
+          authContext: {
+            apiPost: mockApiPost
+          }
+        }
+      );
+
+      // Click remove button
+      const removeButtons = screen.getAllByLabelText(/Remove Jane Doe/);
+      fireEvent.click(removeButtons[0]);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('confirm-dialog')).toBeInTheDocument();
+      });
+
+      // Click confirm button
+      const confirmButton = screen.getByTestId('confirm-button');
+      fireEvent.click(confirmButton);
+
+      // Wait for success dialog
+      await waitFor(() => {
+        expect(screen.getByTestId('info-dialog')).toBeInTheDocument();
+      });
+
+      // Click OK on info dialog
+      const okButton = screen.getByTestId('info-ok-button');
+      fireEvent.click(okButton);
+
+      // Verify setUserRoles was called to filter out the removed role
+      await waitFor(() => {
+        expect(mockSetUserRoles).toHaveBeenCalled();
+      });
+    });
+
+    it('should call correct API endpoint for role removal', async () => {
+      mockApiPost.mockResolvedValueOnce({});
+
+      render(
+        <OrgMembers
+          organization={mockOrganization}
+          userRoles={mockUserRoles}
+          setUserRoles={mockSetUserRoles}
+        />,
+        {
+          authContext: {
+            apiPost: mockApiPost
+          }
+        }
+      );
+
+      const removeButtons = screen.getAllByLabelText(/Remove Jane Doe/);
+      fireEvent.click(removeButtons[0]);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('confirm-dialog')).toBeInTheDocument();
+      });
+
+      const confirmButton = screen.getByTestId('confirm-button');
+      fireEvent.click(confirmButton);
+
+      await waitFor(() => {
+        expect(mockApiPost).toHaveBeenCalledWith(
+          expect.stringMatching(/org-123.*role-1/),
+          { body: {} }
+        );
+      });
+    });
+
+    it('should handle undefined user gracefully', () => {
+      render(
+        <OrgMembers
+          organization={mockOrganization}
+          userRoles={mockUserRoles}
+          setUserRoles={mockSetUserRoles}
+        />,
+        {
+          authContext: {
+            user: undefined,
+            apiPost: mockApiPost
+          }
+        }
+      );
+
+      // Component should still render
+      expect(screen.getByText('Jane Doe')).toBeInTheDocument();
+
+      // Export should be enabled when user is undefined (default behavior)
+      const disableExportValue = screen.getByTestId('disable-export');
+      expect(disableExportValue.textContent).toBe('false');
+    });
+  });
 });


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

This PR restricts the export functionality on the Organization Members table for users with elevated privileges (Global Admin, Regional Admin, and Global View). The export button is now hidden for these user types when viewing organization members.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

As a Global Admin, Regional Admin or Global View user, I should not be able to download users from a table.

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

1. Log into the CyHy Dashboard
2. Click the Admin Hub dropdown
3. Click Manage Organization from the Admin Hub menu
4. Click a View/Edit icon for an organization
5. Click the Members tab

The export button will now be removed for all Global Admin, Regional Admin or Global View users.

## 📷 Screenshots (if appropriate) ##

<img width="1714" height="846" alt="Screenshot 2025-12-11 at 3 45 58 PM" src="https://github.com/user-attachments/assets/9a919b90-e21b-4b7f-8eea-db3f99372229" />


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
