### PR TITLE
Refactor UserForm and add Integration Tests CRASM-3508

### DIFF
--- a/frontend/src/hooks/useAddUserToOrganization.ts
+++ b/frontend/src/hooks/useAddUserToOrganization.ts
@@ -1,0 +1,31 @@
+import { usePostApi } from './usePostApi';
+import { ENDPOINTS } from '@/constants/endpoints';
+
+type UseAddUserToOrganizationResult = {
+  addUserToOrganization: (
+    organizationId: string | number,
+    userId: string | number,
+    role: string
+  ) => Promise<void>;
+};
+
+export const useAddUserToOrganization = (): UseAddUserToOrganizationResult => {
+  const postApi = usePostApi();
+
+  const addUserToOrganization = async (
+    organizationId: string | number,
+    userId: string | number,
+    role: string
+  ): Promise<void> => {
+    const path = ENDPOINTS.ORGANIZATION_ADD_USER.replace(
+      '{organization_id}',
+      String(organizationId)
+    );
+
+    await postApi(path, {
+      body: { user_id: userId, role }
+    });
+  };
+
+  return { addUserToOrganization };
+};

--- a/frontend/src/hooks/useGetApi.ts
+++ b/frontend/src/hooks/useGetApi.ts
@@ -1,0 +1,19 @@
+import { useAuthContext } from 'context';
+
+type GetInit = {
+  showLoading?: boolean;
+  headers?: HeadersInit;
+  [key: string]: unknown;
+};
+
+export const useGetApi = () => {
+  const { apiGet } = useAuthContext();
+
+  return async <TResponse = unknown>(
+    path: string,
+    init: GetInit = {}
+  ): Promise<TResponse> => {
+    const result = await apiGet(path, init);
+    return result as TResponse;
+  };
+};

