### PR TITLE
Restore HMR and update vite.config.mts (CRASM-3637)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -57,6 +57,7 @@
         "@types/react-router-dom": "^5.3.3",
         "@types/react-table": "^7.7.12",
         "@typescript-eslint/eslint-plugin": "^8.37.0",
+        "@typescript-eslint/parser": "^8.37.0",
         "@vitejs/plugin-react": "^4.6.0",
         "@vitest/coverage-istanbul": "^3.2.4",
         "eslint": "^8.26.0",
@@ -18919,7 +18920,6 @@
       },
       "integrity": "sha512-3xP4XzzDNQOIqBMWogftkwxhg5oMKApqY0BAflmLZiFYHqyhSOxv/cd/zPQLTcCXr4AkaKb25joocY0BD1WC6A==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,6 +65,7 @@
     "@types/react-router-dom": "^5.3.3",
     "@types/react-table": "^7.7.12",
     "@typescript-eslint/eslint-plugin": "^8.37.0",
+    "@typescript-eslint/parser": "^8.37.0",
     "@vitejs/plugin-react": "^4.6.0",
     "@vitest/coverage-istanbul": "^3.2.4",
     "eslint": "^8.26.0",

--- a/frontend/vite.config.mts
+++ b/frontend/vite.config.mts
@@ -1,5 +1,5 @@
 // frontend/vite.config.mts
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { visualizer } from 'rollup-plugin-visualizer';
@@ -33,7 +33,6 @@ export default defineConfig({
     host: '0.0.0.0',
     strictPort: true,
     watch: { usePolling: true, interval: 1000 },
-    hmr: { host: 'localhost', clientPort: 3000 },
     proxy: {
       '/matomo/matomo.php': {
         target: 'http://backend:3000',


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
- removed HMR block from defineConfig
   - allows vite to auto-detect
- changed defineConfig import source from 'vite' to 'vitest/config'
   - the original defineConfig import does not support a "test" property.
   - the new one does and this allows a unified config file containing both vite and vitest configs in one file.
   
 **- Run NPM I in frontend locally**
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
- Restore HMR settings for better development experience.
- Replace defineConfig from "vite" with defineConfig from "vitest/config" for improved testing configuration.
- Allows vitest config to be in same file as vite config.
- Closes CRASM-3637
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
- tested locally
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
