### PR TITLE
Update hosts scanned value and its tooltip language (CRASM-3262)

### DIFF
--- a/frontend/src/pages/VulnerabilityScanDash/infoKeyMetricsContent.json
+++ b/frontend/src/pages/VulnerabilityScanDash/infoKeyMetricsContent.json
@@ -33,7 +33,7 @@
       "id": "Assets Owned"
     },
     {
-      "content": "Number of hosts or IPs scanned during each scan run.",
+      "content": "Number of hosts assessed during the latest vulnerability scan run.",
       "id": "Hosts Scanned"
     },
     {

--- a/frontend/src/utils/transformVulnScanData.ts
+++ b/frontend/src/utils/transformVulnScanData.ts
@@ -200,7 +200,7 @@ export const transformVulnScanData = (
         ),
         vulnerabilityScan: vulLabel.label,
         assetsOwned: latestVulnSummary?.assets_owned_count ?? 0,
-        hostsScanned: latestHostSummary?.up_host_count ?? 0,
+        hostsScanned: latestHostSummary?.recent_up_hosts_count ?? 0,
         startDate: vulLabel.usedStart ?? '',
         endDate: vulLabel.usedEnd ?? '',
         enrolledDate: latestVulnSummary?.enrolled_in_vs_timestamp ?? '',

--- a/frontend/vite.config.mts
+++ b/frontend/vite.config.mts
@@ -78,10 +78,10 @@ export default defineConfig({
         'src/components/Metrics/*'
       ],
       thresholds: {
-        statements: 31.25,
-        branches: 21.67,
-        functions: 25.85,
-        lines: 31.91,
+        statements: 35.73,
+        branches: 25.73,
+        functions: 29.98,
+        lines: 36.31,
         autoUpdate: true
       }
     }


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->
Fix the 'Host Scanned' number to be 'count of the number of IPs that have had a VS scan conducted on them', not 'number of hosts that appear to be up'. Update the tooltip language for Hosts Scanned.

## 💭 Motivation and context ##
"Host Scanned" - should be the count of things that have a VS scan (even if there are no findings)
"Detected Hosts" - should be the count of things that nmap has determined to be up
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

In VS Dashboard, the tooltip for Hosts Scanned should be: Number of hosts assessed during the latest vulnerability scan run.
The Hosts Scanned number comes recent_up_hosts_count and the Detected Hosts number comes from up_host_count.

## 📷 Screenshots (if appropriate) ##

The below shows the updated tooltip language for hosts scanned and that its value now differs from detected hosts.
<img width="751" height="282" alt="image" src="https://github.com/user-attachments/assets/8626f423-37a4-4e6c-b0e0-e9b075f7ba6b" />
<img width="536" height="222" alt="image" src="https://github.com/user-attachments/assets/4b2a18e3-9df7-4055-a5b6-594210dc47a2" />


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