--- a/frontend/src/hooks/useOrganizationsByRegion.ts
+++ b/frontend/src/hooks/useOrganizationsByRegion.ts
@@ -1,0 +1,62 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useAuthContext } from 'context';
+import type { Organization } from 'types';
+import { ENDPOINTS } from '@/constants/endpoints';
+import { logger } from '@/utils/logger';
+
+type UseOrganizationsByRegionResult = {
+  organizations: Organization[];
+  isLoading: boolean;
+  errorMessage: string;
+};
+
+export const useOrganizationsByRegion = (
+  regionId: string
+): UseOrganizationsByRegionResult => {
+  const { apiGet } = useAuthContext();
+
+  const [organizations, setOrganizations] = useState<Organization[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const fetchOrganizations = useCallback(async (): Promise<void> => {
+    if (!regionId) {
+      setOrganizations([]);
+      setErrorMessage('');
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const rows = await apiGet<Organization[]>(
+        ENDPOINTS.ORGANIZATIONS_REGION.replace('{region_id}', regionId)
+      );
+      setOrganizations(rows);
+      setErrorMessage('');
+    } catch (error: any) {
+      const detail = error?.response?.data?.detail;
+      setOrganizations([]);
+      setErrorMessage(error.message + (detail ? `. ${detail}` : ''));
+      logger.error('useOrganizationsByRegion failed', { error, regionId });
+    } finally {
+      setIsLoading(false);
+    }
+  }, [apiGet, regionId]);
+
+  useEffect(() => {
+    let isActive = true;
+
+    const run = async () => {
+      if (!isActive) return;
+      await fetchOrganizations();
+    };
+
+    run();
+
+    return () => {
+      isActive = false;
+    };
+  }, [fetchOrganizations]);
+
+  return { organizations, isLoading, errorMessage };
+};

--- a/frontend/src/hooks/usePostApi.ts
+++ b/frontend/src/hooks/usePostApi.ts
@@ -1,0 +1,20 @@
+import { useAuthContext } from 'context';
+
+type PostInit = {
+  body?: unknown;
+  showLoading?: boolean;
+  headers?: HeadersInit;
+  [key: string]: unknown;
+};
+
+export const usePostApi = () => {
+  const { apiPost } = useAuthContext();
+
+  return async <TResponse = unknown>(
+    path: string,
+    init: PostInit = {}
+  ): Promise<TResponse> => {
+    const result = await apiPost(path, init);
+    return result as TResponse;
+  };
+};

--- a/frontend/src/hooks/useRemoveUserFromOrganization.ts
+++ b/frontend/src/hooks/useRemoveUserFromOrganization.ts
@@ -1,0 +1,28 @@
+import { usePostApi } from './usePostApi';
+import { ENDPOINTS } from '@/constants/endpoints';
+
+type UseRemoveUserFromOrganizationResult = {
+  removeUserFromOrganization: (
+    organizationId: string | number,
+    roleId: string | number
+  ) => Promise<void>;
+};
+
+export const useRemoveUserFromOrganization =
+  (): UseRemoveUserFromOrganizationResult => {
+    const postApi = usePostApi();
+
+    const removeUserFromOrganization = async (
+      organizationId: string | number,
+      roleId: string | number
+    ): Promise<void> => {
+      const path = ENDPOINTS.ORGANIZATION_REMOVE_ROLE.replace(
+        '{organization_id}',
+        String(organizationId)
+      ).replace('{role_id}', String(roleId));
+
+      await postApi(path, { body: {} });
+    };
+
+    return { removeUserFromOrganization };
+  };

--- a/frontend/src/hooks/useUpdateUser.ts
+++ b/frontend/src/hooks/useUpdateUser.ts
@@ -1,0 +1,29 @@
+import { usePostApi } from './usePostApi';
+import { ENDPOINTS } from '@/constants/endpoints';
+
+type UpdateUserBody = {
+  first_name?: string;
+  last_name?: string;
+  user_type?: string;
+  email?: string;
+  state: string;
+  region_id: string;
+};
+
+type UseUpdateUserResult = {
+  updateUser: (userId: string | number, body: UpdateUserBody) => Promise<void>;
+};
+
+export const useUpdateUser = (): UseUpdateUserResult => {
+  const postApi = usePostApi();
+
+  const updateUser = async (
+    userId: string | number,
+    body: UpdateUserBody
+  ): Promise<void> => {
+    const path = ENDPOINTS.USER_UPDATE_V2.replace('{user_id}', String(userId));
+    await postApi(path, { body });
+  };
+
+  return { updateUser };
+};

--- a/frontend/src/pages/Users/UserForm.tsx
+++ b/frontend/src/pages/Users/UserForm.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { isEqual } from 'lodash';
 import Alert from '@mui/material/Alert';
 import Autocomplete from '@mui/material/Autocomplete';
@@ -19,8 +19,12 @@ import {
 } from 'types';
 import { useAuthContext } from 'context';
 import { REGION_STATE_MAP, STATE_OPTIONS } from '@/constants/constants';
-import { ENDPOINTS } from '@/constants/endpoints';
 import { logger } from '@/utils/logger';
+
+import { useOrganizationsByRegion } from '@/hooks/useOrganizationsByRegion';
+import { useUpdateUser } from '@/hooks/useUpdateUser';
+import { useAddUserToOrganization } from '@/hooks/useAddUserToOrganization';
+import { useRemoveUserFromOrganization } from '@/hooks/useRemoveUserFromOrganization';
 
 type ApiErrorStates = {
   getUsersError: string;
@@ -95,7 +99,7 @@ const getAllowedDomains = (): string[] => {
     try {
       const parsed = JSON.parse(raw);
       if (Array.isArray(parsed)) {
-        return parsed.map((d) => d.trim()).filter(Boolean);
+        return parsed.map((domain) => domain.trim()).filter(Boolean);
       }
       return [];
     } catch (err) {
@@ -108,7 +112,7 @@ const getAllowedDomains = (): string[] => {
 
   return raw
     .split(',')
-    .map((d: string) => d.trim())
+    .map((domain: string) => domain.trim())
     .filter(Boolean);
 };
 
@@ -126,8 +130,8 @@ const isPermittedEmail = (email: string): boolean => {
 
   const domain = email.slice(atIndex + 1).toLowerCase();
 
-  return allowedDomains.some((d: any) => {
-    const candidate = d.toLowerCase();
+  return allowedDomains.some((allowedDomain: string) => {
+    const candidate = allowedDomain.toLowerCase();
     return domain === candidate;
   });
 };
@@ -175,7 +179,7 @@ const ElevationControl: React.FC<ElevationControlProps> = ({
           type="text"
           fullWidth
           value={confirmGlobalAdminChange}
-          onChange={(e) => setConfirmGlobalAdminChange(e.target.value)}
+          onChange={(event) => setConfirmGlobalAdminChange(event.target.value)}
         />
       </>
     );
@@ -224,7 +228,8 @@ export const UserForm: React.FC<UserFormProps> = ({
   setInfoDialogContent
 }) => {
   const initialValuesRef = useRef(values);
-  const { user, apiGet, apiPost } = useAuthContext();
+  const { user } = useAuthContext();
+
   const [formErrors, setFormErrors] = useState({
     first_name: false,
     last_name: false,
@@ -232,62 +237,48 @@ export const UserForm: React.FC<UserFormProps> = ({
     user_type: false,
     state: false
   });
-  const [organizationsInRegion, setOrganizationsInRegion] = useState<
-    Organization[]
-  >([]);
-  const [isLoading, setIsLoading] = useState(false);
   const [initialOrgIdChange, setInitialOrgIdChange] = useState(false);
   const [confirmGlobalAdminChange, setConfirmGlobalAdminChange] = useState('');
   const [isRoleElevationConfirmed, setIsRoleElevationConfirmed] =
     useState(false);
-  const fetchOrganizations = useCallback(async () => {
-    setIsLoading(true);
-    try {
-      let rows: Organization[] = [];
-      if (values.region_id) {
-        rows = await apiGet<Organization[]>(
-          ENDPOINTS.ORGANIZATIONS_REGION.replace(
-            '{region_id}',
-            values.region_id
-          )
-        );
-      }
-      setOrganizationsInRegion(rows);
-      setApiErrorStates((prev: any) => ({ ...prev, getOrgsError: '' }));
-    } catch (e: any) {
-      setApiErrorStates((prev: any) => ({
-        ...prev,
-        getOrgsError: e.message + ('. ' + e.response?.data?.detail || '')
-      }));
-      logger.error('UserForm.fetchOrganizations failed:', {
-        error: e,
-        regionId: values.region_id
-      });
-    } finally {
-      setIsLoading(false);
-    }
-  }, [apiGet, values.region_id, setApiErrorStates]);
+
+  const {
+    organizations: organizationsInRegion,
+    isLoading,
+    errorMessage: getOrgsErrorMessage
+  } = useOrganizationsByRegion(values.region_id);
 
   useEffect(() => {
-    fetchOrganizations();
-  }, [fetchOrganizations]);
+    setApiErrorStates((previousState: ApiErrorStates) => ({
+      ...previousState,
+      getOrgsError: getOrgsErrorMessage
+    }));
+  }, [getOrgsErrorMessage, setApiErrorStates]);
+
+  const { updateUser } = useUpdateUser();
+  const { addUserToOrganization } = useAddUserToOrganization();
+  const { removeUserFromOrganization } = useRemoveUserFromOrganization();
 
   const getOrgNameById = (id: string) => {
-    const organization = organizationsInRegion.find((org) => org.id === id);
+    const organization = organizationsInRegion.find(
+      (org: Organization) => org.id === id
+    );
     return organization ? organization.name : null;
   };
 
-  const validateForm = (values: UserFormValues) => {
+  const validateForm = (currentValues: UserFormValues) => {
     const nameRegex = /^[A-Za-z\s-']+$/;
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     const newFormErrors = {
       first_name:
-        values.first_name.trim() === '' || !nameRegex.test(values.first_name),
+        currentValues.first_name.trim() === '' ||
+        !nameRegex.test(currentValues.first_name),
       last_name:
-        values.last_name.trim() === '' || !nameRegex.test(values.last_name),
-      email: !emailRegex.test(values.email),
-      user_type: values.user_type.trim() === '',
-      state: values.state.trim() === ''
+        currentValues.last_name.trim() === '' ||
+        !nameRegex.test(currentValues.last_name),
+      email: !emailRegex.test(currentValues.email),
+      user_type: currentValues.user_type.trim() === '',
+      state: currentValues.state.trim() === ''
     };
     setFormErrors(newFormErrors);
     return !Object.values(newFormErrors).some((error) => error);
@@ -324,8 +315,20 @@ export const UserForm: React.FC<UserFormProps> = ({
     if (!validateForm(values) || values.org_id === '') {
       return;
     }
-    const oldRoleLevel = USER_TYPE_MAP[user?.user_type || 'standard'] || 0;
-    const newRoleLevel = USER_TYPE_MAP[values?.user_type] || 0;
+
+    const userId = values.id;
+    if (!userId) {
+      logger.error('UserForm.handleEditUserSubmit: missing user id', {
+        values
+      });
+      return;
+    }
+
+    const oldRoleLevel =
+      USER_TYPE_MAP[user?.user_type as keyof typeof USER_TYPE_MAP] ?? 0;
+    const newRoleLevel =
+      USER_TYPE_MAP[values?.user_type as keyof typeof USER_TYPE_MAP] ?? 0;
+
     if (newRoleLevel > oldRoleLevel) {
       logger.info(
         'UserForm: User role elevation detected, confirming with user',
@@ -339,62 +342,62 @@ export const UserForm: React.FC<UserFormProps> = ({
       state: values.state,
       region_id: values.region_id
     };
+
     if (user?.user_type === 'globalAdmin') {
-      body.first_name = values.first_name;
-      body.last_name = values.last_name;
       body.user_type = values.user_type;
     }
+
     try {
-      await apiPost(
-        ENDPOINTS.USER_UPDATE_V2.replace('{user_id}', String(values.id)),
-        {
-          body
-        }
-      );
+      await updateUser(userId, body);
+
       if (values.originalOrgId !== values.org_id) {
-        if (values.originalOrgId) {
-          await apiPost(
-            ENDPOINTS.ORGANIZATION_REMOVE_ROLE.replace(
-              '{organization_id}',
-              String(values.originalOrgId)
-            ).replace('{role_id}', String(values.originalRoleId)),
-            { body: {} }
+        if (values.originalOrgId && values.originalRoleId) {
+          await removeUserFromOrganization(
+            values.originalOrgId,
+            values.originalRoleId
           );
         }
-        await apiPost(
-          ENDPOINTS.ORGANIZATION_ADD_USER.replace(
-            '{organization_id}',
-            String(values.org_id)
-          ),
-          {
-            body: { user_id: values.id, role: 'user' }
-          }
-        );
+
+        if (values.org_id) {
+          await addUserToOrganization(values.org_id, userId, 'user');
+        } else {
+          logger.error(
+            'UserForm.handleEditUserSubmit: org_id missing when attempting to add user to organization',
+            { values }
+          );
+        }
       }
-      const updatedUsers = users.map((user) =>
-        user.id === values.id
+
+      const updatedUsers = users.map((existingUser: UserType) =>
+        existingUser.id === userId
           ? {
-              ...user,
+              ...existingUser,
               ...values,
               full_name: `${values.first_name} ${values.last_name}`
             }
-          : user
+          : existingUser
       ) as UserType[];
+
       setUsers(updatedUsers);
-      setApiErrorStates({ ...apiErrorStates, getUpdateUserError: '' });
+      setApiErrorStates({
+        ...apiErrorStates,
+        getUpdateUserError: ''
+      });
       setEditUserDialogOpen(false);
       setInfoDialogContent('This user has been successfully updated.');
       setInfoDialogOpen(true);
-    } catch (e: any) {
+    } catch (error: any) {
+      const detail = error?.response?.data?.detail;
       setApiErrorStates({
         ...apiErrorStates,
-        getUpdateUserError: e.message + ('. ' + e.response?.data?.detail || '')
+        getUpdateUserError: error.message + (detail ? `. ${detail}` : '')
       });
       setInfoDialogContent(
         'This user has not been updated. Check the console log for more details.'
       );
+      setInfoDialogOpen(true);
       logger.error('UserForm.handleEditUserSubmit failed:', {
-        error: e,
+        error,
         userId: user?.id
       });
     }
@@ -402,19 +405,19 @@ export const UserForm: React.FC<UserFormProps> = ({
 
   const onTextChange: React.ChangeEventHandler<
     HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
-  > = (e) => {
-    const { name, value } = e.target;
+  > = (event) => {
+    const { name, value } = event.target;
     onChange(name, value);
     const fieldError = validateField(name, value);
-    setFormErrors((prevErrors) => ({
-      ...prevErrors,
+    setFormErrors((previousErrors) => ({
+      ...previousErrors,
       [name]: fieldError
     }));
   };
 
-  const onChange = (name: string, value: any) => {
-    setValues((values: any) => ({
-      ...values,
+  const onChange = (name: string, value: unknown) => {
+    setValues((previousValues: any) => ({
+      ...previousValues,
       [name]: value
     }));
   };
@@ -426,8 +429,8 @@ export const UserForm: React.FC<UserFormProps> = ({
     } else {
       setInitialOrgIdChange(false);
     }
-    setValues((values: any) => ({
-      ...values,
+    setValues((previousValues: any) => ({
+      ...previousValues,
       org_id: orgId,
       org_name: getOrgNameById(orgId)
     }));
@@ -443,9 +446,11 @@ export const UserForm: React.FC<UserFormProps> = ({
 
   const sortedOrgs = organizationsInRegion
     .slice()
-    .sort((a, b) => a.name.localeCompare(b.name));
+    .sort((a: Organization, b: Organization) => a.name.localeCompare(b.name));
 
-  const editedUser = users.find((u) => u.id === values.id);
+  const editedUser = users.find(
+    (userItem: UserType) => userItem.id === values.id
+  );
   const editedUserOrganization =
     editedUser?.roles[0]?.organization?.name || null;
   const userRoleChanged = editedUser?.user_type !== values.user_type;
@@ -534,8 +539,8 @@ export const UserForm: React.FC<UserFormProps> = ({
             disabled={!['globalAdmin'].includes(user?.user_type || '')}
             value={values.state || null}
             onChange={(_, newValue) => {
-              setValues((prev: any) => ({
-                ...prev,
+              setValues((previousValues: any) => ({
+                ...previousValues,
                 state: newValue || '',
                 region_id: newValue ? REGION_STATE_MAP[String(newValue)] : '',
                 org_id: '',
@@ -586,13 +591,18 @@ export const UserForm: React.FC<UserFormProps> = ({
               id="org_id"
               fullWidth
               options={sortedOrgs}
-              getOptionLabel={(option) => {
+              getOptionLabel={(option: Organization) => {
                 if (option.name && option.acronym) {
                   return `${option.name} (${option.acronym})`;
                 }
                 return option.name;
               }}
-              value={sortedOrgs.find((org) => org.id === values.org_id) || null}
+              value={
+                sortedOrgs.find(
+                  (organization: Organization) =>
+                    organization.id === values.org_id
+                ) || null
+              }
               onChange={(_, newValue) => {
                 handleOrgChange(newValue ? newValue.id : '');
               }}
@@ -625,9 +635,9 @@ export const UserForm: React.FC<UserFormProps> = ({
             aria-label="User Type"
             name="user_type"
             value={values.user_type}
-            onChange={(e) => {
+            onChange={(event) => {
               setIsRoleElevationConfirmed(false);
-              onTextChange(e);
+              onTextChange(event);
             }}
           >
             <FormControlLabel
@@ -695,11 +705,12 @@ export const UserForm: React.FC<UserFormProps> = ({
   );
 
   const isNewGlobalAdmin =
-    users?.find((u) => u.id === values.id)?.user_type !== values.user_type &&
-    values.user_type === 'globalAdmin';
+    users?.find((userItem: UserType) => userItem.id === values.id)
+      ?.user_type !== values.user_type && values.user_type === 'globalAdmin';
 
   const isNewRegionalOrGlobalView =
-    users?.find((u) => u.id === values.id)?.user_type !== values.user_type &&
+    users?.find((userItem: UserType) => userItem.id === values.id)
+      ?.user_type !== values.user_type &&
     (values.user_type === 'regionalAdmin' || values.user_type === 'globalView');
 
   const editUserFormDialog = (

--- a/frontend/src/tests/hooks/useAddUserToOrganization.test.ts
+++ b/frontend/src/tests/hooks/useAddUserToOrganization.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useAddUserToOrganization } from '@/hooks/useAddUserToOrganization';
+
+vi.mock('@/hooks/usePostApi', () => ({
+  usePostApi: vi.fn()
+}));
+
+import * as postApiModule from '@/hooks/usePostApi';
+
+describe('useAddUserToOrganization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls the correct endpoint with organization id, user id, and role', async () => {
+    const mockPostApi = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(postApiModule.usePostApi).mockReturnValue(mockPostApi);
+
+    const { result } = renderHook(() => useAddUserToOrganization());
+
+    const organizationId = 'org-123';
+    const userId = 456;
+    const role = 'user';
+
+    await act(async () => {
+      await result.current.addUserToOrganization(organizationId, userId, role);
+    });
+
+    expect(mockPostApi).toHaveBeenCalledTimes(1);
+    const [calledPath, calledInit] = mockPostApi.mock.calls[0];
+
+    expect(String(calledPath)).toContain(organizationId);
+    expect(calledInit.body).toEqual({
+      user_id: userId,
+      role
+    });
+  });
+
+  it('propagates errors from postApi', async () => {
+    const error = new Error('Add user failed');
+    const mockPostApi = vi.fn().mockRejectedValue(error);
+    vi.mocked(postApiModule.usePostApi).mockReturnValue(mockPostApi);
+
+    const { result } = renderHook(() => useAddUserToOrganization());
+
+    await expect(
+      result.current.addUserToOrganization('org-999', 999, 'admin')
+    ).rejects.toThrow('Add user failed');
+  });
+});

--- a/frontend/src/tests/hooks/useAddUserToOrganization.test.ts
+++ b/frontend/src/tests/hooks/useAddUserToOrganization.test.ts
@@ -13,6 +13,10 @@ describe('useAddUserToOrganization', () => {
     vi.clearAllMocks();
   });
 
+  /**
+   * Verifies the hook calls the expected endpoint and sends the correct body
+   * (user_id + role) when adding a user to an organization.
+   */
   it('calls the correct endpoint with organization id, user id, and role', async () => {
     const mockPostApi = vi.fn().mockResolvedValue(undefined);
     vi.mocked(postApiModule.usePostApi).mockReturnValue(mockPostApi);
@@ -37,6 +41,10 @@ describe('useAddUserToOrganization', () => {
     });
   });
 
+  /**
+   * Verifies errors from the underlying postApi call are not swallowed
+   * and are surfaced to the caller.
+   */
   it('propagates errors from postApi', async () => {
     const error = new Error('Add user failed');
     const mockPostApi = vi.fn().mockRejectedValue(error);

--- a/frontend/src/tests/hooks/useGetApi.test.ts
+++ b/frontend/src/tests/hooks/useGetApi.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+import { useGetApi } from '@/hooks/useGetApi';
+import { useAuthContext } from 'context';
+
+vi.mock('context', () => ({
+  useAuthContext: vi.fn()
+}));
+
+describe('useGetApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls apiGet with the provided path and init and returns the result', async () => {
+    const apiGet = vi.fn().mockResolvedValue({ ok: true });
+    vi.mocked(useAuthContext).mockReturnValue({
+      apiGet
+    } as unknown as ReturnType<typeof useAuthContext>);
+
+    const { result } = renderHook(() => useGetApi());
+
+    const response = await result.current<{ ok: boolean }>('/test/path', {
+      showLoading: true,
+      headers: { 'x-test': '1' }
+    });
+
+    expect(apiGet).toHaveBeenCalledTimes(1);
+    expect(apiGet).toHaveBeenCalledWith('/test/path', {
+      showLoading: true,
+      headers: { 'x-test': '1' }
+    });
+    expect(response).toEqual({ ok: true });
+  });
+
+  it('uses an empty init object when none is provided', async () => {
+    const apiGet = vi.fn().mockResolvedValue('value');
+    vi.mocked(useAuthContext).mockReturnValue({
+      apiGet
+    } as unknown as ReturnType<typeof useAuthContext>);
+
+    const { result } = renderHook(() => useGetApi());
+
+    const response = await result.current<string>('/test/path');
+
+    expect(apiGet).toHaveBeenCalledTimes(1);
+    expect(apiGet).toHaveBeenCalledWith('/test/path', {});
+    expect(response).toBe('value');
+  });
+
+  it('propagates errors from apiGet', async () => {
+    const error = new Error('Request failed');
+    const apiGet = vi.fn().mockRejectedValue(error);
+    vi.mocked(useAuthContext).mockReturnValue({
+      apiGet
+    } as unknown as ReturnType<typeof useAuthContext>);
+
+    const { result } = renderHook(() => useGetApi());
+
+    await expect(result.current('/test/path')).rejects.toThrow(
+      'Request failed'
+    );
+  });
+});

--- a/frontend/src/tests/hooks/useGetApi.test.ts
+++ b/frontend/src/tests/hooks/useGetApi.test.ts
@@ -13,6 +13,10 @@ describe('useGetApi', () => {
     vi.clearAllMocks();
   });
 
+  /**
+   * Verifies the hook calls apiGet with the provided path + init options
+   * and returns the resolved response.
+   */
   it('calls apiGet with the provided path and init and returns the result', async () => {
     const apiGet = vi.fn().mockResolvedValue({ ok: true });
     vi.mocked(useAuthContext).mockReturnValue({
@@ -34,6 +38,9 @@ describe('useGetApi', () => {
     expect(response).toEqual({ ok: true });
   });
 
+  /**
+   * Verifies the hook passes an empty init object to apiGet when init is omitted.
+   */
   it('uses an empty init object when none is provided', async () => {
     const apiGet = vi.fn().mockResolvedValue('value');
     vi.mocked(useAuthContext).mockReturnValue({
@@ -49,6 +56,9 @@ describe('useGetApi', () => {
     expect(response).toBe('value');
   });
 
+  /**
+   * Verifies errors from apiGet are not swallowed and bubble up to the caller.
+   */
   it('propagates errors from apiGet', async () => {
     const error = new Error('Request failed');
     const apiGet = vi.fn().mockRejectedValue(error);

--- a/frontend/src/tests/hooks/useOrganizationsByRegion.test.ts
+++ b/frontend/src/tests/hooks/useOrganizationsByRegion.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useOrganizationsByRegion } from '@/hooks/useOrganizationsByRegion';
+import type { Organization } from 'types';
+import { useAuthContext } from 'context';
+
+vi.mock('context', () => ({
+  useAuthContext: vi.fn()
+}));
+
+describe('useOrganizationsByRegion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches organizations for the given region id and exposes them', async () => {
+    const mockOrganizations: Organization[] = [
+      { id: 'org-1', name: 'Org One', acronym: 'ONE' } as Organization
+    ];
+
+    const apiGet = vi.fn().mockResolvedValue(mockOrganizations);
+    vi.mocked(useAuthContext).mockReturnValue({
+      apiGet
+    } as unknown as ReturnType<typeof useAuthContext>);
+
+    const { result } = renderHook(() => useOrganizationsByRegion('region-1'));
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.errorMessage).toBe('');
+    expect(result.current.organizations).toEqual(mockOrganizations);
+
+    expect(apiGet).toHaveBeenCalledTimes(1);
+    const [calledPath] = apiGet.mock.calls[0];
+    expect(String(calledPath)).toContain('region-1');
+  });
+
+  it('does not call API when region id is null', async () => {
+    const apiGet = vi.fn();
+    vi.mocked(useAuthContext).mockReturnValue({
+      apiGet
+    } as unknown as ReturnType<typeof useAuthContext>);
+
+    const { result } = renderHook(() =>
+      useOrganizationsByRegion(null as unknown as string)
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(apiGet).not.toHaveBeenCalled();
+    expect(result.current.organizations).toEqual([]);
+    expect(result.current.errorMessage).toBe('');
+  });
+
+  it('sets errorMessage when API call fails', async () => {
+    const error = Object.assign(new Error('Request failed'), {
+      response: { data: { detail: 'Something went wrong' } }
+    });
+
+    const apiGet = vi.fn().mockRejectedValue(error);
+    vi.mocked(useAuthContext).mockReturnValue({
+      apiGet
+    } as unknown as ReturnType<typeof useAuthContext>);
+
+    const { result } = renderHook(() => useOrganizationsByRegion('region-2'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.organizations).toEqual([]);
+    expect(result.current.errorMessage).toContain('Request failed');
+    expect(result.current.errorMessage).toContain('Something went wrong');
+  });
+});

--- a/frontend/src/tests/hooks/useOrganizationsByRegion.test.ts
+++ b/frontend/src/tests/hooks/useOrganizationsByRegion.test.ts
@@ -13,6 +13,10 @@ describe('useOrganizationsByRegion', () => {
     vi.clearAllMocks();
   });
 
+  /**
+   * Verifies the hook fetches organizations for a given region id and
+   * exposes the returned list after loading completes.
+   */
   it('fetches organizations for the given region id and exposes them', async () => {
     const mockOrganizations: Organization[] = [
       { id: 'org-1', name: 'Org One', acronym: 'ONE' } as Organization
@@ -39,6 +43,10 @@ describe('useOrganizationsByRegion', () => {
     expect(String(calledPath)).toContain('region-1');
   });
 
+  /**
+   * Verifies the hook does not make a request when no region id is provided,
+   * and returns an empty list with no error.
+   */
   it('does not call API when region id is null', async () => {
     const apiGet = vi.fn();
     vi.mocked(useAuthContext).mockReturnValue({
@@ -58,6 +66,10 @@ describe('useOrganizationsByRegion', () => {
     expect(result.current.errorMessage).toBe('');
   });
 
+  /**
+   * Verifies the hook captures request failures and exposes a user-friendly
+   * error message while returning an empty organizations list.
+   */
   it('sets errorMessage when API call fails', async () => {
     const error = Object.assign(new Error('Request failed'), {
       response: { data: { detail: 'Something went wrong' } }

--- a/frontend/src/tests/hooks/usePostApi.test.ts
+++ b/frontend/src/tests/hooks/usePostApi.test.ts
@@ -13,6 +13,10 @@ describe('usePostApi', () => {
     vi.clearAllMocks();
   });
 
+  /**
+   * Verifies the hook calls apiPost with the provided path + init options
+   * and returns the resolved response.
+   */
   it('calls apiPost with the provided path and init and returns the result', async () => {
     const apiPost = vi.fn().mockResolvedValue({ id: '123' });
     vi.mocked(useAuthContext).mockReturnValue({
@@ -37,6 +41,9 @@ describe('usePostApi', () => {
     expect(response).toEqual({ id: '123' });
   });
 
+  /**
+   * Verifies the hook passes an empty init object to apiPost when init is omitted.
+   */
   it('uses an empty init object when none is provided', async () => {
     const apiPost = vi.fn().mockResolvedValue('ok');
     vi.mocked(useAuthContext).mockReturnValue({
@@ -52,6 +59,9 @@ describe('usePostApi', () => {
     expect(response).toBe('ok');
   });
 
+  /**
+   * Verifies errors from apiPost are not swallowed and bubble up to the caller.
+   */
   it('propagates errors from apiPost', async () => {
     const error = new Error('Post failed');
     const apiPost = vi.fn().mockRejectedValue(error);

--- a/frontend/src/tests/hooks/usePostApi.test.ts
+++ b/frontend/src/tests/hooks/usePostApi.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+import { usePostApi } from '@/hooks/usePostApi';
+import { useAuthContext } from 'context';
+
+vi.mock('context', () => ({
+  useAuthContext: vi.fn()
+}));
+
+describe('usePostApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls apiPost with the provided path and init and returns the result', async () => {
+    const apiPost = vi.fn().mockResolvedValue({ id: '123' });
+    vi.mocked(useAuthContext).mockReturnValue({
+      apiPost
+    } as unknown as ReturnType<typeof useAuthContext>);
+
+    const { result } = renderHook(() => usePostApi());
+
+    const payload = { name: 'Jane' };
+    const response = await result.current<{ id: string }>('/test/path', {
+      body: payload,
+      showLoading: true,
+      headers: { 'content-type': 'application/json' }
+    });
+
+    expect(apiPost).toHaveBeenCalledTimes(1);
+    expect(apiPost).toHaveBeenCalledWith('/test/path', {
+      body: payload,
+      showLoading: true,
+      headers: { 'content-type': 'application/json' }
+    });
+    expect(response).toEqual({ id: '123' });
+  });
+
+  it('uses an empty init object when none is provided', async () => {
+    const apiPost = vi.fn().mockResolvedValue('ok');
+    vi.mocked(useAuthContext).mockReturnValue({
+      apiPost
+    } as unknown as ReturnType<typeof useAuthContext>);
+
+    const { result } = renderHook(() => usePostApi());
+
+    const response = await result.current<string>('/test/path');
+
+    expect(apiPost).toHaveBeenCalledTimes(1);
+    expect(apiPost).toHaveBeenCalledWith('/test/path', {});
+    expect(response).toBe('ok');
+  });
+
+  it('propagates errors from apiPost', async () => {
+    const error = new Error('Post failed');
+    const apiPost = vi.fn().mockRejectedValue(error);
+    vi.mocked(useAuthContext).mockReturnValue({
+      apiPost
+    } as unknown as ReturnType<typeof useAuthContext>);
+
+    const { result } = renderHook(() => usePostApi());
+
+    await expect(result.current('/test/path')).rejects.toThrow('Post failed');
+  });
+});

--- a/frontend/src/tests/hooks/useRemoveUserFromOrganization.test.ts
+++ b/frontend/src/tests/hooks/useRemoveUserFromOrganization.test.ts
@@ -13,6 +13,10 @@ describe('useRemoveUserFromOrganization', () => {
     vi.clearAllMocks();
   });
 
+  /**
+   * Verifies the hook calls the expected endpoint (including org + role ids)
+   * and sends an empty body when removing a user from an organization.
+   */
   it('calls the correct endpoint with organization id and role id', async () => {
     const mockPostApi = vi.fn().mockResolvedValue(undefined);
     vi.mocked(postApiModule.usePostApi).mockReturnValue(mockPostApi);
@@ -34,6 +38,10 @@ describe('useRemoveUserFromOrganization', () => {
     expect(calledInit.body).toEqual({});
   });
 
+  /**
+   * Verifies errors from the underlying postApi call are not swallowed
+   * and are surfaced to the caller.
+   */
   it('propagates errors from postApi', async () => {
     const error = new Error('Remove user failed');
     const mockPostApi = vi.fn().mockRejectedValue(error);

--- a/frontend/src/tests/hooks/useRemoveUserFromOrganization.test.ts
+++ b/frontend/src/tests/hooks/useRemoveUserFromOrganization.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useRemoveUserFromOrganization } from '@/hooks/useRemoveUserFromOrganization';
+
+vi.mock('@/hooks/usePostApi', () => ({
+  usePostApi: vi.fn()
+}));
+
+import * as postApiModule from '@/hooks/usePostApi';
+
+describe('useRemoveUserFromOrganization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls the correct endpoint with organization id and role id', async () => {
+    const mockPostApi = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(postApiModule.usePostApi).mockReturnValue(mockPostApi);
+
+    const { result } = renderHook(() => useRemoveUserFromOrganization());
+
+    const organizationId = 'org-123';
+    const roleId = 'role-456';
+
+    await act(async () => {
+      await result.current.removeUserFromOrganization(organizationId, roleId);
+    });
+
+    expect(mockPostApi).toHaveBeenCalledTimes(1);
+    const [calledPath, calledInit] = mockPostApi.mock.calls[0];
+
+    expect(String(calledPath)).toContain(organizationId);
+    expect(String(calledPath)).toContain(roleId);
+    expect(calledInit.body).toEqual({});
+  });
+
+  it('propagates errors from postApi', async () => {
+    const error = new Error('Remove user failed');
+    const mockPostApi = vi.fn().mockRejectedValue(error);
+    vi.mocked(postApiModule.usePostApi).mockReturnValue(mockPostApi);
+
+    const { result } = renderHook(() => useRemoveUserFromOrganization());
+
+    await expect(
+      result.current.removeUserFromOrganization('org-999', 'role-999')
+    ).rejects.toThrow('Remove user failed');
+  });
+});

--- a/frontend/src/tests/hooks/useUpdateUser.test.ts
+++ b/frontend/src/tests/hooks/useUpdateUser.test.ts
@@ -13,6 +13,10 @@ describe('useUpdateUser', () => {
     vi.clearAllMocks();
   });
 
+  /**
+   * Verifies the hook calls the update endpoint with the correct user id
+   * and passes the provided body as the request payload.
+   */
   it('calls the correct endpoint with the provided body', async () => {
     const mockPostApi = vi.fn().mockResolvedValue(undefined);
 
@@ -41,6 +45,10 @@ describe('useUpdateUser', () => {
     expect(calledInit.body).toEqual(body);
   });
 
+  /**
+   * Verifies the hook does not swallow errors and re-throws failures
+   * from the underlying post request.
+   */
   it('propagates errors from postApi', async () => {
     const error = new Error('Request failed');
     const mockPostApi = vi.fn().mockRejectedValue(error);

--- a/frontend/src/tests/hooks/useUpdateUser.test.ts
+++ b/frontend/src/tests/hooks/useUpdateUser.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useUpdateUser } from '@/hooks/useUpdateUser';
+
+vi.mock('@/hooks/usePostApi', () => ({
+  usePostApi: vi.fn()
+}));
+
+import * as postApiModule from '@/hooks/usePostApi';
+
+describe('useUpdateUser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls the correct endpoint with the provided body', async () => {
+    const mockPostApi = vi.fn().mockResolvedValue(undefined);
+
+    // usePostApi is a vi.fn() because of the vi.mock above
+    vi.mocked(postApiModule.usePostApi).mockReturnValue(mockPostApi);
+
+    const { result } = renderHook(() => useUpdateUser());
+
+    const body = {
+      first_name: 'Jane',
+      last_name: 'Doe',
+      state: 'VA',
+      region_id: '1',
+      user_type: 'standard'
+    };
+
+    await act(async () => {
+      await result.current.updateUser(123, body);
+    });
+
+    expect(mockPostApi).toHaveBeenCalledTimes(1);
+
+    const [calledPath, calledInit] = mockPostApi.mock.calls[0];
+
+    expect(String(calledPath)).toContain('/123');
+    expect(calledInit.body).toEqual(body);
+  });
+
+  it('propagates errors from postApi', async () => {
+    const error = new Error('Request failed');
+    const mockPostApi = vi.fn().mockRejectedValue(error);
+
+    vi.mocked(postApiModule.usePostApi).mockReturnValue(mockPostApi);
+
+    const { result } = renderHook(() => useUpdateUser());
+
+    await expect(
+      result.current.updateUser(456, {
+        first_name: 'John',
+        last_name: 'Smith',
+        state: 'CA',
+        region_id: '2'
+      })
+    ).rejects.toThrow('Request failed');
+  });
+});

--- a/frontend/src/tests/pages/Users/UserForm.test.tsx
+++ b/frontend/src/tests/pages/Users/UserForm.test.tsx
@@ -177,6 +177,11 @@ describe('UserForm', () => {
     mockRemoveUserFromOrganization.mockResolvedValue(undefined);
   });
 
+  /**
+   * Verifies a successful submit calls updateUser with the correct payload,
+   * does not change org membership when org_id is unchanged, updates the users
+   * list, closes the dialog, and shows a success message.
+   */
   it('submits successfully and updates users list', async () => {
     const user = userEvent.setup();
 
@@ -223,6 +228,10 @@ describe('UserForm', () => {
     expect(mockSetInfoDialogOpen).toHaveBeenCalledWith(true);
   });
 
+  /**
+   * Verifies a failed update surfaces the error to UI state by calling
+   * setApiErrorStates and showing a failure message to the user.
+   */
   it('handles updateUser error and sets error state', async () => {
     const user = userEvent.setup();
 
@@ -261,6 +270,10 @@ describe('UserForm', () => {
     expect(mockSetInfoDialogOpen).toHaveBeenCalledWith(true);
   });
 
+  /**
+   * Verifies when org_id changes in edit mode, the form removes the user from
+   * the original organization/role and then adds them to the new organization.
+   */
   it('removes and re-adds user to organization when org_id changes', async () => {
     const user = userEvent.setup();
 
@@ -319,6 +332,10 @@ describe('UserForm', () => {
     expect(mockAddUserToOrganization).toHaveBeenCalledWith('org-2', 1, 'user');
   });
 
+  /**
+   * Verifies the email field is locked in edit mode to prevent changing
+   * an existing user’s email address.
+   */
   it('keeps email disabled in edit mode', () => {
     render(
       <UserForm
@@ -339,6 +356,10 @@ describe('UserForm', () => {
     expect(emailInput).toBeDisabled();
   });
 
+  /**
+   * Verifies first name validation rejects numeric input and shows the
+   * expected helper text.
+   */
   it('shows validation error for invalid first name', async () => {
     const user = userEvent.setup();
 
@@ -372,6 +393,10 @@ describe('UserForm', () => {
     ).toBeInTheDocument();
   });
 
+  /**
+   * Verifies the organization field is required and shows a helper error
+   * when org_id is empty.
+   */
   it('shows organization required error helper when org_id is empty', () => {
     const valuesWithoutOrg = {
       ...baseValues,
@@ -397,6 +422,10 @@ describe('UserForm', () => {
     expect(screen.getByText('Organization is required')).toBeInTheDocument();
   });
 
+  /**
+   * Verifies the update error alert renders when getUpdateUserError is present,
+   * so backend/update failures are visible to the user.
+   */
   it('renders update error alert when getUpdateUserError is present', () => {
     const apiErrorStatesWithUpdateError = {
       ...baseApiErrorStates,
@@ -426,6 +455,10 @@ describe('UserForm', () => {
     ).toBeInTheDocument();
   });
 
+  /**
+   * Verifies org fetch failures propagate into apiErrorStates.getOrgsError
+   * via setApiErrorStates so the UI can show org-loading errors.
+   */
   it('updates getOrgsError via setApiErrorStates when org fetch fails', async () => {
     const errorMessage = 'Failed to fetch orgs. Bad request';
 
@@ -465,6 +498,9 @@ describe('UserForm', () => {
     expect(updatedState.getOrgsError).toBe(errorMessage);
   });
 
+  /**
+   * Verifies create mode starts with empty inputs for new user creation.
+   */
   it('in create mode initializes fields as empty', () => {
     const createModeValues = {
       ...baseValues,
@@ -502,6 +538,10 @@ describe('UserForm', () => {
     expect(emailInput).toHaveValue('');
   });
 
+  /**
+   * Verifies edit mode pre-populates the form with the selected user’s
+   * existing data.
+   */
   it('in edit mode pre-populates all existing user data', () => {
     render(
       <UserForm
@@ -527,6 +567,10 @@ describe('UserForm', () => {
     expect(emailInput).toHaveValue('jane@example.com');
   });
 
+  /**
+   * Verifies create-mode email validation rejects an invalid email format,
+   * shows the helper text, and prevents submission.
+   */
   it('shows validation error for invalid email format in create mode', async () => {
     const user = userEvent.setup();
 
@@ -566,6 +610,10 @@ describe('UserForm', () => {
     expect(mockUpdateUser).not.toHaveBeenCalled();
   });
 
+  /**
+   * Verifies the confirm dialog is disabled during an in-flight submission
+   * to prevent duplicate requests, and re-enables/closes when finished.
+   */
   it('disables the dialog while submission is in progress', async () => {
     const user = userEvent.setup();
 

--- a/frontend/src/tests/pages/Users/UserForm.test.tsx
+++ b/frontend/src/tests/pages/Users/UserForm.test.tsx
@@ -1,0 +1,608 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from 'test-utils';
+import userEvent from '@testing-library/user-event';
+import type { Organization } from 'types';
+import UserForm from '@/pages/Users/UserForm';
+
+// ---- mock handles ----
+const mockUseAuthContext = vi.fn();
+const mockUseOrganizationsByRegion = vi.fn();
+const mockUpdateUser = vi.fn();
+const mockAddUserToOrganization = vi.fn();
+const mockRemoveUserFromOrganization = vi.fn();
+
+vi.mock('context', async () => {
+  const actual = await vi.importActual<any>('context');
+
+  return {
+    ...actual,
+    useAuthContext: () => mockUseAuthContext()
+  };
+});
+
+vi.mock('@/hooks/useOrganizationsByRegion', () => ({
+  useOrganizationsByRegion: (...args: unknown[]) =>
+    mockUseOrganizationsByRegion(...args)
+}));
+
+vi.mock('@/hooks/useUpdateUser', () => ({
+  useUpdateUser: () => ({ updateUser: mockUpdateUser })
+}));
+
+vi.mock('@/hooks/useAddUserToOrganization', () => ({
+  useAddUserToOrganization: () => ({
+    addUserToOrganization: mockAddUserToOrganization
+  })
+}));
+
+vi.mock('@/hooks/useRemoveUserFromOrganization', () => ({
+  useRemoveUserFromOrganization: () => ({
+    removeUserFromOrganization: mockRemoveUserFromOrganization
+  })
+}));
+
+vi.mock('components/Dialog/AnimatedConfirmDialog', () => ({
+  __esModule: true,
+  default: ({
+    isOpen,
+    onConfirm,
+    onCancel,
+    title,
+    content,
+    disabled
+  }: {
+    isOpen: boolean;
+    onConfirm: () => void;
+    onCancel: () => void;
+    title: React.ReactNode;
+    content: React.ReactNode;
+    disabled?: boolean;
+  }) =>
+    isOpen ? (
+      <div
+        data-testid="user-form-dialog"
+        data-disabled={disabled ? 'true' : 'false'}
+      >
+        <h2>{title}</h2>
+        <div data-testid="user-form-dialog-content">{content}</div>
+        <button
+          data-testid="user-form-confirm"
+          type="button"
+          onClick={onConfirm}
+        >
+          Confirm
+        </button>
+        <button data-testid="user-form-cancel" type="button" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    ) : null
+}));
+
+// -------------------- Helpers --------------------
+
+const makeOrganization = (
+  overrides: Partial<Organization> = {}
+): Organization => ({
+  id: 'default-org-id',
+  name: 'Default Org',
+  acronym: 'DEF',
+  root_domains: [],
+  ip_blocks: [],
+  is_passive: false,
+  pending_domains: [],
+  type: '' as any,
+  ...overrides
+});
+
+// -------------------- Shared test data --------------------
+
+const baseApiErrorStates = {
+  getUsersError: '',
+  getAddUserError: '',
+  getDeleteError: '',
+  getUpdateUserError: '',
+  getOrgsError: ''
+};
+
+const baseValues: any = {
+  id: 1,
+  first_name: 'Jane',
+  last_name: 'Doe',
+  email: 'jane@example.com',
+  user_type: 'standard',
+  state: 'VA',
+  region_id: '1',
+  org_id: 'org-1',
+  org_name: 'Org One',
+  originalOrgId: 'org-1',
+  originalRoleId: 'role-1'
+};
+
+const baseUsers: any[] = [
+  {
+    id: 1,
+    first_name: 'Jane',
+    last_name: 'Doe',
+    email: 'jane@example.com',
+    user_type: 'standard',
+    full_name: 'Jane Doe',
+    roles: [
+      {
+        organization: { name: 'Org One' }
+      }
+    ],
+    state: 'VA',
+    region_id: '1',
+    org_id: 'org-1'
+  }
+];
+
+// -------------------- Tests --------------------
+
+describe('UserForm', () => {
+  const mockSetUsers = vi.fn();
+  const mockSetValues = vi.fn();
+  const mockSetEditUserDialogOpen = vi.fn();
+  const mockSetApiErrorStates = vi.fn();
+  const mockSetInfoDialogOpen = vi.fn();
+  const mockSetInfoDialogContent = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUseAuthContext.mockReturnValue({
+      user: {
+        id: 'auth-user-id',
+        user_type: 'globalAdmin'
+      }
+    } as any);
+
+    mockUseOrganizationsByRegion.mockReturnValue({
+      organizations: [
+        makeOrganization({
+          id: 'org-1',
+          name: 'Org One',
+          acronym: 'ONE'
+        })
+      ],
+      isLoading: false,
+      errorMessage: '',
+      refetch: vi.fn()
+    });
+
+    mockUpdateUser.mockResolvedValue(undefined);
+    mockAddUserToOrganization.mockResolvedValue(undefined);
+    mockRemoveUserFromOrganization.mockResolvedValue(undefined);
+  });
+
+  it('submits successfully and updates users list', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <UserForm
+        users={baseUsers}
+        setUsers={mockSetUsers}
+        values={baseValues}
+        setValues={mockSetValues}
+        editUserDialogOpen={true}
+        setEditUserDialogOpen={mockSetEditUserDialogOpen}
+        apiErrorStates={baseApiErrorStates}
+        setApiErrorStates={mockSetApiErrorStates}
+        setInfoDialogOpen={mockSetInfoDialogOpen}
+        setInfoDialogContent={mockSetInfoDialogContent}
+      />
+    );
+
+    const confirmButton = await screen.findByTestId('user-form-confirm');
+    await user.click(confirmButton);
+
+    await waitFor(() => {
+      expect(mockUpdateUser).toHaveBeenCalledTimes(1);
+    });
+
+    const [calledId, calledBody] = mockUpdateUser.mock.calls[0];
+
+    expect(calledId).toBe(1);
+    expect(calledBody).toMatchObject({
+      first_name: 'Jane',
+      last_name: 'Doe',
+      state: 'VA',
+      region_id: '1'
+    });
+
+    expect(mockRemoveUserFromOrganization).not.toHaveBeenCalled();
+    expect(mockAddUserToOrganization).not.toHaveBeenCalled();
+
+    expect(mockSetUsers).toHaveBeenCalledTimes(1);
+    expect(mockSetEditUserDialogOpen).toHaveBeenCalledWith(false);
+    expect(mockSetInfoDialogContent).toHaveBeenCalledWith(
+      'This user has been successfully updated.'
+    );
+    expect(mockSetInfoDialogOpen).toHaveBeenCalledWith(true);
+  });
+
+  it('handles updateUser error and sets error state', async () => {
+    const user = userEvent.setup();
+
+    const error = Object.assign(new Error('Update failed'), {
+      response: { data: { detail: 'Bad things happened' } }
+    });
+
+    mockUpdateUser.mockRejectedValueOnce(error);
+
+    render(
+      <UserForm
+        users={baseUsers}
+        setUsers={mockSetUsers}
+        values={baseValues}
+        setValues={mockSetValues}
+        editUserDialogOpen={true}
+        setEditUserDialogOpen={mockSetEditUserDialogOpen}
+        apiErrorStates={baseApiErrorStates}
+        setApiErrorStates={mockSetApiErrorStates}
+        setInfoDialogOpen={mockSetInfoDialogOpen}
+        setInfoDialogContent={mockSetInfoDialogContent}
+      />
+    );
+
+    const confirmButton = await screen.findByTestId('user-form-confirm');
+    await user.click(confirmButton);
+
+    await waitFor(() => {
+      expect(mockUpdateUser).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockSetApiErrorStates).toHaveBeenCalled();
+    expect(mockSetInfoDialogContent).toHaveBeenCalledWith(
+      'This user has not been updated. Check the console log for more details.'
+    );
+    expect(mockSetInfoDialogOpen).toHaveBeenCalledWith(true);
+  });
+
+  it('removes and re-adds user to organization when org_id changes', async () => {
+    const user = userEvent.setup();
+
+    const changedValues = {
+      ...baseValues,
+      org_id: 'org-2',
+      org_name: 'Org Two',
+      originalOrgId: 'org-1',
+      originalRoleId: 'role-1'
+    };
+
+    mockUseOrganizationsByRegion.mockReturnValue({
+      organizations: [
+        makeOrganization({
+          id: 'org-1',
+          name: 'Org One',
+          acronym: 'ONE'
+        }),
+        makeOrganization({
+          id: 'org-2',
+          name: 'Org Two',
+          acronym: 'TWO'
+        })
+      ],
+      isLoading: false,
+      errorMessage: '',
+      refetch: vi.fn()
+    });
+
+    render(
+      <UserForm
+        users={baseUsers}
+        setUsers={mockSetUsers}
+        values={changedValues}
+        setValues={mockSetValues}
+        editUserDialogOpen={true}
+        setEditUserDialogOpen={mockSetEditUserDialogOpen}
+        apiErrorStates={baseApiErrorStates}
+        setApiErrorStates={mockSetApiErrorStates}
+        setInfoDialogOpen={mockSetInfoDialogOpen}
+        setInfoDialogContent={mockSetInfoDialogContent}
+      />
+    );
+
+    const confirmButton = await screen.findByTestId('user-form-confirm');
+    await user.click(confirmButton);
+
+    await waitFor(() => {
+      expect(mockUpdateUser).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockRemoveUserFromOrganization).toHaveBeenCalledWith(
+      'org-1',
+      'role-1'
+    );
+    expect(mockAddUserToOrganization).toHaveBeenCalledWith('org-2', 1, 'user');
+  });
+
+  it('keeps email disabled in edit mode', () => {
+    render(
+      <UserForm
+        users={baseUsers}
+        setUsers={mockSetUsers}
+        values={baseValues}
+        setValues={mockSetValues}
+        editUserDialogOpen={true}
+        setEditUserDialogOpen={mockSetEditUserDialogOpen}
+        apiErrorStates={baseApiErrorStates}
+        setApiErrorStates={mockSetApiErrorStates}
+        setInfoDialogOpen={mockSetInfoDialogOpen}
+        setInfoDialogContent={mockSetInfoDialogContent}
+      />
+    );
+
+    const emailInput = screen.getByPlaceholderText('Enter an Email');
+    expect(emailInput).toBeDisabled();
+  });
+
+  it('shows validation error for invalid first name', async () => {
+    const user = userEvent.setup();
+
+    const valuesWithInvalidFirstName = {
+      ...baseValues,
+      first_name: '1234'
+    };
+
+    render(
+      <UserForm
+        users={baseUsers}
+        setUsers={mockSetUsers}
+        values={valuesWithInvalidFirstName}
+        setValues={mockSetValues}
+        editUserDialogOpen={true}
+        setEditUserDialogOpen={mockSetEditUserDialogOpen}
+        apiErrorStates={baseApiErrorStates}
+        setApiErrorStates={mockSetApiErrorStates}
+        setInfoDialogOpen={mockSetInfoDialogOpen}
+        setInfoDialogContent={mockSetInfoDialogContent}
+      />
+    );
+
+    const confirmButton = await screen.findByTestId('user-form-confirm');
+    await user.click(confirmButton);
+
+    expect(
+      await screen.findByText(
+        'First Name is required and cannot contain numbers'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('shows organization required error helper when org_id is empty', () => {
+    const valuesWithoutOrg = {
+      ...baseValues,
+      org_id: '',
+      org_name: ''
+    };
+
+    render(
+      <UserForm
+        users={baseUsers}
+        setUsers={mockSetUsers}
+        values={valuesWithoutOrg}
+        setValues={mockSetValues}
+        editUserDialogOpen={true}
+        setEditUserDialogOpen={mockSetEditUserDialogOpen}
+        apiErrorStates={baseApiErrorStates}
+        setApiErrorStates={mockSetApiErrorStates}
+        setInfoDialogOpen={mockSetInfoDialogOpen}
+        setInfoDialogContent={mockSetInfoDialogContent}
+      />
+    );
+
+    expect(screen.getByText('Organization is required')).toBeInTheDocument();
+  });
+
+  it('renders update error alert when getUpdateUserError is present', () => {
+    const apiErrorStatesWithUpdateError = {
+      ...baseApiErrorStates,
+      getUpdateUserError: 'Something went wrong updating user'
+    };
+
+    render(
+      <UserForm
+        users={baseUsers}
+        setUsers={mockSetUsers}
+        values={baseValues}
+        setValues={mockSetValues}
+        editUserDialogOpen={true}
+        setEditUserDialogOpen={mockSetEditUserDialogOpen}
+        apiErrorStates={apiErrorStatesWithUpdateError}
+        setApiErrorStates={mockSetApiErrorStates}
+        setInfoDialogOpen={mockSetInfoDialogOpen}
+        setInfoDialogContent={mockSetInfoDialogContent}
+      />
+    );
+
+    expect(
+      screen.getByText(/Error updating user in the database:/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Something went wrong updating user/i)
+    ).toBeInTheDocument();
+  });
+
+  it('updates getOrgsError via setApiErrorStates when org fetch fails', async () => {
+    const errorMessage = 'Failed to fetch orgs. Bad request';
+
+    mockUseOrganizationsByRegion.mockReturnValue({
+      organizations: [],
+      isLoading: false,
+      errorMessage,
+      refetch: vi.fn()
+    });
+
+    render(
+      <UserForm
+        users={baseUsers}
+        setUsers={mockSetUsers}
+        values={baseValues}
+        setValues={mockSetValues}
+        editUserDialogOpen={true}
+        setEditUserDialogOpen={mockSetEditUserDialogOpen}
+        apiErrorStates={baseApiErrorStates}
+        setApiErrorStates={mockSetApiErrorStates}
+        setInfoDialogOpen={mockSetInfoDialogOpen}
+        setInfoDialogContent={mockSetInfoDialogContent}
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockSetApiErrorStates).toHaveBeenCalled();
+    });
+
+    const updater = mockSetApiErrorStates.mock.calls[0][0] as (
+      previous: typeof baseApiErrorStates
+    ) => typeof baseApiErrorStates;
+
+    expect(typeof updater).toBe('function');
+
+    const updatedState = updater(baseApiErrorStates);
+    expect(updatedState.getOrgsError).toBe(errorMessage);
+  });
+
+  it('in create mode initializes fields as empty', () => {
+    const createModeValues = {
+      ...baseValues,
+      id: undefined,
+      first_name: '',
+      last_name: '',
+      email: '',
+      org_id: '',
+      org_name: '',
+      originalOrgId: '',
+      originalRoleId: ''
+    };
+
+    render(
+      <UserForm
+        users={baseUsers}
+        setUsers={mockSetUsers}
+        values={createModeValues}
+        setValues={mockSetValues}
+        editUserDialogOpen={true}
+        setEditUserDialogOpen={mockSetEditUserDialogOpen}
+        apiErrorStates={baseApiErrorStates}
+        setApiErrorStates={mockSetApiErrorStates}
+        setInfoDialogOpen={mockSetInfoDialogOpen}
+        setInfoDialogContent={mockSetInfoDialogContent}
+      />
+    );
+
+    const firstNameInput = screen.getByPlaceholderText('Enter a First Name');
+    const lastNameInput = screen.getByPlaceholderText('Enter a Last Name');
+    const emailInput = screen.getByPlaceholderText('Enter an Email');
+
+    expect(firstNameInput).toHaveValue('');
+    expect(lastNameInput).toHaveValue('');
+    expect(emailInput).toHaveValue('');
+  });
+
+  it('in edit mode pre-populates all existing user data', () => {
+    render(
+      <UserForm
+        users={baseUsers}
+        setUsers={mockSetUsers}
+        values={baseValues}
+        setValues={mockSetValues}
+        editUserDialogOpen={true}
+        setEditUserDialogOpen={mockSetEditUserDialogOpen}
+        apiErrorStates={baseApiErrorStates}
+        setApiErrorStates={mockSetApiErrorStates}
+        setInfoDialogOpen={mockSetInfoDialogOpen}
+        setInfoDialogContent={mockSetInfoDialogContent}
+      />
+    );
+
+    const firstNameInput = screen.getByPlaceholderText('Enter a First Name');
+    const lastNameInput = screen.getByPlaceholderText('Enter a Last Name');
+    const emailInput = screen.getByPlaceholderText('Enter an Email');
+
+    expect(firstNameInput).toHaveValue('Jane');
+    expect(lastNameInput).toHaveValue('Doe');
+    expect(emailInput).toHaveValue('jane@example.com');
+  });
+
+  it('shows validation error for invalid email format in create mode', async () => {
+    const user = userEvent.setup();
+
+    const valuesWithInvalidEmail = {
+      ...baseValues,
+      id: undefined,
+      email: 'not-a-valid-email',
+      org_id: 'org-1',
+      originalOrgId: '',
+      originalRoleId: ''
+    };
+
+    render(
+      <UserForm
+        users={baseUsers}
+        setUsers={mockSetUsers}
+        values={valuesWithInvalidEmail}
+        setValues={mockSetValues}
+        editUserDialogOpen={true}
+        setEditUserDialogOpen={mockSetEditUserDialogOpen}
+        apiErrorStates={baseApiErrorStates}
+        setApiErrorStates={mockSetApiErrorStates}
+        setInfoDialogOpen={mockSetInfoDialogOpen}
+        setInfoDialogContent={mockSetInfoDialogContent}
+      />
+    );
+
+    const confirmButton = await screen.findByTestId('user-form-confirm');
+    await user.click(confirmButton);
+
+    expect(
+      await screen.findByText(
+        'Email is required and must be in the correct format'
+      )
+    ).toBeInTheDocument();
+
+    expect(mockUpdateUser).not.toHaveBeenCalled();
+  });
+
+  it('disables the dialog while submission is in progress', async () => {
+    const user = userEvent.setup();
+
+    let resolveUpdate: () => void;
+    const updatePromise = new Promise<void>((resolve) => {
+      resolveUpdate = resolve;
+    });
+
+    mockUpdateUser.mockReturnValueOnce(
+      updatePromise as unknown as Promise<void>
+    );
+
+    render(
+      <UserForm
+        users={baseUsers}
+        setUsers={mockSetUsers}
+        values={baseValues}
+        setValues={mockSetValues}
+        editUserDialogOpen={true}
+        setEditUserDialogOpen={mockSetEditUserDialogOpen}
+        apiErrorStates={baseApiErrorStates}
+        setApiErrorStates={mockSetApiErrorStates}
+        setInfoDialogOpen={mockSetInfoDialogOpen}
+        setInfoDialogContent={mockSetInfoDialogContent}
+      />
+    );
+
+    const confirmButton = await screen.findByTestId('user-form-confirm');
+    await user.click(confirmButton);
+
+    const dialog = await screen.findByTestId('user-form-dialog');
+    expect(dialog).toHaveAttribute('data-disabled', 'true');
+
+    resolveUpdate!();
+
+    await waitFor(() => {
+      expect(mockSetEditUserDialogOpen).toHaveBeenCalledWith(false);
+    });
+  });
+});


### PR DESCRIPTION


## 🗣 Description ##

Refactored UserForm.tsx to move repeated request logic into reusable API hooks (useGetApi, usePostApi) and user/org hooks (useUpdateUser, useOrganizationsByRegion, useAddUserToOrganization, useRemoveUserFromOrganization). Added unit tests for each hook and a UserForm test to cover create/edit initialization, validation, submit payloads, loading/disabled states, and success/error handling to prevent regressions in admin user workflows.


## 💭 Motivation and context ##

UserForm.tsx previously mixed UI and API logic, which risked duplicated/inconsistent request code across the app. This refactor moves shared request behavior into `useGetApi`/`usePostApi` and creates reusable user hooks, while adding tests that cover validation, create vs. edit initialization, and success/failure + loading states to prevent regressions in admin workflows.

## 🧪 Testing ##

Tested Locally

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.

