### PR TITLE
Fix Elasticsearch errors in DMZ

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -23,7 +23,7 @@ dnspython==2.7.0
 dnstwist==20230918
 docker==7.1.0
 dshield==0.2.1
-elasticsearch==7.17.12
+elasticsearch==7.13.4
 email_validator==2.2.0
 Faker==37.1.0
 fastapi==0.116.2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -49,6 +49,7 @@ multidict==6.1.0
 mypy==1.13.0
 mypy-extensions==1.0.0
 netaddr==1.3.0
+numpy>=1.17, <2.0
 orjson==3.10.12
 packaging==24.2
 pika==1.3.2

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -85,7 +85,7 @@ provider:
   region: ${opt:region, env:AWS_REGION, env:AWS_DEFAULT_REGION,
     file(env.yml):${self:provider.stage}.REGION, 'us-east-1'}
   endpointType: ${file(env.yml):${self:provider.stage}.ENDPOINT_TYPE, ''}
-  runtime: python3.11
+  runtime: python3.12
   timeout: 30
   stage: ${opt:stage, 'dev'}
   environment: ${file(env.yml):${self:provider.stage}, ''}


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
- When testing changes made in [PR 1430](https://github.com/cisagov/XFD/pull/1430), API requests to any endpoint that uses Elasticsearch was either erroring out or returning the following error
```
{
    "detail": "The client noticed that the server is not a supported distribution of Elasticsearch"
}
```
In Elasticsearch 7.14, a "product check" was added to detect a client attempting to connect to an Elasticsearch instance that is not supported. We should eventually move to use opensearch-py instead of Elasticsearch for our implementation within the Django project. 

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [x] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
