### PR TITLE
3861 - Fix update user state dialog modal always showing

### DIFF
--- a/frontend/src/hooks/useCheckUserState.ts
+++ b/frontend/src/hooks/useCheckUserState.ts
@@ -5,11 +5,7 @@ export function useCheckUserState(user: any, isLoggingOut: boolean | null) {
 
   useEffect(() => {
     if (!isLoggingOut && user) {
-      if (
-        !user.state ||
-        user.state === '' ||
-        !localStorage.getItem('user_state')
-      ) {
+      if (!user.state || user.state === '') {
         setIsUpdateStateFormOpen(true);
       }
     }

--- a/frontend/src/tests/hooks/useCheckUserState.test.ts
+++ b/frontend/src/tests/hooks/useCheckUserState.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, act } from '@testing-library/react';
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { useCheckUserState } from '../../hooks/useCheckUserState';
 
 const userWithState = { state: 'VA' };
@@ -7,16 +7,7 @@ const userWithoutState = { state: null };
 const userWithEmptyState = { state: '' };
 
 describe('useCheckUserState', () => {
-  beforeEach(() => {
-    localStorage.clear();
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it('opens the form when user has no state', () => {
-    localStorage.setItem('user_state', 'VA');
     const { result } = renderHook(() =>
       useCheckUserState(userWithoutState, false)
     );
@@ -24,22 +15,13 @@ describe('useCheckUserState', () => {
   });
 
   it('opens the form when user state is empty string', () => {
-    localStorage.setItem('user_state', 'VA');
     const { result } = renderHook(() =>
       useCheckUserState(userWithEmptyState, false)
     );
     expect(result.current.isUpdateStateFormOpen).toBe(true);
   });
 
-  it('opens the form when localStorage user_state is missing', () => {
-    const { result } = renderHook(() =>
-      useCheckUserState(userWithState, false)
-    );
-    expect(result.current.isUpdateStateFormOpen).toBe(true);
-  });
-
-  it('does not open the form when user has state and localStorage is set', () => {
-    localStorage.setItem('user_state', 'VA');
+  it('does not open the form when user has state', () => {
     const { result } = renderHook(() =>
       useCheckUserState(userWithState, false)
     );
@@ -59,7 +41,6 @@ describe('useCheckUserState', () => {
   });
 
   it('opens the form when isLoggingOut transitions from true to false', () => {
-    localStorage.setItem('user_state', 'VA');
     const { result, rerender } = renderHook(
       ({ isLoggingOut }) => useCheckUserState(userWithoutState, isLoggingOut),
       { initialProps: { isLoggingOut: true as boolean | null } }


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

A bug was introduced in previously committed code on this branch: [361b0f8](https://github.com/cisagov/XFD/commit/361b0f8b975fd9916e043869446130063dbf4b80)
The bug involved he update state modal showing with the user having a valid state field on their user record. 

Remove localStorage state check from useCheckUserState hook to determine when UpdateStateForm should show. This change brings the logic directly in line with backend logic for allowing the user to perform such an update.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [x] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
