### PR TITLE
CRASM-4028: Fix Terraform policy use of jsondecode

### DIFF
--- a/infrastructure/worker.tf
+++ b/infrastructure/worker.tf
@@ -44,6 +44,15 @@ EOF
 
 data "aws_ssm_parameter" "worker_kms_keys" { name = var.ssm_worker_kms_keys }
 
+locals {
+  worker_kms_keys_parsed = try(jsondecode(data.aws_ssm_parameter.worker_kms_keys.value), null)
+  worker_kms_key_resources = (
+    local.worker_kms_keys_parsed == null ? [data.aws_ssm_parameter.worker_kms_keys.value]
+    : can(tolist(local.worker_kms_keys_parsed)) ? tolist(local.worker_kms_keys_parsed)
+    : [tostring(local.worker_kms_keys_parsed)]
+  )
+}
+
 resource "aws_iam_role_policy" "worker_task_execution_role_policy" {
   name_prefix = var.worker_ecs_role_name
   role        = aws_iam_role.worker_task_execution_role.id
@@ -124,7 +133,7 @@ resource "aws_iam_role_policy" "worker_task_execution_role_policy" {
       "Action": [
         "kms:Decrypt"
       ],
-      "Resource": "${jsondecode(data.aws_ssm_parameter.worker_kms_keys.value)}"
+      "Resource": "${jsonencode(local.worker_kms_key_resources)}"
     }
   ]
 }

