### PR TITLE
CRASM-3974: Cleanup P&E logs and P&E queue watcher

### DIFF
--- a/backend/pe/peScanController.py
+++ b/backend/pe/peScanController.py
@@ -176,20 +176,27 @@ def queue_url_prefix() -> str:
 
 
 def queue_url_for_scan(scan_type: str) -> str:
-    """Return the queue URL for a scan, creating the queue locally if needed."""
+    """Return the queue URL for a scan, creating the queue if it does not exist."""
+    client = sqs_client()
+    queue_name = queue_name_for_scan(scan_type)
+    response = client.create_queue(
+        QueueName=queue_name,
+        Attributes={
+            "VisibilityTimeout": str(VISIBILITY_TIMEOUT_SECONDS),
+            "MaximumMessageSize": "262144",
+            "MessageRetentionPeriod": "604800",
+        },
+    )
+    queue_url = response["QueueUrl"]
     if sqs_endpoint_url():
-        client = sqs_client()
-        queue_name = queue_name_for_scan(scan_type)
-        response = client.create_queue(QueueName=queue_name)
-        queue_url = normalize_local_queue_url(response["QueueUrl"])
-        client.set_queue_attributes(
-            QueueUrl=queue_url,
-            Attributes={
-                "VisibilityTimeout": str(VISIBILITY_TIMEOUT_SECONDS),
-            },
-        )
-        return queue_url
-    return "{}{}-queue".format(queue_url_prefix(), scan_type)
+        queue_url = normalize_local_queue_url(queue_url)
+    client.set_queue_attributes(
+        QueueUrl=queue_url,
+        Attributes={
+            "VisibilityTimeout": str(VISIBILITY_TIMEOUT_SECONDS),
+        },
+    )
+    return queue_url
 
 
 def pe_db_connection_params() -> Dict[str, str]:

--- a/backend/pe/tests/test_pe_scan_controller.py
+++ b/backend/pe/tests/test_pe_scan_controller.py
@@ -6,7 +6,12 @@ import unittest
 from unittest.mock import MagicMock, mock_open, patch
 
 # Third-Party Libraries
-from pe.peScanController import queue_name_for_scan, resolve_orgs, resolve_scans
+from pe.peScanController import (
+    queue_name_for_scan,
+    queue_url_for_scan,
+    resolve_orgs,
+    resolve_scans,
+)
 
 
 class QueueNameTests(unittest.TestCase):
@@ -26,6 +31,30 @@ class QueueNameTests(unittest.TestCase):
             self.assertEqual(
                 queue_name_for_scan("shodan"), "pe-integration-shodan-queue"
             )
+
+
+class QueueUrlForScanTests(unittest.TestCase):
+    """Verify scan queues are created before messages are sent."""
+
+    @patch("pe.peScanController.sqs_client")
+    @patch("pe.peScanController.sqs_endpoint_url", return_value=None)
+    def test_aws_create_queue_before_send(self, _endpoint_mock, client_mock):
+        """AWS deployments should create the queue when it does not exist yet."""
+        client = MagicMock()
+        client_mock.return_value = client
+        client.create_queue.return_value = {
+            "QueueUrl": "https://sqs.us-east-1.amazonaws.com/123/pe-staging-dnstwist-queue"
+        }
+        with patch.dict(os.environ, {"PE_QUEUE_PREFIX": "pe-staging"}, clear=False):
+            url = queue_url_for_scan("dnstwist")
+        self.assertEqual(
+            url, "https://sqs.us-east-1.amazonaws.com/123/pe-staging-dnstwist-queue"
+        )
+        client.create_queue.assert_called_once()
+        create_kwargs = client.create_queue.call_args.kwargs
+        self.assertEqual(create_kwargs["QueueName"], "pe-staging-dnstwist-queue")
+        self.assertEqual(create_kwargs["Attributes"]["VisibilityTimeout"], "18000")
+        client.set_queue_attributes.assert_called_once()
 
 
 class ResolveScansTests(unittest.TestCase):

