### PR TITLE
CRASM-3525 Add unit tests for navMenuDrawer

### DIFF
--- a/frontend/src/tests/components/Header/navMenuDrawer.test.tsx
+++ b/frontend/src/tests/components/Header/navMenuDrawer.test.tsx
@@ -1,0 +1,404 @@
+// adjust path as needed
+import React from 'react';
+import { describe, it, expect, beforeEach, vi, Mock } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+
+import { NavMenuDrawer } from '../../../components/Header/NavMenuDrawer';
+import {
+  useUserLevel,
+  STANDARD_USER,
+  REGIONAL_ADMIN,
+  GLOBAL_ADMIN,
+  GLOBAL_VIEW
+} from '../../../hooks/useUserLevel';
+import { Header } from '../../../components/Header/Header';
+
+type MenuItemType = any;
+
+const theme = createTheme();
+
+const renderWithProviders = (ui: React.ReactElement) =>
+  render(
+    <MemoryRouter>
+      <ThemeProvider theme={theme}>{ui}</ThemeProvider>
+    </MemoryRouter>
+  );
+
+const getToggleDrawerMocks = () => {
+  const innerToggle = vi.fn();
+  const toggleDrawer = vi.fn().mockReturnValue(innerToggle);
+  return { toggleDrawer, innerToggle };
+};
+
+const actionItemOnClick = vi.fn();
+const objectStoreItem: MenuItemType = {
+  menuItemTitle: 'Object Store Item',
+  objectStoreParams: { id: 'obj-1' }
+};
+const subMenuChild: MenuItemType = {
+  menuItemTitle: 'Submenu Child',
+  objectStoreParams: { id: 'sub-1' }
+};
+
+const baseMenuItems: { [section: string]: MenuItemType[] }[] = [
+  {
+    'Learning Center': [
+      {
+        menuItemTitle: 'Learning Link',
+        path: '/learning'
+      },
+      {
+        menuItemTitle: 'Learning Submenu',
+        subMenuItems: [subMenuChild]
+      }
+    ]
+  },
+  {
+    Main: [
+      {
+        menuItemTitle: 'Action Item',
+        onClick: actionItemOnClick
+      },
+      objectStoreItem,
+      {
+        menuItemTitle: 'External HTTP',
+        path: 'http://example.com'
+      },
+      {
+        menuItemTitle: 'Mail Link',
+        path: 'mailto:test@example.com'
+      },
+      {
+        menuItemTitle: 'Internal Link',
+        path: '/internal'
+      }
+    ]
+  }
+];
+
+vi.mock('context', () => ({
+  useAuthContext: () => ({
+    apiPost: vi.fn(),
+    logout: vi.fn()
+  })
+}));
+
+vi.mock('../../../hooks/useUserLevel', () => ({
+  useUserLevel: vi.fn(),
+  GLOBAL_ADMIN: 4,
+  GLOBAL_VIEW: 3,
+  REGIONAL_ADMIN: 2,
+  STANDARD_USER: 1
+}));
+
+const renderHeader = () =>
+  render(
+    <MemoryRouter>
+      <ThemeProvider theme={theme}>
+        <Header />
+      </ThemeProvider>
+    </MemoryRouter>
+  );
+
+const mockedUseUserLevel = useUserLevel as unknown as Mock;
+
+const openMobileMenu = async () => {
+  const user = userEvent.setup();
+  const menuButton = screen.getByRole('button', {
+    name: /open mobile menu/i
+  });
+  await user.click(menuButton);
+};
+
+describe('NavMenuDrawer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('respects openDrawer prop (dialog appears only when openDrawer is true)', () => {
+    const { toggleDrawer } = getToggleDrawerMocks();
+
+    const { rerender, queryByRole } = renderWithProviders(
+      <NavMenuDrawer
+        toggleDrawer={toggleDrawer}
+        openDrawer={false}
+        menuItems={baseMenuItems}
+      />
+    );
+
+    expect(
+      queryByRole('dialog', { name: /navigation menu/i })
+    ).not.toBeInTheDocument();
+
+    rerender(
+      <MemoryRouter>
+        <ThemeProvider theme={theme}>
+          <NavMenuDrawer
+            toggleDrawer={toggleDrawer}
+            openDrawer={true}
+            menuItems={baseMenuItems}
+          />
+        </ThemeProvider>
+      </MemoryRouter>
+    );
+
+    expect(
+      queryByRole('dialog', { name: /navigation menu/i })
+    ).toBeInTheDocument();
+  });
+
+  it('onClose calls toggleDrawer(false) and its inner function', async () => {
+    const { toggleDrawer, innerToggle } = getToggleDrawerMocks();
+
+    renderWithProviders(
+      <NavMenuDrawer
+        toggleDrawer={toggleDrawer}
+        openDrawer={true}
+        menuItems={baseMenuItems}
+      />
+    );
+
+    const presentationEls = screen.getAllByRole('presentation');
+    const container = presentationEls[0];
+
+    fireEvent.keyDown(container, { key: 'Escape', code: 'Escape' });
+
+    expect(toggleDrawer).toHaveBeenCalledWith(false);
+    expect(innerToggle).toHaveBeenCalled();
+  });
+
+  it('renders dropdown section and reveals its items when expanded', async () => {
+    const user = userEvent.setup();
+    const { toggleDrawer } = getToggleDrawerMocks();
+
+    renderWithProviders(
+      <NavMenuDrawer
+        toggleDrawer={toggleDrawer}
+        openDrawer={true}
+        menuItems={baseMenuItems}
+      />
+    );
+
+    expect(screen.queryByText('Learning Link')).not.toBeInTheDocument();
+    expect(screen.queryByText('Learning Submenu')).not.toBeInTheDocument();
+
+    const learningCenterButton = screen.getByRole('button', {
+      name: /learning center/i
+    });
+    await user.click(learningCenterButton);
+
+    expect(screen.getByText('Learning Link')).toBeInTheDocument();
+  });
+
+  it('renders submenu and its children when onMenuItemClick is provided', async () => {
+    const user = userEvent.setup();
+    const { toggleDrawer } = getToggleDrawerMocks();
+    const onMenuItemClick = vi.fn().mockResolvedValue(undefined);
+
+    renderWithProviders(
+      <NavMenuDrawer
+        toggleDrawer={toggleDrawer}
+        openDrawer={true}
+        menuItems={baseMenuItems}
+        onMenuItemClick={onMenuItemClick}
+      />
+    );
+
+    const learningCenterButton = screen.getByRole('button', {
+      name: /learning center/i
+    });
+    await user.click(learningCenterButton);
+
+    const learningSubmenuButton = screen.getByRole('menuitem', {
+      name: /learning submenu/i
+    });
+    expect(learningSubmenuButton).toBeInTheDocument();
+
+    await user.click(learningSubmenuButton);
+
+    expect(screen.getByText('Submenu Child')).toBeInTheDocument();
+  });
+
+  it('calls onClick for "Action Item" and closes the drawer', async () => {
+    const user = userEvent.setup();
+    const { toggleDrawer, innerToggle } = getToggleDrawerMocks();
+
+    renderWithProviders(
+      <NavMenuDrawer
+        toggleDrawer={toggleDrawer}
+        openDrawer={true}
+        menuItems={baseMenuItems}
+      />
+    );
+
+    const actionItem = screen.getByRole('menuitem', {
+      name: /action item/i
+    });
+
+    const toggleCallsBefore = toggleDrawer.mock.calls.length;
+
+    await user.click(actionItem);
+
+    expect(actionItemOnClick).toHaveBeenCalledTimes(1);
+    expect(toggleDrawer.mock.calls.length).toBe(toggleCallsBefore + 1);
+    expect(innerToggle).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('Header / NavMenuDrawer role-based menus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not show Admin Hub for STANDARD_USER (userLevel = 1)', async () => {
+    mockedUseUserLevel.mockReturnValue({
+      userLevel: STANDARD_USER,
+      user_type: 'standard',
+      user: null,
+      formattedUserType: 'Standard User'
+    });
+
+    renderHeader();
+    await openMobileMenu();
+
+    const drawer = screen.getByRole('dialog', { name: /navigation menu/i });
+    const drawerQueries = within(drawer);
+
+    expect(drawerQueries.queryByText(/admin hub/i)).not.toBeInTheDocument();
+  });
+
+  it('shows Admin Hub without Admin Tools for REGIONAL_ADMIN (userLevel = 2)', async () => {
+    const user = userEvent.setup();
+
+    mockedUseUserLevel.mockReturnValue({
+      userLevel: REGIONAL_ADMIN,
+      user_type: 'regionalAdmin',
+      user: { isRegistered: true, user_type: 'regionalAdmin' },
+      formattedUserType: 'Regional Admin'
+    });
+
+    renderHeader();
+
+    const mobileButton = screen.getByRole('button', {
+      name: /open mobile menu/i
+    });
+    await user.click(mobileButton);
+
+    const drawer = screen.getByRole('dialog', {
+      name: /navigation menu/i
+    });
+    const drawerQueries = within(drawer);
+
+    const adminHubToggle = drawerQueries.getByRole('button', {
+      name: /admin hub/i
+    });
+    expect(adminHubToggle).toBeInTheDocument();
+
+    await user.click(adminHubToggle);
+
+    expect(
+      drawerQueries.getByRole('menuitem', { name: /manage organizations/i })
+    ).toBeInTheDocument();
+    expect(
+      drawerQueries.getByRole('menuitem', { name: /manage users/i })
+    ).toBeInTheDocument();
+    expect(
+      drawerQueries.getByRole('menuitem', { name: /user registration/i })
+    ).toBeInTheDocument();
+    expect(
+      drawerQueries.queryByRole('menuitem', { name: /admin tools/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows Admin Hub with Admin Tools for GLOBAL_ADMIN (userLevel = 4)', async () => {
+    const user = userEvent.setup();
+
+    mockedUseUserLevel.mockReturnValue({
+      userLevel: GLOBAL_ADMIN,
+      user_type: 'globalAdmin',
+      user: { isRegistered: true, user_type: 'globalAdmin' },
+      formattedUserType: 'Global Admin'
+    });
+
+    renderHeader();
+
+    const mobileButton = screen.getByRole('button', {
+      name: /open mobile menu/i
+    });
+    await user.click(mobileButton);
+
+    const drawer = screen.getByRole('dialog', {
+      name: /navigation menu/i
+    });
+    const drawerQueries = within(drawer);
+
+    const adminHubToggle = drawerQueries.getByRole('button', {
+      name: /admin hub/i
+    });
+    expect(adminHubToggle).toBeInTheDocument();
+
+    await user.click(adminHubToggle);
+
+    const adminToolsItem = drawerQueries.getByRole('menuitem', {
+      name: /admin tools/i
+    });
+    expect(adminToolsItem).toBeInTheDocument();
+
+    expect(
+      drawerQueries.getByRole('menuitem', { name: /manage organizations/i })
+    ).toBeInTheDocument();
+    expect(
+      drawerQueries.getByRole('menuitem', { name: /manage users/i })
+    ).toBeInTheDocument();
+    expect(
+      drawerQueries.getByRole('menuitem', { name: /user registration/i })
+    ).toBeInTheDocument();
+  });
+
+  it('shows Admin Hub without Admin Tools for GLOBAL_VIEW (userLevel = 3)', async () => {
+    const user = userEvent.setup();
+
+    mockedUseUserLevel.mockReturnValue({
+      userLevel: GLOBAL_VIEW,
+      user_type: 'globalView',
+      user: { isRegistered: true, user_type: 'globalView' },
+      formattedUserType: 'Global View'
+    });
+
+    renderHeader();
+
+    const mobileButton = screen.getByRole('button', {
+      name: /open mobile menu/i
+    });
+    await user.click(mobileButton);
+
+    const drawer = screen.getByRole('dialog', {
+      name: /navigation menu/i
+    });
+    const drawerQueries = within(drawer);
+
+    const adminHubToggle = drawerQueries.getByRole('button', {
+      name: /admin hub/i
+    });
+    expect(adminHubToggle).toBeInTheDocument();
+
+    await user.click(adminHubToggle);
+
+    expect(
+      drawerQueries.queryByRole('menuitem', { name: /admin tools/i })
+    ).not.toBeInTheDocument();
+    expect(
+      drawerQueries.getByRole('menuitem', { name: /manage organizations/i })
+    ).toBeInTheDocument();
+    expect(
+      drawerQueries.getByRole('menuitem', { name: /manage users/i })
+    ).toBeInTheDocument();
+    expect(
+      drawerQueries.getByRole('menuitem', { name: /user registration/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/components/Header/navMenuDrawer.test.tsx
+++ b/frontend/src/tests/components/Header/navMenuDrawer.test.tsx
@@ -254,7 +254,7 @@ describe('Header / NavMenuDrawer role-based menus', () => {
     vi.clearAllMocks();
   });
 
-  it('does not show Admin Hub for STANDARD_USER (userLevel = 1)', async () => {
+  it('does not show Admin Hub for STANDARD_USER', async () => {
     mockedUseUserLevel.mockReturnValue({
       userLevel: STANDARD_USER,
       user_type: 'standard',
@@ -271,7 +271,7 @@ describe('Header / NavMenuDrawer role-based menus', () => {
     expect(drawerQueries.queryByText(/admin hub/i)).not.toBeInTheDocument();
   });
 
-  it('shows Admin Hub without Admin Tools for REGIONAL_ADMIN (userLevel = 2)', async () => {
+  it('shows Admin Hub without Admin Tools for REGIONAL_ADMIN', async () => {
     const user = userEvent.setup();
 
     mockedUseUserLevel.mockReturnValue({
@@ -314,7 +314,7 @@ describe('Header / NavMenuDrawer role-based menus', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('shows Admin Hub with Admin Tools for GLOBAL_ADMIN (userLevel = 4)', async () => {
+  it('shows Admin Hub with Admin Tools for GLOBAL_ADMIN', async () => {
     const user = userEvent.setup();
 
     mockedUseUserLevel.mockReturnValue({
@@ -359,7 +359,7 @@ describe('Header / NavMenuDrawer role-based menus', () => {
     ).toBeInTheDocument();
   });
 
-  it('shows Admin Hub without Admin Tools for GLOBAL_VIEW (userLevel = 3)', async () => {
+  it('shows Admin Hub without Admin Tools for GLOBAL_VIEW', async () => {
     const user = userEvent.setup();
 
     mockedUseUserLevel.mockReturnValue({


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds unit tests for the frontend navMenuDrawer.tsx
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This change is required to expand test coverage of the XFD frontend.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Code was tested by running vitest locally to verify the test cases worked. 

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [x] Create a pre-release (necessary if and only if the pre-release version was bumped).

