### PR TITLE
CRASM-3605 Retired Organization Displaying On Dashboard

### DIFF
--- a/backend/src/xfd_django/xfd_api/api_methods/organization.py
+++ b/backend/src/xfd_django/xfd_api/api_methods/organization.py
@@ -28,7 +28,7 @@ from ..auth import (
     is_org_admin,
     is_regional_admin,
 )
-from ..helpers.filter_helpers import apply_organization_filters
+from ..helpers.filter_helpers import active_organizations, apply_organization_filters
 from ..helpers.regionStateMap import REGION_STATE_MAP
 from ..helpers.uuid_helpers import is_valid_uuid
 from ..schema_models import organization_schema
@@ -56,7 +56,8 @@ def list_organizations(current_user):
 
         # Fetch organizations with related userRoles and tags
         organizations = (
-            Organization.objects.prefetch_related("tags", "user_roles")
+            active_organizations()
+            .prefetch_related("tags", "user_roles")
             .filter(**org_filter)
             .order_by("name")
         )
@@ -144,6 +145,9 @@ def get_organization(organization_id, current_user):
         )
 
         if not organization:
+            raise HTTPException(status_code=404, detail="Organization not found")
+
+        if organization.retired:
             raise HTTPException(status_code=404, detail="Organization not found")
 
         # Fetch scan tasks related to the organization, limited to 10 most recent
@@ -275,24 +279,28 @@ def get_by_state(state, current_user):
         raise HTTPException(status_code=403, detail="Unauthorized")
 
     # Fetch organizations based on the provided state