--- a/backend/pe/tools/pe_queue_lib.sh
+++ b/backend/pe/tools/pe_queue_lib.sh
@@ -9,19 +9,28 @@ pe_queue_lib_init() {
     esac
   fi
   PE_QUEUE_REGION="${AWS_REGION:-us-east-1}"
-  if [[ -z "${PE_QUEUE_ACCOUNT_ID:-}" ]]; then
-    PE_QUEUE_ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+}
+
+pe_queue_url_for_catalog_key() {
+  local queue_name err_file url
+  queue_name="$(pe_queue_name_for_catalog_key "$1")"
+  err_file="$(mktemp)"
+  if ! url="$(aws sqs get-queue-url \
+    --region "$PE_QUEUE_REGION" \
+    --queue-name "$queue_name" \
+    --query QueueUrl \
+    --output text 2>"$err_file")"; then
+    PE_LAST_QUEUE_ERROR="$(tr '\n' ' ' < "$err_file" | sed 's/  */ /g; s/^ //; s/ $//')"
+    rm -f "$err_file"
+    return 1
   fi
+  rm -f "$err_file"
+  PE_LAST_QUEUE_ERROR=""
+  printf '%s' "$url"
 }
 
 pe_queue_name_for_catalog_key() {
   echo "${PE_QUEUE_PREFIX}-${1}-queue"
-}
-
-pe_queue_url_for_catalog_key() {
-  local queue_name
-  queue_name="$(pe_queue_name_for_catalog_key "$1")"
-  echo "https://sqs.${PE_QUEUE_REGION}.amazonaws.com/${PE_QUEUE_ACCOUNT_ID}/${queue_name}"
 }
 
 # Split comma-separated catalog keys into lines (trimmed, non-empty).
@@ -30,43 +39,68 @@ pe_split_catalog_keys() {
   printf '%s' "$scans_csv" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | sed '/^$/d'
 }
 
-# Print "queue_name visible in_flight" or return 1 if the queue does not exist.
+# Print "visible in_flight" or return 1. Sets PE_LAST_QUEUE_ERROR on failure.
 pe_read_queue_depth() {
   local queue_url="$1"
-  local attrs
+  local err_file attrs visible in_flight
+  PE_LAST_QUEUE_ERROR=""
+  err_file="$(mktemp)"
   if ! attrs="$(aws sqs get-queue-attributes \
     --region "$PE_QUEUE_REGION" \
     --queue-url "$queue_url" \
     --attribute-names ApproximateNumberOfMessages ApproximateNumberOfMessagesNotVisible \
-    --output json 2>/dev/null)"; then
+    --output json 2>"$err_file")"; then
+    PE_LAST_QUEUE_ERROR="$(tr '\n' ' ' < "$err_file" | sed 's/  */ /g; s/^ //; s/ $//')"
+    rm -f "$err_file"
     return 1
   fi
-  local visible in_flight
+  rm -f "$err_file"
   visible="$(printf '%s' "$attrs" | jq -r '.Attributes.ApproximateNumberOfMessages // "0"')"
   in_flight="$(printf '%s' "$attrs" | jq -r '.Attributes.ApproximateNumberOfMessagesNotVisible // "0"')"
