### PR TITLE
Unit tests for SeverityByPromiananceTooltip CRASM-3553

### DIFF
--- a/frontend/src/tests/pages/Users/UserForm.test.tsx
+++ b/frontend/src/tests/pages/Users/UserForm.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, act } from 'test-utils';
+import { render, screen, waitFor } from 'test-utils';
 import userEvent from '@testing-library/user-event';
 import type { Organization } from 'types';
 import UserForm from '@/pages/Users/UserForm';
@@ -79,28 +79,6 @@ vi.mock('components/Dialog/AnimatedConfirmDialog', () => ({
       </div>
     ) : null
 }));
-
-type DeferredPromise<TValue> = {
-  promise: Promise<TValue>;
-  resolve: (value: TValue) => void;
-  reject: (reason?: unknown) => void;
-};
-
-const createDeferredPromise = <TValue,>(): DeferredPromise<TValue> => {
-  let resolvePromise!: (value: TValue) => void;
-  let rejectPromise!: (reason?: unknown) => void;
-
-  const promise = new Promise<TValue>((resolve, reject) => {
-    resolvePromise = resolve;
-    rejectPromise = reject;
-  });
-
-  return {
-    promise,
-    resolve: resolvePromise,
-    reject: rejectPromise
-  };
-};
 
 // -------------------- Helpers --------------------
 