--- a/infrastructure/worker.tf
+++ b/infrastructure/worker.tf
@@ -57,87 +57,85 @@ resource "aws_iam_role_policy" "worker_task_execution_role_policy" {
   name_prefix = var.worker_ecs_role_name
   role        = aws_iam_role.worker_task_execution_role.id
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "ecr:BatchCheckLayerAvailability",
-        "ecr:BatchGetImage",
-        "ecr:GetAuthorizationToken",
-        "ecr:GetDownloadUrlForLayer",
-        "logs:CreateLogStream",
-        "logs:PutLogEvents",
-        "sqs:DeleteMessage",
-        "sqs:GetQueueAttributes",
-        "sqs:ListQueues",
-        "sqs:ReceiveMessage"
-      ],
-      "Resource": "*"
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "ssm:GetParameters"
-      ],
-      "Resource": [
-        "${aws_ssm_parameter.crossfeed_send_db_host.arn}",
-        "${aws_ssm_parameter.crossfeed_send_db_name.arn}",
-        "${aws_ssm_parameter.es_endpoint.arn}",
-        "${data.aws_ssm_parameter.censys_api_id.arn}",
-        "${data.aws_ssm_parameter.censys_api_secret.arn}",
-        "${data.aws_ssm_parameter.cf_api_key.arn}",
-        "${data.aws_ssm_parameter.checksum_salt.arn}",
-        "${data.aws_ssm_parameter.db_password.arn}",
-        "${data.aws_ssm_parameter.db_username.arn}",
-        "${data.aws_ssm_parameter.intelx_api_key.arn}",
-        "${data.aws_ssm_parameter.lg_api_key.arn}",
-        "${data.aws_ssm_parameter.lg_workspace_name.arn}",
-        "${data.aws_ssm_parameter.pe_api_key.arn}",
-        "${data.aws_ssm_parameter.pe_api_url.arn}",
-        "${data.aws_ssm_parameter.pe_db_name.arn}",
-        "${data.aws_ssm_parameter.pe_db_password.arn}",
-        "${data.aws_ssm_parameter.pe_db_username.arn}",
-        "${data.aws_ssm_parameter.pe_shodan_api_keys.arn}",
-        "${data.aws_ssm_parameter.qualys_password.arn}",
-        "${data.aws_ssm_parameter.qualys_username.arn}",
-        "${data.aws_ssm_parameter.shodan_api_key.arn}",
-        "${data.aws_ssm_parameter.shodan_ip_chunk_size.arn}",
-        "${data.aws_ssm_parameter.shodan_query_days_back.arn}",
-        "${data.aws_ssm_parameter.sixgill_client_id.arn}",
-        "${data.aws_ssm_parameter.sixgill_client_secret.arn}",
-        "${data.aws_ssm_parameter.ssm_dmz_api_key.arn}",
-        "${data.aws_ssm_parameter.ssm_dmz_sync_endpoint.arn}",
-        "${data.aws_ssm_parameter.ssm_latest_port_scan_cutoff.arn}",
-        "${data.aws_ssm_parameter.ssm_mdl_name.arn}",
-        "${data.aws_ssm_parameter.ssm_mdl_password.arn}",
-        "${data.aws_ssm_parameter.ssm_mdl_username.arn}",
-        "${data.aws_ssm_parameter.ssm_nist_api_key.arn}",
-        "${data.aws_ssm_parameter.ssm_redshift_database.arn}",
-        "${data.aws_ssm_parameter.ssm_redshift_host.arn}",
-        "${data.aws_ssm_parameter.ssm_redshift_password.arn}",
-        "${data.aws_ssm_parameter.ssm_redshift_user.arn}",
-        "${data.aws_ssm_parameter.ssm_vs_pull_date_range.arn}",
-        "${data.aws_ssm_parameter.ssm_whoisxml_thread_count.arn}",
-        "${data.aws_ssm_parameter.whoisxml_api_key.arn}",
-        "${data.aws_ssm_parameter.worker_signature_private_key.arn}",
-        "${data.aws_ssm_parameter.worker_signature_public_key.arn}",
-        "${data.aws_ssm_parameter.xpanse_api_key.arn}",
-        "${data.aws_ssm_parameter.xpanse_auth_id.arn}"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "kms:Decrypt"
-      ],
-      "Resource": "${jsonencode(local.worker_kms_key_resources)}"
-    }
-  ]
-}
-EOF
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:BatchGetImage",
+          "ecr:GetAuthorizationToken",
+          "ecr:GetDownloadUrlForLayer",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes",
+          "sqs:ListQueues",
+          "sqs:ReceiveMessage",
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ssm:GetParameters",
+        ]
+        Resource = [
+          aws_ssm_parameter.crossfeed_send_db_host.arn,
+          aws_ssm_parameter.crossfeed_send_db_name.arn,
+          aws_ssm_parameter.es_endpoint.arn,
+          data.aws_ssm_parameter.censys_api_id.arn,
+          data.aws_ssm_parameter.censys_api_secret.arn,
+          data.aws_ssm_parameter.cf_api_key.arn,
+          data.aws_ssm_parameter.checksum_salt.arn,
+          data.aws_ssm_parameter.db_password.arn,
+          data.aws_ssm_parameter.db_username.arn,
+          data.aws_ssm_parameter.intelx_api_key.arn,
+          data.aws_ssm_parameter.lg_api_key.arn,
+          data.aws_ssm_parameter.lg_workspace_name.arn,
+          data.aws_ssm_parameter.pe_api_key.arn,
+          data.aws_ssm_parameter.pe_api_url.arn,
+          data.aws_ssm_parameter.pe_db_name.arn,
+          data.aws_ssm_parameter.pe_db_password.arn,
+          data.aws_ssm_parameter.pe_db_username.arn,
+          data.aws_ssm_parameter.pe_shodan_api_keys.arn,
+          data.aws_ssm_parameter.qualys_password.arn,
+          data.aws_ssm_parameter.qualys_username.arn,
+          data.aws_ssm_parameter.shodan_api_key.arn,
+          data.aws_ssm_parameter.shodan_ip_chunk_size.arn,
+          data.aws_ssm_parameter.shodan_query_days_back.arn,
+          data.aws_ssm_parameter.sixgill_client_id.arn,
+          data.aws_ssm_parameter.sixgill_client_secret.arn,
+          data.aws_ssm_parameter.ssm_dmz_api_key.arn,
+          data.aws_ssm_parameter.ssm_dmz_sync_endpoint.arn,
+          data.aws_ssm_parameter.ssm_latest_port_scan_cutoff.arn,
+          data.aws_ssm_parameter.ssm_mdl_name.arn,
+          data.aws_ssm_parameter.ssm_mdl_password.arn,
+          data.aws_ssm_parameter.ssm_mdl_username.arn,
+          data.aws_ssm_parameter.ssm_nist_api_key.arn,
+          data.aws_ssm_parameter.ssm_redshift_database.arn,
+          data.aws_ssm_parameter.ssm_redshift_host.arn,
+          data.aws_ssm_parameter.ssm_redshift_password.arn,
+          data.aws_ssm_parameter.ssm_redshift_user.arn,
+          data.aws_ssm_parameter.ssm_vs_pull_date_range.arn,
+          data.aws_ssm_parameter.ssm_whoisxml_thread_count.arn,
+          data.aws_ssm_parameter.whoisxml_api_key.arn,
+          data.aws_ssm_parameter.worker_signature_private_key.arn,
+          data.aws_ssm_parameter.worker_signature_public_key.arn,
+          data.aws_ssm_parameter.xpanse_api_key.arn,
+          data.aws_ssm_parameter.xpanse_auth_id.arn,
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "kms:Decrypt",
+        ]
+        Resource = local.worker_kms_key_resources
+      },
+    ]
+  })
 }
 
 resource "aws_iam_role" "worker_task_role" {

--- a/infrastructure/worker.tf
+++ b/infrastructure/worker.tf
@@ -123,7 +123,7 @@ resource "aws_iam_role_policy" "worker_task_execution_role_policy" {
         Action = [
           "kms:Decrypt",
         ]
-        Resource = jsondecode(data.aws_ssm_parameter.worker_kms_keys.value)
+        Resource = nonsensitive(jsondecode(data.aws_ssm_parameter.worker_kms_keys.value))
       },
     ]
   })