-  echo "$visible $in_flight"
+  PE_LAST_QUEUE_DEPTH="${visible} ${in_flight}"
+  return 0
 }
 
 pe_print_queue_status_for_scans() {
   local scans_csv="$1"
-  local scan_key queue_name queue_url depths visible in_flight
+  local scan_key queue_name queue_url visible in_flight
   local any=false
+  local unreadable=false
 
-  while IFS= read -r scan_key; do
+  while IFS= read -r scan_key || [[ -n "$scan_key" ]]; do
+    [[ -z "$scan_key" ]] && continue
     queue_name="$(pe_queue_name_for_catalog_key "$scan_key")"
-    queue_url="$(pe_queue_url_for_catalog_key "$scan_key")"
-    if ! depths="$(pe_read_queue_depth "$queue_url")"; then
-      echo "  ${queue_name}: (queue not found)"
+    if ! queue_url="$(pe_queue_url_for_catalog_key "$scan_key")"; then
+      if [[ -n "${PE_LAST_QUEUE_ERROR:-}" ]]; then
+        echo "  ${queue_name}: (cannot resolve queue — ${PE_LAST_QUEUE_ERROR})"
+      else
+        echo "  ${queue_name}: (queue not found)"
+      fi
+      unreadable=true
       continue
     fi
-    visible="${depths%% *}"
-    in_flight="${depths#* }"
+    if ! pe_read_queue_depth "$queue_url"; then
+      if [[ -n "${PE_LAST_QUEUE_ERROR:-}" ]]; then
+        echo "  ${queue_name}: (cannot read queue — ${PE_LAST_QUEUE_ERROR})"
+      else
+        echo "  ${queue_name}: (cannot read queue)"
+      fi
+      unreadable=true
+      continue
+    fi
+    visible="${PE_LAST_QUEUE_DEPTH%% *}"
+    in_flight="${PE_LAST_QUEUE_DEPTH#* }"
     echo "  ${queue_name}: ${visible} visible, ${in_flight} in flight"
     if [[ "$visible" != "0" || "$in_flight" != "0" ]]; then
       any=true
     fi
-  done < <(pe_split_catalog_keys "$scans_csv")
+  done <<EOF
+$(pe_split_catalog_keys "$scans_csv")
+EOF
 
+  if [[ "$unreadable" == true ]]; then
+    return 2
+  fi
   if [[ "$any" == true ]]; then
     return 0
   fi
@@ -75,35 +109,45 @@ pe_print_queue_status_for_scans() {
 
 pe_queues_have_messages() {
   pe_print_queue_status_for_scans "$1" >/dev/null
+  return $?
 }
 
 pe_purge_queues_for_scans() {
   local scans_csv="$1"
   local scan_key queue_name queue_url
-  while IFS= read -r scan_key; do
+  while IFS= read -r scan_key || [[ -n "$scan_key" ]]; do
+    [[ -z "$scan_key" ]] && continue
     queue_name="$(pe_queue_name_for_catalog_key "$scan_key")"
-    queue_url="$(pe_queue_url_for_catalog_key "$scan_key")"
+    if ! queue_url="$(pe_queue_url_for_catalog_key "$scan_key")"; then
+      echo "ERROR: could not resolve queue URL for ${queue_name}" >&2
+      return 1
+    fi
     echo "Purging ${queue_name}..."
     if ! aws sqs purge-queue --region "$PE_QUEUE_REGION" --queue-url "$queue_url"; then
       echo "ERROR: failed to purge ${queue_name}. Ensure the IAM principal has sqs:PurgeQueue." >&2
       return 1
     fi
-  done < <(pe_split_catalog_keys "$scans_csv")
+  done <<EOF
+$(pe_split_catalog_keys "$scans_csv")
+EOF
 }
 
 pe_confirm_queue_action() {
   local scans_csv="$1"
   local choice
 
-  echo "The following PE scan queues already contain messages:"
-  echo
-  pe_print_queue_status_for_scans "$scans_csv"
-  echo
-  echo "Choose an action:"
-  echo "  [c] Clear queues (purge) and continue"
-  echo "  [C] Continue without clearing (append new messages / use existing backlog)"
-  echo "  [a] Abort"
-  echo
+  echo "The following PE scan queues already contain messages:" >&2
+  echo >&2
+  pe_print_queue_status_for_scans "$scans_csv" >&2
+  echo >&2
+  echo "Choose an action:" >&2
+  echo "  c — Purge selected queues, then invoke the scan (visible messages only)" >&2
+  echo "  C — Keep existing messages and invoke anyway (append / use backlog)" >&2
+  echo "  a — Abort (do not invoke Lambda)" >&2
+  echo >&2
+  echo "Note: purge does not remove in-flight messages (already received by workers)." >&2
+  echo "Stop running ECS tasks first if you need a fully empty queue." >&2
+  echo >&2
 
   if [[ ! -t 0 ]]; then
     echo "ERROR: queues are not empty and stdin is not a TTY." >&2
@@ -112,14 +156,14 @@ pe_confirm_queue_action() {
   fi
 
   while true; do
-    read -r -p "Choice [c/C/a]: " choice
+    read -r -p "Enter c (purge+continue), C (continue), or a (abort): " choice
     case "$choice" in
       c|C) echo "$choice"; return 0 ;;
       a|A)
         echo "Aborted." >&2
         return 2
         ;;
-      *) echo "Enter c, C, or a." ;;
+      *) echo "Enter c (purge+continue), C (continue), or a (abort)." >&2 ;;
     esac
   done
 }
