### PR TITLE
Fix Org Table Filter Model Bug (CRASM-3677)

### DIFF
--- a/frontend/src/pages/Organizations/Organizations.tsx
+++ b/frontend/src/pages/Organizations/Organizations.tsx
@@ -36,7 +36,8 @@ import { logger } from '@/utils/logger';
 import {
   cleanFilterModelItems,
   shouldTriggerFilterUpdate,
-  buildOrgFilters
+  buildOrgFilters,
+  isFilterModelEmpty
 } from '@/utils/tableUtils';
 
 // Constants
@@ -233,6 +234,11 @@ export const Organizations: React.FC = () => {
           onFilterModelChange={(model) => {
             const cleanedModel = cleanFilterModelItems(model, filterModel);
             setFilterModel(cleanedModel);
+            const emptyModel = isFilterModelEmpty(cleanedModel);
+            if (emptyModel) {
+              setHasActiveFilters(false);
+              return;
+            }
 
             const shouldUpdate = shouldTriggerFilterUpdate(
               cleanedModel.items,

--- a/frontend/src/tests/utils/cleanFilterModelItems.test.ts
+++ b/frontend/src/tests/utils/cleanFilterModelItems.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { cleanFilterModelItems } from '@/utils/tableUtils';
 
 describe('cleanFilterModelItems', () => {
-  it('clears value when field changes then filters them out', () => {
+  it('clears value when field changes and sets it to undefined', () => {
     const newModel = {
       items: [{ id: 1, field: 'name', operator: 'equals', value: 'test' }]
     };
@@ -13,10 +13,10 @@ describe('cleanFilterModelItems', () => {
     };
 
     const cleanedModel = cleanFilterModelItems(newModel, previousModel);
-    expect(cleanedModel.items.length).toBe(0);
+    expect(cleanedModel.items[0].value).toBeUndefined();
   });
 
-  it('normalizes empty/null/whitespace values to undefined then filters them out', () => {
+  it('normalizes empty/null/whitespace values to undefined', () => {
     const newModel = {
       items: [{ id: 1, field: 'name', operator: 'equals', value: '' }]
     };
@@ -25,6 +25,6 @@ describe('cleanFilterModelItems', () => {
     };
 
     const cleanedModel = cleanFilterModelItems(newModel, previousModel);
-    expect(cleanedModel.items.length).toBe(0);
+    expect(cleanedModel.items[0].value).toBeUndefined();
   });
 });

--- a/frontend/src/tests/utils/isFilterModelEmpty.test.ts
+++ b/frontend/src/tests/utils/isFilterModelEmpty.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { isFilterModelEmpty } from '@/utils/tableUtils';
+
+describe('isFilterModelEmpty', () => {
+  it('returns true for an empty filter model', () => {
+    const model = { items: [] };
+    expect(isFilterModelEmpty(model)).toBe(true);
+  });
+
+  it('returns true for a filter model with an undefined values', () => {
+    const model = {
+      items: [{ field: 'name', operator: 'contains', value: undefined }]
+    };
+    expect(isFilterModelEmpty(model)).toBe(true);
+  });
+
+  it('returns true for a filter model with null values', () => {
+    const model = {
+      items: [{ field: 'name', operator: 'contains', value: null }]
+    };
+    expect(isFilterModelEmpty(model)).toBe(true);
+  });
+
+  it('returns true for a filter model with empty string values', () => {
+    const model = {
+      items: [{ field: 'name', operator: 'contains', value: '' }]
+    };
+    expect(isFilterModelEmpty(model)).toBe(true);
+  });
+
+  it('returns false for a filter model with a defined value', () => {
+    const model = {
+      items: [{ field: 'name', operator: 'contains', value: 'Test' }]
+    };
+    expect(isFilterModelEmpty(model)).toBe(false);
+  });
+});

--- a/frontend/src/utils/tableUtils.ts
+++ b/frontend/src/utils/tableUtils.ts
@@ -203,34 +203,34 @@ export const cleanFilterModelItems = (
   newModel: GridFilterModel,
   previousModel: GridFilterModel
 ): GridFilterModel => {
-  const cleanedItems = newModel.items
-    .map((item, index) => {
-      const prevItem = previousModel.items[index];
+  const cleanedItems = newModel.items.map((item, index) => {
+    const prevItem = previousModel.items[index];
 
-      // Clear value when field changes (prevents value carryover)
-      if (
-        prevItem &&
-        prevItem.field !== item.field &&
-        prevItem.id === item.id
-      ) {
-        return { ...item, value: undefined };
-      }
+    // Clear value when field changes (prevents value carryover)
+    if (prevItem && prevItem.field !== item.field && prevItem.id === item.id) {
+      return { ...item, value: undefined };
+    }
 
-      // Normalize empty/null/whitespace values to undefined
-      if (
-        item.value === '' ||
-        item.value === null ||
-        (typeof item.value === 'string' && item.value.trim() === '')
-      ) {
-        return { ...item, value: undefined };
-      }
+    // Normalize empty/null/whitespace values to undefined
+    if (
+      item.value === '' ||
+      item.value === null ||
+      (typeof item.value === 'string' && item.value.trim() === '')
+    ) {
+      return { ...item, value: undefined };
+    }
 
-      return item;
-    })
-
-    .filter((item) => item.value !== undefined);
+    return item;
+  });
 
   return { ...newModel, items: cleanedItems };
+};
+
+export const isFilterModelEmpty = (model: GridFilterModel): boolean => {
+  return model.items.every(
+    (item) =>
+      item.value === undefined || item.value === null || item.value === ''
+  );
 };
 
 export const buildOrgFilters = (model: GridFilterModel) => {


### PR DESCRIPTION


<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #
**Fix Org Table Filter Model Bug (CRASM-3677)**

## 🗣 Description ##
- resolves issue where undefined values were preventing updates to the filter model's "field" and "operator" columns.
- added helper function to check if filter model is empty.
- returns true if all filter items have undefined, null, or empty string values.
- if true, filter badge should not be displayed.
- early return from all other filter related logic when model is empty.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
