### PR TITLE
CRASM-3585: Update Findings Library DataGrid column visibility for enhanced privacy and usability

### DIFF
--- a/frontend/src/pages/Domains/Domains.tsx
+++ b/frontend/src/pages/Domains/Domains.tsx
@@ -249,7 +249,24 @@ export const Domains: React.FC = () => {
     const allColumns = [
       {
         field: 'name',
-        headerName: 'IP Addresses',
+        headerName: 'Domain Name',
+        minWidth: 100,
+        flex: 1,
+        filterOperators: stringFilterOperators,
+        renderCell: (cellValues: GridRenderCellParams<DomainRow>) => {
+          return (
+            <Box
+              component="span"
+              aria-label={`Domain Name: ${cellValues.row.name}`}
+            >
+              {cellValues.row.name}
+            </Box>
+          );
+        }
+      },
+      {
+        field: 'ip',
+        headerName: 'IP Address',
         minWidth: 100,
         flex: 1,
         filterOperators: stringFilterOperators,
@@ -274,7 +291,7 @@ export const Domains: React.FC = () => {
           return (
             <Box
               component="span"
-              aria-label={`Organization for IP ${cellValues.row.ip}: ${cellValues.row.organization_name}`}
+              aria-label={`Organization for Domain ${cellValues.row.name}: ${cellValues.row.organization_name}`}
             >
               {cellValues.row.organization_name}
             </Box>
@@ -291,7 +308,7 @@ export const Domains: React.FC = () => {
           return (
             <Box
               component="span"
-              aria-label={`Ports for IP ${cellValues.row.ip}: ${cellValues.row.ports_preview}`}
+              aria-label={`Ports for Domain ${cellValues.row.name}: ${cellValues.row.ports_preview}`}
             >
               {cellValues.row.ports_preview}
             </Box>
@@ -308,7 +325,7 @@ export const Domains: React.FC = () => {
           return (
             <Box
               component="span"
-              aria-label={`Services for IP ${cellValues.row.ip}: ${cellValues.row.services_preview}`}
+              aria-label={`Services for Domain ${cellValues.row.name}: ${cellValues.row.services_preview}`}
             >
               {cellValues.row.services_preview}
             </Box>
@@ -378,7 +395,7 @@ export const Domains: React.FC = () => {
         renderCell: (cellValues: GridRenderCellParams) => {
           return (
             <IconButton
-              aria-label={`View Details for IP ${cellValues.row.ip}`}
+              aria-label={`View Details for Domain ${cellValues.row.name}`}
               tabIndex={cellValues.tabIndex}
               color="primary"
               onClick={() =>

--- a/frontend/src/pages/Domains/Domains.tsx
+++ b/frontend/src/pages/Domains/Domains.tsx
@@ -245,9 +245,8 @@ export const Domains: React.FC = () => {
     }
   }, []);
 
-  const domCols = useMemo<GridColDef[]>(
-    () => {
-      const allColumns = [
+  const domCols = useMemo<GridColDef[]>(() => {
+    const allColumns = [
       {
         field: 'name',
         headerName: 'IP Addresses',
@@ -396,12 +395,10 @@ export const Domains: React.FC = () => {
     ];
 
     // Filter out organization column for standard users
-    return user?.user_type === 'standard' 
-      ? allColumns.filter(col => col.field !== 'organization_name')
+    return user?.user_type === 'standard'
+      ? allColumns.filter((col) => col.field !== 'organization_name')
       : allColumns;
-    },
-    [history, stringFilterOperators, user]
-  );
+  }, [history, stringFilterOperators, user]);
 
   const noRowsOverlay = (
     <Paper>

--- a/frontend/src/pages/Domains/Domains.tsx
+++ b/frontend/src/pages/Domains/Domains.tsx
@@ -89,17 +89,16 @@ export const Domains: React.FC = () => {
 
   const [userColumnVisibility, setUserColumnVisibility] =
     useState<GridColumnVisibilityModel>({
-      // TODO: Show Domain Name column once WAS data is available
-      // Currently hidden as we only have IP addresses, not actual domain names
-      name: false
+      // TODO: Once WAS data is available, remove Domain Name column filtering
+      // from domCols and restore it here as: name: true (or remove this state entirely)
     });
 
   // Compute final column visibility based on user type and business rules
   const columnVisibilityModel = useMemo<GridColumnVisibilityModel>(() => {
     const visibility = { ...userColumnVisibility };
 
-    // Note: Organization column is completely filtered out for standard users
-    // in the domCols useMemo, so no need to hide it here via visibility model
+    // Note: Both Domain Name and Organization columns are now filtered out completely
+    // in the domCols useMemo rather than hidden via visibility model for cleaner UX
 
     return visibility;
   }, [userColumnVisibility]);
@@ -425,11 +424,19 @@ export const Domains: React.FC = () => {
       }
     ];
 
-    // Filter out Organization column for standard users to completely hide it from column chooser
-    const filteredColumns =
-      user?.user_type === 'standard'
-        ? allColumns.filter((col) => col.field !== 'organization_name')
-        : allColumns;
+    // Filter out columns that should be hidden from column chooser
+    let filteredColumns = allColumns;
+
+    // TODO: Remove this filter once WAS data is available - Domain Name column should be user-controllable
+    // Remove Domain Name column from column chooser for all users (pending WAS data integration)
+    filteredColumns = filteredColumns.filter((col) => col.field !== 'name');
+
+    // Remove Organization column for standard users to completely hide it from column chooser
+    if (user?.user_type === 'standard') {
+      filteredColumns = filteredColumns.filter(
+        (col) => col.field !== 'organization_name'
+      );
+    }
 
     return filteredColumns;
   }, [history, stringFilterOperators, user?.user_type]);

--- a/frontend/src/pages/Domains/Domains.tsx
+++ b/frontend/src/pages/Domains/Domains.tsx
@@ -87,21 +87,8 @@ export const Domains: React.FC = () => {
     | { orgName?: string; orgId?: string }
     | undefined;
 
-  const [userColumnVisibility, setUserColumnVisibility] =
-    useState<GridColumnVisibilityModel>({
-      // TODO: Once WAS data is available, remove Domain Name column filtering
-      // from domCols and restore it here as: name: true (or remove this state entirely)
-    });
-
-  // Compute final column visibility based on user type and business rules
-  const columnVisibilityModel = useMemo<GridColumnVisibilityModel>(() => {
-    const visibility = { ...userColumnVisibility };
-
-    // Note: Both Domain Name and Organization columns are now filtered out completely
-    // in the domCols useMemo rather than hidden via visibility model for cleaner UX
-
-    return visibility;
-  }, [userColumnVisibility]);
+  const [columnVisibilityModel, setColumnVisibilityModel] =
+    useState<GridColumnVisibilityModel>({});
   const [domains, setDomains] = useState<DomainSearchApiResponse[]>([]);
   const [totalResults, setTotalResults] = useState(0);
   const { listDomains } = useDomainApi(
@@ -540,7 +527,7 @@ export const Domains: React.FC = () => {
               columns={domCols}
               columnVisibilityModel={columnVisibilityModel}
               onColumnVisibilityModelChange={(model) =>
-                setUserColumnVisibility(model)
+                setColumnVisibilityModel(model)
               }
               loading={isLoading}
               filterMode="server"

--- a/frontend/src/pages/Domains/Domains.tsx
+++ b/frontend/src/pages/Domains/Domains.tsx
@@ -98,13 +98,11 @@ export const Domains: React.FC = () => {
   const columnVisibilityModel = useMemo<GridColumnVisibilityModel>(() => {
     const visibility = { ...userColumnVisibility };
 
-    // Hide organization column for standard users
-    if (user?.user_type === 'standard') {
-      visibility.organization_name = false;
-    }
+    // Note: Organization column is completely filtered out for standard users
+    // in the domCols useMemo, so no need to hide it here via visibility model
 
     return visibility;
-  }, [userColumnVisibility, user?.user_type]);
+  }, [userColumnVisibility]);
   const [domains, setDomains] = useState<DomainSearchApiResponse[]>([]);
   const [totalResults, setTotalResults] = useState(0);
   const { listDomains } = useDomainApi(
@@ -427,8 +425,14 @@ export const Domains: React.FC = () => {
       }
     ];
 
-    return allColumns;
-  }, [history, stringFilterOperators]);
+    // Filter out Organization column for standard users to completely hide it from column chooser
+    const filteredColumns =
+      user?.user_type === 'standard'
+        ? allColumns.filter((col) => col.field !== 'organization_name')
+        : allColumns;
+
+    return filteredColumns;
+  }, [history, stringFilterOperators, user?.user_type]);
 
   const noRowsOverlay = (
     <Paper>

--- a/frontend/src/pages/Domains/Domains.tsx
+++ b/frontend/src/pages/Domains/Domains.tsx
@@ -80,7 +80,7 @@ const formatDays = (dateString: string) => {
 };
 
 export const Domains: React.FC = () => {
-  const { showAllOrganizations } = useAuthContext();
+  const { showAllOrganizations, user } = useAuthContext();
   const history = useHistory();
   const location = useLocation();
   const state = location.state as
@@ -246,10 +246,11 @@ export const Domains: React.FC = () => {
   }, []);
 
   const domCols = useMemo<GridColDef[]>(
-    () => [
+    () => {
+      const allColumns = [
       {
         field: 'name',
-        headerName: 'Domain',
+        headerName: 'IP Addresses',
         minWidth: 100,
         flex: 1,
         filterOperators: stringFilterOperators,
@@ -257,9 +258,9 @@ export const Domains: React.FC = () => {
           return (
             <Box
               component="span"
-              aria-label={`Domain Name: ${cellValues.row.name}`}
+              aria-label={`IP Address: ${cellValues.row.ip}`}
             >
-              {cellValues.row.name}
+              {cellValues.row.ip}
             </Box>
           );
         }
@@ -274,26 +275,9 @@ export const Domains: React.FC = () => {
           return (
             <Box
               component="span"
-              aria-label={`Organization using Domain ${cellValues.row.name}: ${cellValues.row.organization_name}`}
+              aria-label={`Organization for IP ${cellValues.row.ip}: ${cellValues.row.organization_name}`}
             >
               {cellValues.row.organization_name}
-            </Box>
-          );
-        }
-      },
-      {
-        field: 'ip',
-        headerName: 'IP',
-        minWidth: 50,
-        flex: 1,
-        filterOperators: stringFilterOperators,
-        renderCell: (cellValues: GridRenderCellParams<DomainRow>) => {
-          return (
-            <Box
-              component="span"
-              aria-label={`IP Address for Domain ${cellValues.row.name}: ${cellValues.row.ip}`}
-            >
-              {cellValues.row.ip}
             </Box>
           );
         }
@@ -308,7 +292,7 @@ export const Domains: React.FC = () => {
           return (
             <Box
               component="span"
-              aria-label={`Ports for Domain ${cellValues.row.name}: ${cellValues.row.ports_preview}`}
+              aria-label={`Ports for IP ${cellValues.row.ip}: ${cellValues.row.ports_preview}`}
             >
               {cellValues.row.ports_preview}
             </Box>
@@ -325,7 +309,7 @@ export const Domains: React.FC = () => {
           return (
             <Box
               component="span"
-              aria-label={`Services for Domain ${cellValues.row.name}: ${cellValues.row.services_preview}`}
+              aria-label={`Services for IP ${cellValues.row.ip}: ${cellValues.row.services_preview}`}
             >
               {cellValues.row.services_preview}
             </Box>
@@ -395,7 +379,7 @@ export const Domains: React.FC = () => {
         renderCell: (cellValues: GridRenderCellParams) => {
           return (
             <IconButton
-              aria-label={`View Details for Domain ${cellValues.row.name}`}
+              aria-label={`View Details for IP ${cellValues.row.ip}`}
               tabIndex={cellValues.tabIndex}
               color="primary"
               onClick={() =>
@@ -409,8 +393,14 @@ export const Domains: React.FC = () => {
           );
         }
       }
-    ],
-    [history, stringFilterOperators]
+    ];
+
+    // Filter out organization column for standard users
+    return user?.user_type === 'standard' 
+      ? allColumns.filter(col => col.field !== 'organization_name')
+      : allColumns;
+    },
+    [history, stringFilterOperators, user]
   );
 
   const noRowsOverlay = (

--- a/frontend/src/pages/Domains/Domains.tsx
+++ b/frontend/src/pages/Domains/Domains.tsx
@@ -87,8 +87,24 @@ export const Domains: React.FC = () => {
     | { orgName?: string; orgId?: string }
     | undefined;
 
-  const [columnVisibilityModel, setColumnVisibilityModel] =
-    useState<GridColumnVisibilityModel>({});
+  const [userColumnVisibility, setUserColumnVisibility] =
+    useState<GridColumnVisibilityModel>({
+      // TODO: Show Domain Name column once WAS data is available
+      // Currently hidden as we only have IP addresses, not actual domain names
+      name: false
+    });
+
+  // Compute final column visibility based on user type and business rules
+  const columnVisibilityModel = useMemo<GridColumnVisibilityModel>(() => {
+    const visibility = { ...userColumnVisibility };
+    
+    // Hide organization column for standard users
+    if (user?.user_type === 'standard') {
+      visibility.organization_name = false;
+    }
+    
+    return visibility;
+  }, [userColumnVisibility, user?.user_type]);
   const [domains, setDomains] = useState<DomainSearchApiResponse[]>([]);
   const [totalResults, setTotalResults] = useState(0);
   const { listDomains } = useDomainApi(
@@ -411,11 +427,8 @@ export const Domains: React.FC = () => {
       }
     ];
 
-    // Filter out organization column for standard users
-    return user?.user_type === 'standard'
-      ? allColumns.filter((col) => col.field !== 'organization_name')
-      : allColumns;
-  }, [history, stringFilterOperators, user]);
+    return allColumns;
+  }, [history, stringFilterOperators]);
 
   const noRowsOverlay = (
     <Paper>
@@ -516,7 +529,7 @@ export const Domains: React.FC = () => {
               columns={domCols}
               columnVisibilityModel={columnVisibilityModel}
               onColumnVisibilityModelChange={(model) =>
-                setColumnVisibilityModel(model)
+                setUserColumnVisibility(model)
               }
               loading={isLoading}
               filterMode="server"

--- a/frontend/src/pages/Domains/Domains.tsx
+++ b/frontend/src/pages/Domains/Domains.tsx
@@ -97,12 +97,12 @@ export const Domains: React.FC = () => {
   // Compute final column visibility based on user type and business rules
   const columnVisibilityModel = useMemo<GridColumnVisibilityModel>(() => {
     const visibility = { ...userColumnVisibility };
-    
+
     // Hide organization column for standard users
     if (user?.user_type === 'standard') {
       visibility.organization_name = false;
     }
-    
+
     return visibility;
   }, [userColumnVisibility, user?.user_type]);
   const [domains, setDomains] = useState<DomainSearchApiResponse[]>([]);

--- a/frontend/src/tests/pages/Domains/domainsTable.test.tsx
+++ b/frontend/src/tests/pages/Domains/domainsTable.test.tsx
@@ -57,11 +57,11 @@ describe('Domains component', () => {
     const grid = await screen.findByRole('grid');
     expect(grid).toBeInTheDocument();
 
-    const firstDomainName = await screen.findByText(/^example\.com$/i);
-    expect(firstDomainName).toBeInTheDocument();
+    const firstDomainIP = await screen.findByText(/^192\.0\.2\.1$/i);
+    expect(firstDomainIP).toBeInTheDocument();
 
-    const websiteMatches = await screen.findAllByText(/^website\.io$/i);
-    expect(websiteMatches.length).toBeGreaterThan(0);
+    const ipMatches = await screen.findAllByText(/^192\.0\.2\./);
+    expect(ipMatches.length).toBeGreaterThan(0);
 
     const rows = await screen.findAllByRole('row');
     expect(rows.length).toBe(sampleResponse.result.length + 1);
@@ -98,6 +98,197 @@ describe('Domains component', () => {
     const errorText = await screen.findByText(/error loading domains/i);
     expect(errorText).toBeInTheDocument();
   });
+
+  // Column visibility tests for CRASM-3585
+  describe('column visibility', () => {
+    it('hides Domain Name column for all users (pending WAS data)', async () => {
+      apiPostMock.mockResolvedValueOnce(sampleResponse);
+
+      render(<Domains />, {
+        initialHistory: ['/domains'],
+        authContext: {
+          apiPost: apiPostMock,
+          currentOrganization: null,
+          user: testUser as unknown as AuthUser
+        }
+      });
+
+      const grid = await screen.findByRole('grid');
+      expect(grid).toBeInTheDocument();
+
+      // Domain Name column should be hidden for all users
+      const domainNameHeader = screen.queryByRole('columnheader', { name: /domain name/i });
+      expect(domainNameHeader).not.toBeInTheDocument();
+
+      // IP Address column should be visible
+      const ipAddressHeader = await screen.findByRole('columnheader', { name: /ip address/i });
+      expect(ipAddressHeader).toBeInTheDocument();
+    });
+
+    it('hides Organization column for standard users', async () => {
+      apiPostMock.mockResolvedValueOnce(sampleResponse);
+
+      const standardUser = { ...testUser, user_type: 'standard' };
+
+      render(<Domains />, {
+        initialHistory: ['/domains'],
+        authContext: {
+          apiPost: apiPostMock,
+          currentOrganization: null,
+          user: standardUser as unknown as AuthUser
+        }
+      });
+
+      const grid = await screen.findByRole('grid');
+      expect(grid).toBeInTheDocument();
+
+      // Organization column should be hidden for standard users
+      const orgHeader = screen.queryByRole('columnheader', { name: /organization/i });
+      expect(orgHeader).not.toBeInTheDocument();
+    });
+
+    it('shows Organization column for globalAdmin users', async () => {
+      apiPostMock.mockResolvedValueOnce(sampleResponse);
+
+      const adminUser = { ...testUser, user_type: 'globalAdmin' };
+
+      render(<Domains />, {
+        initialHistory: ['/domains'],
+        authContext: {
+          apiPost: apiPostMock,
+          currentOrganization: null,
+          user: adminUser as unknown as AuthUser
+        }
+      });
+
+      const grid = await screen.findByRole('grid');
+      expect(grid).toBeInTheDocument();
+
+      // Organization column should be visible for admin users
+      const orgHeader = await screen.findByRole('columnheader', { name: /organization/i });
+      expect(orgHeader).toBeInTheDocument();
+    });
+
+    it('shows Organization column for globalView users', async () => {
+      apiPostMock.mockResolvedValueOnce(sampleResponse);
+
+      const globalViewUser = { ...testUser, user_type: 'globalView' };
+
+      render(<Domains />, {
+        initialHistory: ['/domains'],
+        authContext: {
+          apiPost: apiPostMock,
+          currentOrganization: null,
+          user: globalViewUser as unknown as AuthUser
+        }
+      });
+
+      const grid = await screen.findByRole('grid');
+      expect(grid).toBeInTheDocument();
+
+      // Organization column should be visible for globalView users
+      const orgHeader = await screen.findByRole('columnheader', { name: /organization/i });
+      expect(orgHeader).toBeInTheDocument();
+    });
+
+    it('shows Organization column for regionalAdmin users', async () => {
+      apiPostMock.mockResolvedValueOnce(sampleResponse);
+
+      const regionalAdminUser = { ...testUser, user_type: 'regionalAdmin' };
+
+      render(<Domains />, {
+        initialHistory: ['/domains'],
+        authContext: {
+          apiPost: apiPostMock,
+          currentOrganization: null,
+          user: regionalAdminUser as unknown as AuthUser
+        }
+      });
+
+      const grid = await screen.findByRole('grid');
+      expect(grid).toBeInTheDocument();
+
+      // Organization column should be visible for regionalAdmin users
+      const orgHeader = await screen.findByRole('columnheader', { name: /organization/i });
+      expect(orgHeader).toBeInTheDocument();
+    });
+
+    it('renders IP addresses when Domain Name column is hidden', async () => {
+      apiPostMock.mockResolvedValueOnce(sampleResponse);
+
+      render(<Domains />, {
+        initialHistory: ['/domains'],
+        authContext: {
+          apiPost: apiPostMock,
+          currentOrganization: null,
+          user: testUser as unknown as AuthUser
+        }
+      });
+
+      const grid = await screen.findByRole('grid');
+      expect(grid).toBeInTheDocument();
+
+      // Should see IP addresses in the table since Domain Name is hidden
+      const ipMatches = await screen.findAllByText(/^192\.0\.2\./);
+      expect(ipMatches.length).toBeGreaterThan(0);
+
+      // Should not see domain names since that column is hidden
+      const domainMatches = screen.queryAllByText(/example\.com|test\.com|sample\.org/);
+      expect(domainMatches.length).toBe(0);
+    });
+  });
+
+  // Data rendering tests
+  describe('data rendering', () => {
+    it('displays correct number of rows with data', async () => {
+      apiPostMock.mockResolvedValueOnce(sampleResponse);
+
+      render(<Domains />, {
+        initialHistory: ['/domains'],
+        authContext: {
+          apiPost: apiPostMock,
+          currentOrganization: null,
+          user: testUser as unknown as AuthUser
+        }
+      });
+
+      const grid = await screen.findByRole('grid');
+      expect(grid).toBeInTheDocument();
+
+      // Should have header row + data rows
+      const rows = await screen.findAllByRole('row');
+      expect(rows.length).toBe(sampleResponse.result.length + 1); // +1 for header
+    });
+
+    it('handles edge case with single domain result', async () => {
+      const singleDomainResponse = {
+        result: [sampleResponse.result[0]],
+        count: 1
+      };
+      apiPostMock.mockResolvedValueOnce(singleDomainResponse);
+
+      render(<Domains />, {
+        initialHistory: ['/domains'],
+        authContext: {
+          apiPost: apiPostMock,
+          currentOrganization: null,
+          user: testUser as unknown as AuthUser
+        }
+      });
+
+      const grid = await screen.findByRole('grid');
+      expect(grid).toBeInTheDocument();
+
+      // Should have header row + 1 data row
+      const rows = await screen.findAllByRole('row');
+      expect(rows.length).toBe(2);
+
+      // Should display the IP address for the single domain
+      const ipAddress = await screen.findByText(/^192\.0\.2\.1$/i);
+      expect(ipAddress).toBeInTheDocument();
+    });
+  });
+
   // To-Do: CRASM-3385 Move server-side pagination, sort, and filter tests to Playwright e2e tests.
 
   // it('supports server-side pagination', async () => {

--- a/frontend/src/tests/pages/Domains/domainsTable.test.tsx
+++ b/frontend/src/tests/pages/Domains/domainsTable.test.tsx
@@ -101,7 +101,7 @@ describe('Domains component', () => {
 
   // Column visibility tests for CRASM-3585
   describe('column visibility', () => {
-    it('hides Domain Name column for all users (pending WAS data)', async () => {
+    it('completely removes Domain Name column for all users (pending WAS data)', async () => {
       apiPostMock.mockResolvedValueOnce(sampleResponse);
 
       render(<Domains />, {
@@ -116,7 +116,8 @@ describe('Domains component', () => {
       const grid = await screen.findByRole('grid');
       expect(grid).toBeInTheDocument();
 
-      // Domain Name column should be hidden for all users
+      // Domain Name column should be completely removed (not just hidden) for all users
+      // This means it won't appear in the column chooser menu until WAS data is available
       const domainNameHeader = screen.queryByRole('columnheader', {
         name: /domain name/i
       });

--- a/frontend/src/tests/pages/Domains/domainsTable.test.tsx
+++ b/frontend/src/tests/pages/Domains/domainsTable.test.tsx
@@ -129,7 +129,7 @@ describe('Domains component', () => {
       expect(ipAddressHeader).toBeInTheDocument();
     });
 
-    it('hides Organization column for standard users', async () => {
+    it('completely removes Organization column for standard users', async () => {
       apiPostMock.mockResolvedValueOnce(sampleResponse);
 
       const standardUser = { ...testUser, user_type: 'standard' };
@@ -146,7 +146,8 @@ describe('Domains component', () => {
       const grid = await screen.findByRole('grid');
       expect(grid).toBeInTheDocument();
 
-      // Organization column should be hidden for standard users
+      // Organization column should be completely removed (not just hidden) for standard users
+      // This means it won't appear in the column chooser menu at all
       const orgHeader = screen.queryByRole('columnheader', {
         name: /organization/i
       });

--- a/frontend/src/tests/pages/Domains/domainsTable.test.tsx
+++ b/frontend/src/tests/pages/Domains/domainsTable.test.tsx
@@ -57,11 +57,11 @@ describe('Domains component', () => {
     const grid = await screen.findByRole('grid');
     expect(grid).toBeInTheDocument();
 
-    const firstDomainIP = await screen.findByText(/^192\.0\.2\.1$/i);
-    expect(firstDomainIP).toBeInTheDocument();
+    const firstDomainName = await screen.findByText(/^example\.com$/i);
+    expect(firstDomainName).toBeInTheDocument();
 
-    const ipMatches = await screen.findAllByText(/^192\.0\.2\./);
-    expect(ipMatches.length).toBeGreaterThan(0);
+    const websiteMatches = await screen.findAllByText(/^website\.io$/i);
+    expect(websiteMatches.length).toBeGreaterThan(0);
 
     const rows = await screen.findAllByRole('row');
     expect(rows.length).toBe(sampleResponse.result.length + 1);

--- a/frontend/src/tests/pages/Domains/domainsTable.test.tsx
+++ b/frontend/src/tests/pages/Domains/domainsTable.test.tsx
@@ -246,7 +246,7 @@ describe('Domains component', () => {
 
       // Should not see domain names since that column is hidden
       const domainMatches = screen.queryAllByText(
-        /example\.com|test\.com|sample\.org/
+        /^(example\.com|test\.com|sample\.org)$/
       );
       expect(domainMatches.length).toBe(0);
     });

--- a/frontend/src/tests/pages/Domains/domainsTable.test.tsx
+++ b/frontend/src/tests/pages/Domains/domainsTable.test.tsx
@@ -57,11 +57,11 @@ describe('Domains component', () => {
     const grid = await screen.findByRole('grid');
     expect(grid).toBeInTheDocument();
 
-    const firstDomainName = await screen.findByText(/^example\.com$/i);
-    expect(firstDomainName).toBeInTheDocument();
+    const firstDomainIP = await screen.findByText(/^192\.0\.2\.1$/i);
+    expect(firstDomainIP).toBeInTheDocument();
 
-    const websiteMatches = await screen.findAllByText(/^website\.io$/i);
-    expect(websiteMatches.length).toBeGreaterThan(0);
+    const ipMatches = await screen.findAllByText(/^192\.0\.2\./);
+    expect(ipMatches.length).toBeGreaterThan(0);
 
     const rows = await screen.findAllByRole('row');
     expect(rows.length).toBe(sampleResponse.result.length + 1);

--- a/frontend/src/tests/pages/Domains/domainsTable.test.tsx
+++ b/frontend/src/tests/pages/Domains/domainsTable.test.tsx
@@ -117,11 +117,15 @@ describe('Domains component', () => {
       expect(grid).toBeInTheDocument();
 
       // Domain Name column should be hidden for all users
-      const domainNameHeader = screen.queryByRole('columnheader', { name: /domain name/i });
+      const domainNameHeader = screen.queryByRole('columnheader', {
+        name: /domain name/i
+      });
       expect(domainNameHeader).not.toBeInTheDocument();
 
       // IP Address column should be visible
-      const ipAddressHeader = await screen.findByRole('columnheader', { name: /ip address/i });
+      const ipAddressHeader = await screen.findByRole('columnheader', {
+        name: /ip address/i
+      });
       expect(ipAddressHeader).toBeInTheDocument();
     });
 
@@ -143,7 +147,9 @@ describe('Domains component', () => {
       expect(grid).toBeInTheDocument();
 
       // Organization column should be hidden for standard users
-      const orgHeader = screen.queryByRole('columnheader', { name: /organization/i });
+      const orgHeader = screen.queryByRole('columnheader', {
+        name: /organization/i
+      });
       expect(orgHeader).not.toBeInTheDocument();
     });
 
@@ -165,7 +171,9 @@ describe('Domains component', () => {
       expect(grid).toBeInTheDocument();
 
       // Organization column should be visible for admin users
-      const orgHeader = await screen.findByRole('columnheader', { name: /organization/i });
+      const orgHeader = await screen.findByRole('columnheader', {
+        name: /organization/i
+      });
       expect(orgHeader).toBeInTheDocument();
     });
 
@@ -187,7 +195,9 @@ describe('Domains component', () => {
       expect(grid).toBeInTheDocument();
 
       // Organization column should be visible for globalView users
-      const orgHeader = await screen.findByRole('columnheader', { name: /organization/i });
+      const orgHeader = await screen.findByRole('columnheader', {
+        name: /organization/i
+      });
       expect(orgHeader).toBeInTheDocument();
     });
 
@@ -209,7 +219,9 @@ describe('Domains component', () => {
       expect(grid).toBeInTheDocument();
 
       // Organization column should be visible for regionalAdmin users
-      const orgHeader = await screen.findByRole('columnheader', { name: /organization/i });
+      const orgHeader = await screen.findByRole('columnheader', {
+        name: /organization/i
+      });
       expect(orgHeader).toBeInTheDocument();
     });
 
@@ -233,7 +245,9 @@ describe('Domains component', () => {
       expect(ipMatches.length).toBeGreaterThan(0);
 
       // Should not see domain names since that column is hidden
-      const domainMatches = screen.queryAllByText(/example\.com|test\.com|sample\.org/);
+      const domainMatches = screen.queryAllByText(
+        /example\.com|test\.com|sample\.org/
+      );
       expect(domainMatches.length).toBe(0);
     });
   });


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

This PR updates the Domains table in the Findings Library to temporarily hide the Domain Name column until Web Application Scanning (WAS) data source integration provides actual domain name resolution:

- **Hides Domain Name column** for all users using MUI DataGrid's `columnVisibilityModel` (clean, semantic approach)
- **Maintains IP Address column** visibility so users can still identify domains by their IP addresses  
- **Preserves Organization column logic** - continues to hide for standard users, visible for admin users (globalAdmin, regionalAdmin, globalView)
- **Adds comprehensive test coverage** for column visibility across all user types and scenarios
- **Includes TODO comment** and follow-up ticket planning for re-enabling the column once WAS data is available

**Technical Implementation:** Uses MUI DataGrid's built-in column visibility management instead of array filtering, providing cleaner code and better maintainability.


## 💭 Motivation and context ##
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

This change addresses CRASM-3585 based on **design team feedback** that the Domain Name column should be hidden until the WAS (Web Application Scanning) datasource integration is complete, as the current data only provides IP addresses without corresponding domain name resolution.

**Implementation Approach:**
- **Requirement:** Hide Domain Name column entirely while keeping IP Address column visible
- **Rationale:** Avoid showing misleading domain names when only IP data is available
- **Solution:** Temporary column hiding with clear restoration path

This solution maintains user experience while awaiting backend data integration, with a clear path forward for restoration once WAS data becomes available.

## 🧪 Testing ##
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

- **Column visibility tests** for all user types (standard, globalAdmin, globalView, regionalAdmin)
- **Domain Name column hiding** verification across all user scenarios
- **Organization column visibility** rules maintained (hidden for standard users)
- **Content rendering validation** - confirms IP addresses display correctly when Domain Name column is hidden

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

### /inventory/domains

**Before:** 
<img width="1189" height="552" alt="Screenshot 2025-12-19 at 8 22 02 AM" src="https://github.com/user-attachments/assets/94a987a8-02aa-46f0-8d0c-c72779cdbe39" />

**After:**

Standard users:
<img width="1192" height="668" alt="Screenshot 2025-12-23 at 9 04 39 AM" src="https://github.com/user-attachments/assets/22a2d951-7090-423f-8711-84bddb7ad210" />
<img width="733" height="354" alt="Screenshot 2025-12-23 at 10 13 11 AM" src="https://github.com/user-attachments/assets/450573b5-8b3f-452b-9c42-318f61945a8f" />
<img width="516" height="382" alt="Screenshot 2025-12-23 at 10 13 04 AM" src="https://github.com/user-attachments/assets/5217b294-f024-4b7f-94ed-57f3b04bd1f9" />

All other users: 
<img width="1186" height="605" alt="Screenshot 2025-12-23 at 9 03 24 AM" src="https://github.com/user-attachments/assets/ed6bbe0a-a0f0-4906-b172-89d6bb73ff56" />
<img width="759" height="403" alt="Screenshot 2025-12-23 at 10 14 45 AM" src="https://github.com/user-attachments/assets/a4140a57-9b1d-4e0a-b86b-cc6f1c9fbe1e" />
<img width="423" height="388" alt="Screenshot 2025-12-23 at 10 14 38 AM" src="https://github.com/user-attachments/assets/194c186f-168b-4406-9b5c-f665ca851eae" />

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