@@ -138,6 +182,11 @@ pe_guard_queues_for_scans() {
   fi
 
   if ! pe_queues_have_messages "$scans_csv"; then
+    status=$?
+    if [[ "$status" -eq 2 ]]; then
+      echo "ERROR: could not read one or more PE scan queues (check IAM sqs:GetQueueAttributes on pe-staging-*)." >&2
+      return 1
+    fi
     echo "PE scan queues are empty for: ${scans_csv}"
     return 0
   fi
@@ -156,6 +205,10 @@ pe_guard_queues_for_scans() {
     pe_purge_queues_for_scans "$scans_csv"
     echo "Waiting 5s for SQS purge to settle..."
     sleep 5
+    if pe_queues_have_messages "$scans_csv"; then
+      echo "WARNING: queue still has messages after purge (in-flight messages are not purged)." >&2
+      pe_print_queue_status_for_scans "$scans_csv" >&2
+    fi
   fi
   return 0
 }

--- a/backend/pe/tools/watch_queues.sh
+++ b/backend/pe/tools/watch_queues.sh
@@ -58,10 +58,16 @@ command -v jq >/dev/null 2>&1 || { echo "ERROR: jq is required" >&2; exit 1; }
 pe_queue_lib_init
 
 print_status() {
-  local timestamp
+  local timestamp status
   timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
   echo "=== ${timestamp} ==="
-  if pe_print_queue_status_for_scans "$SCANS"; then
+  pe_print_queue_status_for_scans "$SCANS"
+  status=$?
+  if [[ "$status" -eq 2 ]]; then
+    echo "  (could not read one or more queues — check IAM or AWS_REGION)" >&2
+    return 2
+  fi
+  if [[ "$status" -eq 0 ]]; then
     echo "  (messages still present)"
     return 1
   fi
@@ -72,6 +78,10 @@ print_status() {
 if [[ "$ONCE" == true ]]; then
   if print_status; then
     exit 0
+  fi
+  status=$?
+  if [[ "$status" -eq 2 ]]; then
+    exit 2
   fi
   exit 1
 fi

--- a/backend/pe/worker/pe_worker.py
+++ b/backend/pe/worker/pe_worker.py
@@ -19,7 +19,6 @@ from botocore.exceptions import ClientError
 LOGGER = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 
-LOG_PATH = "/app/pe_reports_logging.log"
 EMPTY_CONFIRM_SLEEP_SECONDS = 5
 POLL_WAIT_SECONDS = 5
 # Keep in sync with peScanController.VISIBILITY_TIMEOUT_SECONDS / XFD scan queues.
@@ -181,10 +180,6 @@ def run_scan(service_type: str, org: str) -> bool:
         LOGGER.error("Scan command exited with code %s", exit_code)
         return False
 
-    if os.path.isfile(LOG_PATH):
-        with open(LOG_PATH, encoding="utf-8") as log_file:
-            sys.stdout.write(log_file.read())
-        os.remove(LOG_PATH)
     return True
 
 

--- a/backend/src/tasks/functions.yml
+++ b/backend/src/tasks/functions.yml
@@ -196,6 +196,8 @@ peScanController:
         - sqs:SendMessage
         - sqs:GetQueueUrl
         - sqs:GetQueueAttributes
+        - sqs:CreateQueue
+        - sqs:SetQueueAttributes
       Resource: '*'
     - Effect: Allow
       Action:

--- a/infrastructure/worker.tf
+++ b/infrastructure/worker.tf
@@ -188,6 +188,7 @@ resource "aws_iam_role_policy" "worker_task_role_policy" {
     {
       "Effect": "Allow",
       "Action": [
+        "sqs:ChangeMessageVisibility",
         "sqs:DeleteMessage",
         "sqs:GetQueueAttributes",
         "sqs:ListQueues",


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

- Removed duplicate logging in worker containers — pe_reports_logging.log was being dumped again at the end of each scan
- Added sqs:ChangeMessageVisibility to the ECS worker task role so long scans can extend message visibility
- PE Lambda now auto-creates SQS queues in AWS (not just local ElasticMQ)
- Added sqs:CreateQueue and sqs:SetQueueAttributes to the PE scan controller Lambda IAM policy
- Fixed operator queue tools to resolve queue URLs via get-queue-url instead of guessing from account ID
- Fixed purge prompt so c actually purges (menu output was polluting the captured choice)
- Clearer purge/continue/abort prompt labels and warning when in-flight messages remain after purge
- Fixed watch_queues.sh reporting queues as empty when they weren’t (status=$? bug)
- Better error messages when queues can’t be read (IAM/region hints)
- Added test that queue_url_for_scan creates the queue before sending messages

## 💭 Motivation and context ##

Now that I was able to fully test in staging-cd. I caught a couple issues with the queue watcher described above and then logging that was duplicated.

## 🧪 Testing ##

Passes pre-commit and github checks.

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [x] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