-    organizations = Organization.objects.filter(state=state).values(
-        "id",
-        "created_at",
-        "updated_at",
-        "acronym",
-        "name",
-        "root_domains",
-        "ip_blocks",
-        "is_passive",
-        "pending_domains",
-        "country",
-        "state",
-        "region_id",
-        "state_fips",
-        "state_name",
-        "county",
-        "county_fips",
-        "type",
+    organizations = (
+        active_organizations()
+        .filter(state=state)
+        .values(
+            "id",
+            "created_at",
+            "updated_at",
+            "acronym",
+            "name",
+            "root_domains",
+            "ip_blocks",
+            "is_passive",
+            "pending_domains",
+            "country",
+            "state",
+            "region_id",
+            "state_fips",
+            "state_name",
+            "county",
+            "county_fips",
+            "type",
+        )
     )
 
     if not organizations:
@@ -317,24 +325,28 @@ def get_by_region(region_id, current_user):
         raise HTTPException(status_code=403, detail="Unauthorized")
 
     # Fetch organizations based on the provided state
-    organizations = Organization.objects.filter(region_id=region_id).values(
-        "id",
-        "created_at",
-        "updated_at",
-        "acronym",
-        "name",
-        "root_domains",
-        "ip_blocks",
-        "is_passive",
-        "pending_domains",
-        "country",
-        "state",
-        "region_id",
-        "state_fips",
-        "state_name",
-        "county",
-        "county_fips",
-        "type",
+    organizations = (
+        active_organizations()
+        .filter(region_id=region_id)
+        .values(
+            "id",
+            "created_at",
+            "updated_at",
+            "acronym",
+            "name",
+            "root_domains",
+            "ip_blocks",
+            "is_passive",
+            "pending_domains",
+            "country",
+            "state",
+            "region_id",
+            "state_fips",
+            "state_name",
+            "county",
+            "county_fips",
+            "type",
+        )
     )
 
     if not organizations:
@@ -358,7 +370,8 @@ def get_all_regions(current_user):
 
         # Fetch distinct region_id values
         regions = (
-            Organization.objects.exclude(region_id__isnull=True)
+            active_organizations()
+            .exclude(region_id__isnull=True)
             .values("region_id")
             .distinct()
         )
@@ -382,7 +395,8 @@ def get_all_region_ids(current_user) -> list:
             raise HTTPException(status_code=403, detail="Unauthorized")
 
         regions_qs = (
-            Organization.objects.exclude(region_id__isnull=True)
+            active_organizations()
+            .exclude(region_id__isnull=True)
             .values_list("region_id", flat=True)
             .distinct()
         )
@@ -1200,6 +1214,11 @@ def search_organizations_task(search_body, current_user: User):
             query_body["query"]["bool"]["filter"].append(
                 {"terms": {"region_id": search_body.regions}}
             )
+
+        # Exclude retired organizations (documents without the field remain visible)
+        query_body["query"]["bool"]["filter"].append(
+            {"bool": {"must_not": {"term": {"retired": True}}}}
+        )
 
         # Log the query for debugging
         LOGGER.debug("Query body: %s", query_body)

--- a/backend/src/xfd_django/xfd_api/api_methods/scan.py
+++ b/backend/src/xfd_django/xfd_api/api_methods/scan.py
@@ -11,6 +11,7 @@ from fastapi import HTTPException, status
 from xfd_mini_dl.models import Organization, OrganizationTag, Scan
 
 from ..auth import is_global_view_admin, is_global_write_admin
+from ..helpers.filter_helpers import active_organizations
 from ..schema_models.scan import SCAN_SCHEMA, NewScan
 from ..tasks.lambda_client import LambdaClient
 
@@ -31,7 +32,7 @@ def list_scans(current_user):
         scans = Scan.objects.prefetch_related("tags").all()
 
         # Fetch all organizations
-        organizations = Organization.objects.values("id", "name")
+        organizations = active_organizations().values("id", "name")
 
         # Convert to list of dicts with related tags
         scan_list = []
@@ -325,7 +326,7 @@ def get_scan(scan_id: str, current_user):
         scan = Scan.objects.prefetch_related("organizations", "tags").get(id=scan_id)
 
         # Fetch all organizations
-        all_organizations = Organization.objects.values("id", "name")
+        all_organizations = active_organizations().values("id", "name")
     except Scan.DoesNotExist:
         raise HTTPException(status_code=404, detail="Scan not found")
 

--- a/backend/src/xfd_django/xfd_api/helpers/filter_helpers.py
+++ b/backend/src/xfd_django/xfd_api/helpers/filter_helpers.py
@@ -254,6 +254,9 @@ def apply_organization_filters(base_q, filters: dict):
     region_id = filters.get("region_id")
     acronym = filters.get("acronym")
 
+    # Always exclude retired orgs
+    q &= Q(retired=False)
+
     if acronym:
         q &= Q(acronym__icontains=str(acronym).strip())
 

--- a/backend/src/xfd_django/xfd_api/helpers/filter_helpers.py
+++ b/backend/src/xfd_django/xfd_api/helpers/filter_helpers.py
@@ -6,8 +6,17 @@ import logging
 # Third-Party Libraries
 from django.db.models.query import Q, QuerySet
 from fastapi import HTTPException, status
+from xfd_mini_dl.models import Organization
 
 from ..schema_models.vulnerability import VulnerabilityFilters
+
+ACTIVE_ORGANIZATION_Q = Q(retired=False)
+
+
+def active_organizations() -> QuerySet:
+    """Return a queryset excluding retired organizations."""
+    return Organization.objects.filter(ACTIVE_ORGANIZATION_Q)
+
 
 # Define the severity levels
 SEVERITY_LEVELS = ["Low", "Medium", "High", "Critical"]
@@ -254,8 +263,7 @@ def apply_organization_filters(base_q, filters: dict):
     region_id = filters.get("region_id")
     acronym = filters.get("acronym")
 
-    # Always exclude retired orgs
-    q &= Q(retired=False)
+    q &= ACTIVE_ORGANIZATION_Q
 
     if acronym:
         q &= Q(acronym__icontains=str(acronym).strip())

--- a/backend/src/xfd_django/xfd_api/tasks/es_client.py
+++ b/backend/src/xfd_django/xfd_api/tasks/es_client.py
@@ -14,7 +14,11 @@ ORGANIZATIONS_INDEX = "organizations-1"
 
 # Define mappings
 organization_mapping = {
-    "properties": {"name": {"type": "text"}, "suggest": {"type": "completion"}}
+    "properties": {
+        "name": {"type": "text"},
+        "suggest": {"type": "completion"},
+        "retired": {"type": "boolean"},
+    }
 }
 
 domain_mapping = {
@@ -95,10 +99,29 @@ class ESClient:
                 "_op_type": "update",
                 "_index": ORGANIZATIONS_INDEX,
                 "_id": org["id"],
-                "doc": {**org, "suggest": [{"input": org["name"], "weight": 1}]},
+                "doc": {
+                    **org,
+                    "retired": bool(org.get("retired", False)),
+                    "suggest": [{"input": org["name"], "weight": 1}],
+                },
                 "doc_as_upsert": True,
             }
             for org in organizations
+        ]
+        self._bulk_update(actions)
+
+    def delete_organizations(self, organization_ids):
+        """Delete organizations from Elasticsearch by ID."""
+        if not organization_ids:
+            return
+
+        actions = [
+            {
+                "_op_type": "delete",
+                "_index": ORGANIZATIONS_INDEX,
+                "_id": str(org_id),
+            }
+            for org_id in organization_ids
         ]
         self._bulk_update(actions)
 

--- a/backend/src/xfd_django/xfd_api/tasks/helpers/syncdb_helpers/es_sync.py
+++ b/backend/src/xfd_django/xfd_api/tasks/helpers/syncdb_helpers/es_sync.py
@@ -46,8 +46,16 @@ def update_organization_chunk(es_client, organizations):
 def sync_es_organizations():
     """Sync elastic search organizations."""
     try:
-        # Fetch all organization IDs
-        organization_ids = list(Organization.objects.values_list("id", flat=True))
+        retired_ids = list(
+            Organization.objects.filter(retired=True).values_list("id", flat=True)
+        )
+        if retired_ids:
+            LOGGER.info("Removing %d retired organizations from ES.", len(retired_ids))
+            es_client.delete_organizations(retired_ids)
+
+        organization_ids = list(
+            Organization.objects.filter(retired=False).values_list("id", flat=True)
+        )
         LOGGER.info("Found %d organizations to sync.", len(organization_ids))
 
         if organization_ids:
@@ -58,7 +66,14 @@ def sync_es_organizations():
                 # Fetch full organization data for the current chunk
                 organizations = list(
                     Organization.objects.filter(id__in=organization_chunk).values(
-                        "id", "name", "country", "state", "region_id", "tags", "acronym"
+                        "id",
+                        "name",
+                        "country",
+                        "state",
+                        "region_id",
+                        "tags",
+                        "acronym",
+                        "retired",
                     )
                 )
                 LOGGER.info("Syncing %d organizations...", len(organizations))

--- a/backend/src/xfd_django/xfd_api/tests/test_es_sync.py
+++ b/backend/src/xfd_django/xfd_api/tests/test_es_sync.py
@@ -1,0 +1,46 @@
+"""Test Elasticsearch organization sync."""
+# Standard Python Libraries
+from datetime import datetime
+from unittest.mock import patch
+
+# Third-Party Libraries
+import pytest
+from xfd_api.tasks.helpers.syncdb_helpers.es_sync import sync_es_organizations
+from xfd_mini_dl.models import Organization
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
+@patch("xfd_api.tasks.helpers.syncdb_helpers.es_sync.es_client")
+def test_sync_es_organizations_excludes_retired(mock_es_client):
+    """Retired organizations should be deleted from ES and not re-indexed."""
+    active_org = Organization.objects.create(
+        name="Active ES Org",
+        root_domains=["active.com"],
+        ip_blocks=[],
+        is_passive=False,
+        retired=False,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    retired_org = Organization.objects.create(
+        name="Retired ES Org",
+        root_domains=["retired.com"],
+        ip_blocks=[],
+        is_passive=False,
+        retired=True,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+    sync_es_organizations()
+
+    mock_es_client.delete_organizations.assert_called_once()
+    deleted_ids = mock_es_client.delete_organizations.call_args[0][0]
+    assert retired_org.id in deleted_ids
+
+    mock_es_client.update_organizations.assert_called_once()
+    synced_orgs = mock_es_client.update_organizations.call_args[0][0]
+    synced_ids = {org["id"] for org in synced_orgs}
+    assert active_org.id in synced_ids
+    assert retired_org.id not in synced_ids
+    assert all(org.get("retired") is False for org in synced_orgs)

--- a/backend/src/xfd_django/xfd_api/tests/test_organization.py
+++ b/backend/src/xfd_django/xfd_api/tests/test_organization.py
@@ -2599,3 +2599,236 @@ def test_get_organizations_by_region_global_view():
     data = response.json()
 
     assert any(result["id"] == str(organization.id) for result in data)
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
+def test_list_organizations_v2_excludes_retired():
+    """Retired organizations should not appear in v2 organization search."""
+    admin = User.objects.create(
+        first_name="Admin",
+        last_name="User",
+        email="{}@example.com".format(secrets.token_hex(4)),
+        user_type=UserType.GLOBAL_VIEW,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+    active_org = Organization.objects.create(
+        name="Active Org",
+        root_domains=["active.com"],
+        ip_blocks=[],
+        is_passive=False,
+        retired=False,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    Organization.objects.create(
+        name="Retired Org",
+        root_domains=["retired.com"],
+        ip_blocks=[],
+        is_passive=False,
+        retired=True,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+    response = client.post(
+        "/v2/organizations/search",
+        headers={"Authorization": "Bearer {}".format(create_jwt_token(admin))},
+        json={"page": 1, "pageSize": 15, "filters": {}},
+    )
+
+    assert response.status_code == 200
+    org_ids = [org["id"] for org in response.json()["result"]]
+    assert str(active_org.id) in org_ids
+    assert response.json()["count"] == 1
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
+def test_get_organizations_by_region_excludes_retired():
+    """Retired organizations should not appear in region-based organization lists."""
+    user = User.objects.create(
+        first_name="Test",
+        last_name="Admin",
+        email="{}@example.com".format(secrets.token_hex(4)),
+        user_type=UserType.REGIONAL_ADMIN,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+    active_org = Organization.objects.create(
+        name="Active Region Org",
+        root_domains=["active.com"],
+        ip_blocks=[],
+        is_passive=False,
+        region_id="99901",
+        retired=False,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    Organization.objects.create(
+        name="Retired Region Org",
+        root_domains=["retired.com"],
+        ip_blocks=[],
+        is_passive=False,
+        region_id="99901",
+        retired=True,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+    response = client.get(
+        "/organizations/region_id/99901",
+        headers={"Authorization": "Bearer {}".format(create_jwt_token(user))},
+    )
+
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+    assert response.json()[0]["id"] == str(active_org.id)
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
+def test_get_organizations_by_state_excludes_retired():
+    """Retired organizations should not appear in state-based organization lists."""
+    user = User.objects.create(
+        first_name="Test",
+        last_name="Admin",
+        email="{}@example.com".format(secrets.token_hex(4)),
+        user_type=UserType.REGIONAL_ADMIN,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+    active_org = Organization.objects.create(
+        name="Active State Org",
+        root_domains=["active.com"],
+        ip_blocks=[],
+        is_passive=False,
+        state="TX",
+        retired=False,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    Organization.objects.create(
+        name="Retired State Org",
+        root_domains=["retired.com"],
+        ip_blocks=[],
+        is_passive=False,
+        state="TX",
+        retired=True,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+    response = client.get(
+        "/organizations/state/TX",
+        headers={"Authorization": "Bearer {}".format(create_jwt_token(user))},
+    )
+
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+    assert response.json()[0]["id"] == str(active_org.id)
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
+def test_get_organization_retired_returns_404():
+    """Direct access to a retired organization should return 404."""
+    user = User.objects.create(
+        first_name="",
+        last_name="",
+        email="{}@example.com".format(secrets.token_hex(4)),
+        user_type=UserType.GLOBAL_VIEW,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+    organization = Organization.objects.create(
+        name="Retired Org",
+        root_domains=["retired.com"],
+        ip_blocks=[],
+        is_passive=False,
+        retired=True,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+    response = client.get(
+        "/organizations/{}".format(organization.id),
+        headers={"Authorization": "Bearer {}".format(create_jwt_token(user))},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Organization not found"
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
+def test_list_organizations_excludes_retired():
+    """Retired organizations should not appear in the legacy organization list."""
+    user = User.objects.create(
+        first_name="",
+        last_name="",
+        email="{}@example.com".format(secrets.token_hex(4)),
+        user_type=UserType.GLOBAL_VIEW,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+    active_org = Organization.objects.create(
+        name="Active List Org",
+        root_domains=["active.com"],
+        ip_blocks=[],
+        is_passive=False,
+        parent=None,
+        retired=False,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    Organization.objects.create(
+        name="Retired List Org",
+        root_domains=["retired.com"],
+        ip_blocks=[],
+        is_passive=False,
+        parent=None,
+        retired=True,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+    response = client.get(
+        "/organizations",
+        headers={"Authorization": "Bearer {}".format(create_jwt_token(user))},
+    )
+
+    assert response.status_code == 200
+    org_ids = [org["id"] for org in response.json()]
+    assert str(active_org.id) in org_ids
+    assert len(org_ids) == 1
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
+@patch("xfd_api.tasks.es_client.ESClient.search_organizations")
+def test_search_organizations_excludes_retired(mock_search):
+    """Elasticsearch organization search should filter out retired organizations."""
+    admin = User.objects.create(
+        first_name="Admin",
+        last_name="User",
+        email="{}@example.com".format(secrets.token_hex(4)),
+        user_type=UserType.GLOBAL_VIEW,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+    mock_search.return_value = {"hits": {"hits": []}}
+
+    response = client.post(
+        "/search/organizations",
+        json={"search_term": "Test Org", "regions": ["region-1"]},
+        headers={"Authorization": "Bearer {}".format(create_jwt_token(admin))},
+    )
+
+    assert response.status_code == 200
+    mock_search.assert_called_once()
+    query_body = mock_search.call_args[0][0]
+    filters = query_body["query"]["bool"]["filter"]
+    assert {"terms": {"region_id": ["region-1"]}} in filters
+    assert {"bool": {"must_not": {"term": {"retired": True}}}} in filters

--- a/backend/src/xfd_django/xfd_api/tests/test_scan.py
+++ b/backend/src/xfd_django/xfd_api/tests/test_scan.py
@@ -68,6 +68,48 @@ def test_list_scans_by_global_admin():
     assert any(org["id"] == str(organization.id) for org in data["organizations"])
 
 
+@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
+def test_list_scans_excludes_retired_orgs():
+    """Scan organization pickers should not include retired organizations."""
+    user = User.objects.create(
+        first_name="",
+        last_name="",
+        email="{}@example.com".format(secrets.token_hex(4)),
+        user_type=UserType.GLOBAL_ADMIN,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+    active_org = Organization.objects.create(
+        name="Active Scan Org",
+        root_domains=["active.com"],
+        ip_blocks=[],
+        is_passive=False,
+        retired=False,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    Organization.objects.create(
+        name="Retired Scan Org",
+        root_domains=["retired.com"],
+        ip_blocks=[],
+        is_passive=False,
+        retired=True,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+    response = client.get(
+        "/scans",
+        headers={"Authorization": "Bearer " + create_jwt_token(user)},
+    )
+
+    assert response.status_code == 200
+    org_ids = [org["id"] for org in response.json()["organizations"]]
+    assert str(active_org.id) in org_ids
+    assert len(org_ids) == 1
+
+
 # Test: create by globalAdmin should succeed
 @pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
 def test_create_scan_by_global_admin():


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
Updates:
- Added shared active_organizations() helper so retired orgs are filtered consistently across API queries
- Excluded retired orgs from organization list/search endpoints: GET /organizations, GET /organizations/region_id/{id}, GET /organizations/state/{state}, POST /v2/organizations/search
- Return 404 for direct access to retired orgs via GET /organizations/{id}
- Excluded retired orgs from scan admin org picker lists (GET /scans, GET /scans/{id})
- Updated Elasticsearch org search (POST /search/organizations) to filter out retired: true documents
- Updated ES org sync to index only active orgs, include retired on indexed docs, and delete retired orgs from the index
- Added tests covering API endpoints, ES search query filtering, scan lists, and ES sync behavior


This update ensures that retired organizations are no longer displayed on the CyHy Dashboard front end. Previously, retired organizations were still included in API responses, causing them to appear in UI filters and results.
The organization filtering logic was updated in:
backend/src/xfd_django/xfd_api/helpers/filter_helpers.py
Specifically:
Added Q(retired=False) to the apply_organization_filters() function.
Ensures all organization queries automatically exclude retired entries.
No other filtering behavior was modified.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->


## 💭 Motivation and context ##
This change ensures that retired organizations are no longer visible on the CyHy Dashboard, improving data accuracy and preventing users from interacting with outdated organization records.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
Before the change
Logged into the CyHy Dashboard.
Navigated to Admin Hub → Manage Orgs → Filters.
Searched for a known retired organization that has been set to retired in DB .
Result: The retired organization appeared in the search results, meaning the dashboard still displayed organizations marked as retired.

After the change
Repeated the same steps on the updated backend.
Searched for the same retired organization.
Result: The organization no longer appeared in the filter results.
Confirmed that active (non‑retired) organizations still appear correctly and all other filter functionality behaves as expected.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


## 📷 Screenshots (if appropriate) ##
<img width="1350" height="489" alt="image" src="https://github.com/user-attachments/assets/18bd5685-cc79-4a58-ba6e-f0d1b0c0f8bd" />

Before change:
<img width="1350" height="833" alt="image" src="https://github.com/user-attachments/assets/0c8866b2-e371-466b-bbaf-e25083acdcd9" />


After change:
<img width="1350" height="774" alt="image" src="https://github.com/user-attachments/assets/cc6f3c22-64da-4f86-aa25-074d3e7e0d02" />
<img width="1350" height="604" alt="image" src="https://github.com/user-attachments/assets/947bcad4-44d5-46c8-89a9-71d5887ea761" />


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [x] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