--- a/infrastructure/worker.tf
+++ b/infrastructure/worker.tf
@@ -44,15 +44,6 @@ EOF
 
 data "aws_ssm_parameter" "worker_kms_keys" { name = var.ssm_worker_kms_keys }
 
-locals {
-  worker_kms_keys_parsed = try(jsondecode(data.aws_ssm_parameter.worker_kms_keys.value), null)
-  worker_kms_key_resources = (
-    local.worker_kms_keys_parsed == null ? [data.aws_ssm_parameter.worker_kms_keys.value]
-    : can(tolist(local.worker_kms_keys_parsed)) ? tolist(local.worker_kms_keys_parsed)
-    : [tostring(local.worker_kms_keys_parsed)]
-  )
-}
-
 resource "aws_iam_role_policy" "worker_task_execution_role_policy" {
   name_prefix = var.worker_ecs_role_name
   role        = aws_iam_role.worker_task_execution_role.id
@@ -132,7 +123,7 @@ resource "aws_iam_role_policy" "worker_task_execution_role_policy" {
         Action = [
           "kms:Decrypt",
         ]
-        Resource = local.worker_kms_key_resources
+        Resource = jsondecode(data.aws_ssm_parameter.worker_kms_keys.value)
       },
     ]
   })


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Fixes terraform plan failures for the worker task execution role's kms:Decrypt policy in LZ environments (staging/production).

The Fix:

1. Converted the worker task execution role policy from a heredoc to jsonencode(), passing KMS resources as a native HCL list via jsondecode().
2. Standardized WORKER_KMS_KEYS in SSM to a JSON array in all environments. Updated staging-cd from * to ["*"] to match. Staging and production were already in the correct format.

## 💭 Motivation and context ##

terraform plan was passing in DMZ environments (staging-cd, integration) but failing in LZ environments (staging, production).

The worker task execution role reads KMS key ARNs from the WORKER_KMS_KEYS SSM parameter. The original heredoc policy used jsondecode(...) inline, which failed in staging/production with Invalid template interpolation value: string required — heredoc interpolation only accepts strings, **not lists.** WORKER_KMS_KEYS was a list in staging/prod but a string in staging-cd/integration.

An attempted fix using jsonencode() inside the heredoc then failed in staging-cd with invalid JSON policy errors when multiple ARNs were present.

The root cause was twofold: mixing list values into a string heredoc, and inconsistent SSM parameter formats across environments (* in staging-cd vs JSON arrays in staging/production).

## 🧪 Testing ##

Passes terraform plan in all environments. 

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [x] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