@@ -207,9 +185,6 @@ describe('UserForm', () => {
   it('submits successfully and updates users list', async () => {
     const user = userEvent.setup();
 
-    const updateDeferred = createDeferredPromise<void>();
-    mockUpdateUser.mockReturnValueOnce(updateDeferred.promise);
-
     render(
       <UserForm
         users={baseUsers}
@@ -226,24 +201,10 @@ describe('UserForm', () => {
     );
 
     const confirmButton = await screen.findByTestId('user-form-confirm');
-
-    await act(async () => {
-      await user.click(confirmButton);
-    });
-
-    await act(async () => {
-      updateDeferred.resolve(undefined);
-      await updateDeferred.promise;
-    });
+    await user.click(confirmButton);
 
     await waitFor(() => {
       expect(mockUpdateUser).toHaveBeenCalledTimes(1);
-      expect(mockSetUsers).toHaveBeenCalledTimes(1);
-      expect(mockSetEditUserDialogOpen).toHaveBeenCalledWith(false);
-      expect(mockSetInfoDialogContent).toHaveBeenCalledWith(
-        'This user has been successfully updated.'
-      );
-      expect(mockSetInfoDialogOpen).toHaveBeenCalledWith(true);
     });
 
     const [calledId, calledBody] = mockUpdateUser.mock.calls[0];
@@ -258,6 +219,13 @@ describe('UserForm', () => {
 
     expect(mockRemoveUserFromOrganization).not.toHaveBeenCalled();
     expect(mockAddUserToOrganization).not.toHaveBeenCalled();
+
+    expect(mockSetUsers).toHaveBeenCalledTimes(1);
+    expect(mockSetEditUserDialogOpen).toHaveBeenCalledWith(false);
+    expect(mockSetInfoDialogContent).toHaveBeenCalledWith(
+      'This user has been successfully updated.'
+    );
+    expect(mockSetInfoDialogOpen).toHaveBeenCalledWith(true);
   });
 
   /**
@@ -271,8 +239,7 @@ describe('UserForm', () => {
       response: { data: { detail: 'Bad things happened' } }
     });
 
-    const updateDeferred = createDeferredPromise<void>();
-    mockUpdateUser.mockReturnValueOnce(updateDeferred.promise);
+    mockUpdateUser.mockRejectedValueOnce(error);
 
     render(
       <UserForm
@@ -290,28 +257,17 @@ describe('UserForm', () => {
     );
 
     const confirmButton = await screen.findByTestId('user-form-confirm');
-
-    await act(async () => {
-      await user.click(confirmButton);
-    });
-
-    await act(async () => {
-      updateDeferred.reject(error);
-      try {
-        await updateDeferred.promise;
-      } catch {
-        // Expected rejection.
-      }
-    });
+    await user.click(confirmButton);
 
     await waitFor(() => {
       expect(mockUpdateUser).toHaveBeenCalledTimes(1);
-      expect(mockSetApiErrorStates).toHaveBeenCalled();
-      expect(mockSetInfoDialogContent).toHaveBeenCalledWith(
-        'This user has not been updated. Check the console log for more details.'
-      );
-      expect(mockSetInfoDialogOpen).toHaveBeenCalledWith(true);
     });
+
+    expect(mockSetApiErrorStates).toHaveBeenCalled();
+    expect(mockSetInfoDialogContent).toHaveBeenCalledWith(
+      'This user has not been updated. Check the console log for more details.'
+    );
+    expect(mockSetInfoDialogOpen).toHaveBeenCalledWith(true);
   });
 
   /**
@@ -347,9 +303,6 @@ describe('UserForm', () => {
       refetch: vi.fn()
     });
 
-    const updateDeferred = createDeferredPromise<void>();
-    mockUpdateUser.mockReturnValueOnce(updateDeferred.promise);
-
     render(
       <UserForm
         users={baseUsers}
@@ -366,28 +319,17 @@ describe('UserForm', () => {
     );
 
     const confirmButton = await screen.findByTestId('user-form-confirm');
-
-    await act(async () => {
-      await user.click(confirmButton);
-    });
-
-    await act(async () => {
-      updateDeferred.resolve(undefined);
-      await updateDeferred.promise;
-    });
+    await user.click(confirmButton);
 
     await waitFor(() => {
       expect(mockUpdateUser).toHaveBeenCalledTimes(1);
-      expect(mockRemoveUserFromOrganization).toHaveBeenCalledWith(
-        'org-1',
-        'role-1'
-      );
-      expect(mockAddUserToOrganization).toHaveBeenCalledWith(
-        'org-2',
-        1,
-        'user'
-      );
     });
+
+    expect(mockRemoveUserFromOrganization).toHaveBeenCalledWith(
+      'org-1',
+      'role-1'
+    );
+    expect(mockAddUserToOrganization).toHaveBeenCalledWith('org-2', 1, 'user');
   });
 
   /**
@@ -700,16 +642,10 @@ describe('UserForm', () => {
     );
 
     const confirmButton = await screen.findByTestId('user-form-confirm');
-
-    await act(async () => {
-      await user.click(confirmButton);
-    });
+    await user.click(confirmButton);
 
     const dialog = await screen.findByTestId('user-form-dialog');
-
-    await waitFor(() => {
-      expect(dialog).toHaveAttribute('data-disabled', 'true');
-    });
+    expect(dialog).toHaveAttribute('data-disabled', 'true');
 
     resolveUpdate!();
 

--- a/frontend/src/tests/pages/Users/UserForm.test.tsx
+++ b/frontend/src/tests/pages/Users/UserForm.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from 'test-utils';
+import { render, screen, waitFor, act } from 'test-utils';
 import userEvent from '@testing-library/user-event';
 import type { Organization } from 'types';
 import UserForm from '@/pages/Users/UserForm';
@@ -79,6 +79,28 @@ vi.mock('components/Dialog/AnimatedConfirmDialog', () => ({
       </div>
     ) : null
 }));
+
+type DeferredPromise<TValue> = {
+  promise: Promise<TValue>;
+  resolve: (value: TValue) => void;
+  reject: (reason?: unknown) => void;
+};
+
+const createDeferredPromise = <TValue,>(): DeferredPromise<TValue> => {
+  let resolvePromise!: (value: TValue) => void;
+  let rejectPromise!: (reason?: unknown) => void;
+
+  const promise = new Promise<TValue>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+
+  return {
+    promise,
+    resolve: resolvePromise,
+    reject: rejectPromise
+  };
+};
 
 // -------------------- Helpers --------------------
 
@@ -185,6 +207,9 @@ describe('UserForm', () => {
   it('submits successfully and updates users list', async () => {
     const user = userEvent.setup();
 
+    const updateDeferred = createDeferredPromise<void>();
+    mockUpdateUser.mockReturnValueOnce(updateDeferred.promise);
+
     render(
       <UserForm
         users={baseUsers}
@@ -201,7 +226,15 @@ describe('UserForm', () => {
     );
 
     const confirmButton = await screen.findByTestId('user-form-confirm');
-    await user.click(confirmButton);
+
+    await act(async () => {
+      await user.click(confirmButton);
+    });
+
+    await act(async () => {
+      updateDeferred.resolve(undefined);
+      await updateDeferred.promise;
+    });
 
     await waitFor(() => {
       expect(mockUpdateUser).toHaveBeenCalledTimes(1);
@@ -238,7 +271,8 @@ describe('UserForm', () => {
       response: { data: { detail: 'Bad things happened' } }
     });
 
-    mockUpdateUser.mockRejectedValueOnce(error);
+    const updateDeferred = createDeferredPromise<void>();
+    mockUpdateUser.mockReturnValueOnce(updateDeferred.promise);
 
     render(
       <UserForm
@@ -256,7 +290,19 @@ describe('UserForm', () => {
     );
 
     const confirmButton = await screen.findByTestId('user-form-confirm');
-    await user.click(confirmButton);
+
+    await act(async () => {
+      await user.click(confirmButton);
+    });
+
+    await act(async () => {
+      updateDeferred.reject(error);
+      try {
+        await updateDeferred.promise;
+      } catch {
+        // Expected rejection.
+      }
+    });
 
     await waitFor(() => {
       expect(mockUpdateUser).toHaveBeenCalledTimes(1);
@@ -301,6 +347,9 @@ describe('UserForm', () => {
       refetch: vi.fn()
     });
 
+    const updateDeferred = createDeferredPromise<void>();
+    mockUpdateUser.mockReturnValueOnce(updateDeferred.promise);
+
     render(
       <UserForm
         users={baseUsers}
@@ -317,7 +366,15 @@ describe('UserForm', () => {
     );
 
     const confirmButton = await screen.findByTestId('user-form-confirm');
-    await user.click(confirmButton);
+
+    await act(async () => {
+      await user.click(confirmButton);
+    });
+
+    await act(async () => {
+      updateDeferred.resolve(undefined);
+      await updateDeferred.promise;
+    });
 
     await waitFor(() => {
       expect(mockUpdateUser).toHaveBeenCalledTimes(1);
@@ -643,7 +700,10 @@ describe('UserForm', () => {
     );
 
     const confirmButton = await screen.findByTestId('user-form-confirm');
-    await user.click(confirmButton);
+
+    await act(async () => {
+      await user.click(confirmButton);
+    });
 
     const dialog = await screen.findByTestId('user-form-dialog');
 

--- a/frontend/src/tests/pages/Users/UserForm.test.tsx
+++ b/frontend/src/tests/pages/Users/UserForm.test.tsx
@@ -205,6 +205,12 @@ describe('UserForm', () => {
 
     await waitFor(() => {
       expect(mockUpdateUser).toHaveBeenCalledTimes(1);
+      expect(mockSetUsers).toHaveBeenCalledTimes(1);
+      expect(mockSetEditUserDialogOpen).toHaveBeenCalledWith(false);
+      expect(mockSetInfoDialogContent).toHaveBeenCalledWith(
+        'This user has been successfully updated.'
+      );
+      expect(mockSetInfoDialogOpen).toHaveBeenCalledWith(true);
     });
 
     const [calledId, calledBody] = mockUpdateUser.mock.calls[0];
@@ -219,13 +225,6 @@ describe('UserForm', () => {
 
     expect(mockRemoveUserFromOrganization).not.toHaveBeenCalled();
     expect(mockAddUserToOrganization).not.toHaveBeenCalled();
-
-    expect(mockSetUsers).toHaveBeenCalledTimes(1);
-    expect(mockSetEditUserDialogOpen).toHaveBeenCalledWith(false);
-    expect(mockSetInfoDialogContent).toHaveBeenCalledWith(
-      'This user has been successfully updated.'
-    );
-    expect(mockSetInfoDialogOpen).toHaveBeenCalledWith(true);
   });
 
   /**
@@ -261,13 +260,12 @@ describe('UserForm', () => {
 
     await waitFor(() => {
       expect(mockUpdateUser).toHaveBeenCalledTimes(1);
+      expect(mockSetApiErrorStates).toHaveBeenCalled();
+      expect(mockSetInfoDialogContent).toHaveBeenCalledWith(
+        'This user has not been updated. Check the console log for more details.'
+      );
+      expect(mockSetInfoDialogOpen).toHaveBeenCalledWith(true);
     });
-
-    expect(mockSetApiErrorStates).toHaveBeenCalled();
-    expect(mockSetInfoDialogContent).toHaveBeenCalledWith(
-      'This user has not been updated. Check the console log for more details.'
-    );
-    expect(mockSetInfoDialogOpen).toHaveBeenCalledWith(true);
   });
 
   /**
@@ -323,13 +321,16 @@ describe('UserForm', () => {
 
     await waitFor(() => {
       expect(mockUpdateUser).toHaveBeenCalledTimes(1);
+      expect(mockRemoveUserFromOrganization).toHaveBeenCalledWith(
+        'org-1',
+        'role-1'
+      );
+      expect(mockAddUserToOrganization).toHaveBeenCalledWith(
+        'org-2',
+        1,
+        'user'
+      );
     });
-
-    expect(mockRemoveUserFromOrganization).toHaveBeenCalledWith(
-      'org-1',
-      'role-1'
-    );
-    expect(mockAddUserToOrganization).toHaveBeenCalledWith('org-2', 1, 'user');
   });
 
   /**
@@ -645,7 +646,10 @@ describe('UserForm', () => {
     await user.click(confirmButton);
 
     const dialog = await screen.findByTestId('user-form-dialog');
-    expect(dialog).toHaveAttribute('data-disabled', 'true');
+
+    await waitFor(() => {
+      expect(dialog).toHaveAttribute('data-disabled', 'true');
+    });
 
     resolveUpdate!();
 

--- a/frontend/src/tests/pages/VulnerabilityScanDash/SeverityByProminanceTooltip.test.tsx
+++ b/frontend/src/tests/pages/VulnerabilityScanDash/SeverityByProminanceTooltip.test.tsx
@@ -1,0 +1,236 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from 'test-utils';
+
+import SevByPromTooltip from '@/pages/VulnerabilityScanDash/SeverityByProminanceTooltip';
+
+// ----------------------------
+// Mocks
+// ----------------------------
+const mockUseItemTooltip = vi.fn();
+
+vi.mock('@mui/x-charts/ChartsTooltip', () => ({
+  useItemTooltip: () => mockUseItemTooltip()
+}));
+
+const mockFormatDisplayValue = vi.fn(
+  (value: unknown) => `formatted:${String(value)}`
+);
+
+vi.mock('@/utils/stringUtils', () => ({
+  formatDisplayValue: (value: unknown) => mockFormatDisplayValue(value)
+}));
+
+// ----------------------------
+// Tests
+// ----------------------------
+describe('SevByPromTooltip', () => {
+  const allDataFixture = [
+    {
+      type: 'All',
+      criticalMaxAge: 12,
+      highMaxAge: 34,
+      mediumMaxAge: 56,
+      lowMaxAge: 78
+    },
+    {
+      type: 'KEV',
+      criticalMaxAge: 3,
+      highMaxAge: 6,
+      mediumMaxAge: 9,
+      lowMaxAge: 12
+    }
+  ];
+
+  const datasetFixture = [
+    { severity: 'Critical', value: 45 },
+    { severity: 'High', value: 105 }
+  ];
+
+  beforeEach(() => {
+    // Reset hook and formatting mocks between tests.
+    mockUseItemTooltip.mockReset();
+    mockFormatDisplayValue.mockClear();
+  });
+
+  it('returns null when tooltipData is null', () => {
+    // Ensures tooltip does not render when the chart tooltip hook has no data.
+    mockUseItemTooltip.mockReturnValue(null);
+
+    const { container } = render(
+      <SevByPromTooltip allData={allDataFixture} dataset={datasetFixture} />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('returns null when dataIndex is missing/invalid', () => {
+    // Ensures tooltip does not render when the hook output has no usable dataIndex.
+    mockUseItemTooltip.mockReturnValue({
+      identifier: undefined,
+      color: '#002B45'
+    });
+
+    const firstRender = render(
+      <SevByPromTooltip allData={allDataFixture} dataset={datasetFixture} />
+    );
+
+    expect(firstRender.container).toBeEmptyDOMElement();
+
+    mockUseItemTooltip.mockReturnValue({
+      identifier: { dataIndex: -1 },
+      color: '#002B45'
+    });
+
+    const secondRender = render(
+      <SevByPromTooltip allData={allDataFixture} dataset={datasetFixture} />
+    );
+
+    expect(secondRender.container).toBeEmptyDOMElement();
+  });
+
+  it('returns null when severity cannot be derived from dataset[dataIndex]', () => {
+    // Ensures tooltip does not render when the dataset cannot provide a severity for the active index.
+    mockUseItemTooltip.mockReturnValue({
+      identifier: { dataIndex: 0 },
+      color: '#002B45'
+    });
+
+    const { container } = render(
+      <SevByPromTooltip allData={allDataFixture} dataset={[]} />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders "Detected KEVs" label and includes Max Age (Days) for color #002B45', () => {
+    // Verifies KEV branch label, total count, and max age values render correctly.
+    mockUseItemTooltip.mockReturnValue({
+      identifier: { dataIndex: 0 },
+      color: '#002B45'
+    });
+
+    render(
+      <SevByPromTooltip allData={allDataFixture} dataset={datasetFixture} />
+    );
+
+    expect(screen.getByText('Detected KEVs')).toBeInTheDocument();
+
+    expect(screen.getByText('Total Count')).toBeInTheDocument();
+    expect(screen.getByText('formatted:45')).toBeInTheDocument();
+
+    expect(screen.getByText('Max Age (Days)')).toBeInTheDocument();
+    expect(screen.getByText('formatted:3')).toBeInTheDocument(); // KEV + critical
+  });
+
+  it('renders "Distinct Vulnerabilities" label and DOES NOT include Max Age (Days) for color #005288', () => {
+    // Verifies distinct branch label renders and max age section is omitted.
+    mockUseItemTooltip.mockReturnValue({
+      identifier: { dataIndex: 0 },
+      color: '#005288'
+    });
+
+    render(
+      <SevByPromTooltip allData={allDataFixture} dataset={datasetFixture} />
+    );
+
+    expect(screen.getByText('Distinct Vulnerabilities')).toBeInTheDocument();
+
+    expect(screen.getByText('Total Count')).toBeInTheDocument();
+    expect(screen.getByText('formatted:45')).toBeInTheDocument();
+
+    expect(screen.queryByText('Max Age (Days)')).toBeNull();
+  });
+
+  it('renders "Detected Vulnerabilities" label and includes Max Age (Days) for all other colors', () => {
+    // Verifies default branch label, total count, and max age values render correctly.
+    mockUseItemTooltip.mockReturnValue({
+      identifier: { dataIndex: 0 },
+      color: '#0078AE'
+    });
+
+    render(
+      <SevByPromTooltip allData={allDataFixture} dataset={datasetFixture} />
+    );
+
+    expect(screen.getByText('Detected Vulnerabilities')).toBeInTheDocument();
+
+    expect(screen.getByText('Total Count')).toBeInTheDocument();
+    expect(screen.getByText('formatted:45')).toBeInTheDocument();
+
+    expect(screen.getByText('Max Age (Days)')).toBeInTheDocument();
+    expect(screen.getByText('formatted:12')).toBeInTheDocument(); // All + critical
+  });
+
+  it('updates content when switching segments (dataIndex changes)', () => {
+    // Verifies tooltip values change when the active segment index changes.
+    mockUseItemTooltip.mockReturnValue({
+      identifier: { dataIndex: 0 },
+      color: '#002B45'
+    });
+
+    const rendered = render(
+      <SevByPromTooltip allData={allDataFixture} dataset={datasetFixture} />
+    );
+
+    expect(screen.getByText('formatted:45')).toBeInTheDocument();
+    expect(screen.getByText('formatted:3')).toBeInTheDocument();
+
+    mockUseItemTooltip.mockReturnValue({
+      identifier: { dataIndex: 1 },
+      color: '#002B45'
+    });
+
+    rendered.rerender(
+      <SevByPromTooltip allData={allDataFixture} dataset={datasetFixture} />
+    );
+
+    expect(screen.getByText('formatted:105')).toBeInTheDocument();
+    expect(screen.getByText('formatted:6')).toBeInTheDocument();
+  });
+
+  it('handles missing max age data (formatDisplayValue called with undefined)', () => {
+    // Verifies missing max age values render safely and are passed to the formatter as undefined.
+    const allDataMissingFixture = [{ type: 'All' }];
+
+    mockUseItemTooltip.mockReturnValue({
+      identifier: { dataIndex: 0 },
+      color: '#0078AE'
+    });
+
+    render(
+      <SevByPromTooltip
+        allData={allDataMissingFixture}
+        dataset={datasetFixture}
+      />
+    );
+
+    expect(screen.getByText('Detected Vulnerabilities')).toBeInTheDocument();
+    expect(screen.getByText('Max Age (Days)')).toBeInTheDocument();
+    expect(screen.getByText('formatted:undefined')).toBeInTheDocument();
+
+    expect(mockFormatDisplayValue).toHaveBeenCalledWith(undefined);
+  });
+
+  it('hides when tooltipData becomes null (simulating mouse leave / blur)', () => {
+    // Verifies tooltip unmounts when the chart tooltip hook returns null (dismissal).
+    mockUseItemTooltip.mockReturnValue({
+      identifier: { dataIndex: 0 },
+      color: '#002B45'
+    });
+
+    const rendered = render(
+      <SevByPromTooltip allData={allDataFixture} dataset={datasetFixture} />
+    );
+
+    expect(screen.getByText('Detected KEVs')).toBeInTheDocument();
+
+    mockUseItemTooltip.mockReturnValue(null);
+    rendered.rerender(
+      <SevByPromTooltip allData={allDataFixture} dataset={datasetFixture} />
+    );
+
+    expect(screen.queryByText('Detected KEVs')).toBeNull();
+    expect(screen.queryByText('Total Count')).toBeNull();
+  });
+});

--- a/frontend/vite.config.mts
+++ b/frontend/vite.config.mts
@@ -77,10 +77,10 @@ export default defineConfig({
         'src/components/Metrics/*'
       ],
       thresholds: {
-        statements: 46.71,
-        branches: 34.89,
-        functions: 42.36,
-        lines: 47.23,
+        statements: 45.78,
+        branches: 34.52,
+        functions: 41.25,
+        lines: 46.29,
         autoUpdate: true
       }
     }

--- a/frontend/vite.config.mts
+++ b/frontend/vite.config.mts
@@ -77,10 +77,10 @@ export default defineConfig({
         'src/components/Metrics/*'
       ],
       thresholds: {
-        statements: 43.59,
-        branches: 32.78,
-        functions: 38.82,
-        lines: 44.09,
+        statements: 44.27,
+        branches: 33.62,
+        functions: 39.53,
+        lines: 44.74,
         autoUpdate: true
       }
     }

--- a/frontend/vite.config.mts
+++ b/frontend/vite.config.mts
@@ -77,10 +77,10 @@ export default defineConfig({
         'src/components/Metrics/*'
       ],
       thresholds: {
-        statements: 45.36,
-        branches: 33.96,
-        functions: 40.95,
-        lines: 45.91,
+        statements: 46.71,
+        branches: 34.89,
+        functions: 42.36,
+        lines: 47.23,
         autoUpdate: true
       }
     }


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Added unit tests for SeverityByProminanceTooltip to check that it shows the right text for each tooltip state, updates when the selected segment changes, and disappears when the tooltip is no longer active.

## 💭 Motivation and context ##

We’re adding unit tests to make sure the tooltip always shows the right label and values for the selected chart segment, updates correctly when the user moves to a different segment, and disappears when it should. This helps catch UI breakages early when the tooltip logic or data mapping changes.

## 🧪 Testing ##

Tested locally

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

