### PR TITLE
Fixing Use Case Description in New Okta SAML Logic

### DIFF
--- a/backend/src/xfd_django/xfd_api/auth_saml.py
+++ b/backend/src/xfd_django/xfd_api/auth_saml.py
@@ -299,7 +299,9 @@ def _upsert_user(identity: Dict[str, Any]) -> User:
 
     # Update additional fields
     user.cognito_username = None
-    user.cognito_use_case_description = identity["nickname"]
+    user.cognito_use_case_description = (
+        identity["nickname"] if "nickname" in identity else ""
+    )
     user.cognito_email_verified = True
     user.cognito_groups = groups
     user.last_logged_in = datetime.now(timezone.utc)

--- a/backend/src/xfd_django/xfd_api/auth_saml.py
+++ b/backend/src/xfd_django/xfd_api/auth_saml.py
@@ -247,6 +247,7 @@ def _extract_identity(auth: OneLogin_Saml2_Auth) -> Dict[str, Any]:
     email = (attrs.get("email") or [None])[0]
     first = (attrs.get("firstName") or attrs.get("given_name") or [""])[0]
     last = (attrs.get("lastName") or attrs.get("family_name") or [""])[0]
+    nickname = (attrs.get("nickname") or [""])[0]
     groups = attrs.get("groups") or []
 
     return {
@@ -255,6 +256,7 @@ def _extract_identity(auth: OneLogin_Saml2_Auth) -> Dict[str, Any]:
         "first": first,
         "last": last,
         "groups": groups,
+        "nickname": nickname,
     }
 
 

--- a/backend/src/xfd_django/xfd_api/auth_saml.py
+++ b/backend/src/xfd_django/xfd_api/auth_saml.py
@@ -299,7 +299,7 @@ def _upsert_user(identity: Dict[str, Any]) -> User:
 
     # Update additional fields
     user.cognito_username = None
-    user.cognito_use_case_description = None
+    user.cognito_use_case_description = identity["nickname"]
     user.cognito_email_verified = True
     user.cognito_groups = groups
     user.last_logged_in = datetime.now(timezone.utc)


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
Resolves CRASM-3660

Adds back the use_case (nickname) field in Okta auth processing)
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
Fixes missing use_case field in user upsert logic.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
After logging in, the use case field will now be populated correctly to determine use case (justification)
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

