### PR TITLE
Add pending user fields to User Registration (CRASM-3999)

### DIFF
--- a/backend/src/xfd_django/xfd_api/api_methods/user.py
+++ b/backend/src/xfd_django/xfd_api/api_methods/user.py
@@ -541,6 +541,7 @@ def update_user_v2(user_id, user_data, current_user):
             "full_name": user.full_name,
             "email": updated_user.email,
             "region_id": updated_user.region_id,
+            "invite_pending": updated_user.invite_pending,
             "state": updated_user.state,
             "user_type": updated_user.user_type,
             "last_logged_in": user.last_logged_in,

--- a/backend/src/xfd_django/xfd_api/api_methods/user.py
+++ b/backend/src/xfd_django/xfd_api/api_methods/user.py
@@ -476,16 +476,18 @@ def update_user_v2(
                 status_code=403, detail="Only global admins can update userType."
             )
 
-        if x_origin_path == "user-management" and user.invite_pending is True:
-            raise HTTPException(
-                status_code=403,
-                detail="Modifying a pending user is not permitted from the manage users screen.",
-            )
-
         # Check if allowed fields to update then execute
         # updates = user_data.dict(exclude_unset=True)
         updates = user_data.model_dump(exclude_unset=True)
         allowed_fields = get_allowed_user_update_fields(current_user, user)
+
+        if x_origin_path == "user-management" and (
+            user.invite_pending is True or updates.get("invite_pending") is True
+        ):
+            raise HTTPException(
+                status_code=403,
+                detail="Modifying a pending user is not permitted from the manage users screen.",
+            )
 
         # Check for disallowed fields before applying updates
         requested_fields = set(updates.keys())

--- a/backend/src/xfd_django/xfd_api/api_methods/user.py
+++ b/backend/src/xfd_django/xfd_api/api_methods/user.py
@@ -4,6 +4,7 @@
 from datetime import datetime
 import logging
 import os
+from typing import Optional
 
 # Third-Party Libraries
 from django.conf import settings
@@ -450,7 +451,9 @@ def get_users_v2(state, region_id, invite_pending, current_user):
 
 
 # POST: /v2/update_user/{user_id}
-def update_user_v2(user_id, user_data, current_user):
+def update_user_v2(
+    user_id, user_data, current_user, x_origin_path: Optional[str] = None
+):
     """Update a particular user."""
     try:
         # Validate that the user ID is a valid UUID
@@ -471,6 +474,12 @@ def update_user_v2(user_id, user_data, current_user):
         if (not is_global_write_admin(current_user)) and user_data.user_type:
             raise HTTPException(
                 status_code=403, detail="Only global admins can update userType."
+            )
+
+        if x_origin_path == "user-management" and user.invite_pending is True:
+            raise HTTPException(
+                status_code=403,
+                detail="Modifying a pending user is not permitted from the manage users screen.",
             )
 
         # Check if allowed fields to update then execute

--- a/backend/src/xfd_django/xfd_api/api_methods/user.py
+++ b/backend/src/xfd_django/xfd_api/api_methods/user.py
@@ -227,7 +227,8 @@ def get_users(current_user):
                     else None
                 ),
                 "accepted_terms_version": user.accepted_terms_version,
-                "date_accepted_terms": user.date_accepted_terms,
+                "date_accepted_terms": user.date_accepted_terms,  # Example of a test field
+                "invite_pending": user.invite_pending,
                 "roles": [
                     {
                         "id": str(role.id),
@@ -421,6 +422,7 @@ def get_users_v2(state, region_id, invite_pending, current_user):
                     else None
                 ),
                 "accepted_terms_version": user.accepted_terms_version,
+                "invite_pending": user.invite_pending,
                 "roles": [
                     {
                         "id": str(role.id),

--- a/backend/src/xfd_django/xfd_api/api_methods/user.py
+++ b/backend/src/xfd_django/xfd_api/api_methods/user.py
@@ -228,7 +228,7 @@ def get_users(current_user):
                     else None
                 ),
                 "accepted_terms_version": user.accepted_terms_version,
-                "date_accepted_terms": user.date_accepted_terms,  # Example of a test field
+                "date_accepted_terms": user.date_accepted_terms,
                 "invite_pending": user.invite_pending,
                 "roles": [
                     {

--- a/backend/src/xfd_django/xfd_api/schema_models/user.py
+++ b/backend/src/xfd_django/xfd_api/schema_models/user.py
@@ -199,6 +199,7 @@ class UserResponseV2(BaseModel):
     last_name: str
     full_name: str
     email: str
+    invite_pending: bool
     accepted_terms_version: Optional[str] = None
     date_accepted_terms: Optional[datetime] = None
     cognito_use_case_description: Optional[str] = None

--- a/backend/src/xfd_django/xfd_api/schema_models/user.py
+++ b/backend/src/xfd_django/xfd_api/schema_models/user.py
@@ -199,7 +199,7 @@ class UserResponseV2(BaseModel):
     last_name: str
     full_name: str
     email: str
-    invite_pending: bool
+    invite_pending: Optional[bool] = None
     accepted_terms_version: Optional[str] = None
     date_accepted_terms: Optional[datetime] = None
     cognito_use_case_description: Optional[str] = None

--- a/backend/src/xfd_django/xfd_api/tests/test_user.py
+++ b/backend/src/xfd_django/xfd_api/tests/test_user.py
@@ -1596,8 +1596,8 @@ def test_update_user_v2_standard_user_cannot_update_own_email():
 
     assert response.status_code == 403
     assert (
-        response.json()["detail"]
-        == "You do not have permission to perform this action."
+        "You do not have permission to perform this action."
+        in response.json()["detail"]
     )
 
 
@@ -1627,8 +1627,8 @@ def test_update_user_v2_standard_user_cannot_approve_themselves():
 
     assert response.status_code == 403
     assert (
-        response.json()["detail"]
-        == "You do not have permission to perform this action."
+        "You do not have permission to perform this action."
+        in response.json()["detail"]
     )
 
 
@@ -1663,8 +1663,8 @@ def test_update_user_v2_regional_admin_cannot_update_user_type():
 
     assert response.status_code == 403
     assert (
-        response.json()["detail"]
-        == "You do not have permission to perform this action."
+        "You do not have permission to perform this action."
+        in response.json()["detail"]
     )
 
 
@@ -1722,10 +1722,6 @@ def test_update_user_v2_standard_user_cannot_update_name():
     )
 
     assert response.status_code == 403
-    assert (
-        response.json()["detail"]
-        == "You do not have permission to perform this action."
-    )
 
 
 @pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])

--- a/backend/src/xfd_django/xfd_api/tests/test_user.py
+++ b/backend/src/xfd_django/xfd_api/tests/test_user.py
@@ -1029,6 +1029,7 @@ def test_get_users_by_region_id_as_regional_admin():
         region_id="1",
         created_at=datetime.now(),
         updated_at=datetime.now(),
+        invite_pending=False,
     )
 
     user1 = User.objects.create(
@@ -1039,6 +1040,7 @@ def test_get_users_by_region_id_as_regional_admin():
         region_id="1",
         created_at=datetime.now(),
         updated_at=datetime.now(),
+        invite_pending=False,
     )
 
     user2 = User.objects.create(
@@ -1049,6 +1051,7 @@ def test_get_users_by_region_id_as_regional_admin():
         region_id="1",
         created_at=datetime.now(),
         updated_at=datetime.now(),
+        invite_pending=False,
     )
 
     response = client.get(
@@ -1126,6 +1129,7 @@ def test_get_users_by_state_as_regional_admin():
         email="{}@example.com".format(secrets.token_hex(4)),
         user_type=UserType.REGIONAL_ADMIN,
         state="CA",
+        invite_pending=False,
         created_at=datetime.now(),
         updated_at=datetime.now(),
     )
@@ -1437,7 +1441,10 @@ def test_update_user_v2_as_standard_user_fails():
     )
 
     assert response.status_code == 403
-    assert response.json()["detail"] == "Unauthorized access."
+    assert (
+        response.json()["detail"]
+        == "You do not have permission to perform this action."
+    )
 
 
 @pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
@@ -1520,7 +1527,10 @@ def test_update_user_v2_update_userType_by_non_admin_fails():
         },
     )
     assert response.status_code == 403
-    assert response.json()["detail"] == "Only global admins can update userType."
+    assert (
+        response.json()["detail"]
+        == "You do not have permission to perform this action."
+    )
 
 
 @pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
@@ -1559,7 +1569,7 @@ def test_update_user_v2_from_management_screen_on_pending_user_fails():
     assert response.status_code == 403
     assert (
         response.json()["detail"]
-        == "Modifying a pending user status is not permitted from the manage users screen."
+        == "You do not have permission to perform this action."
     )
 
 
@@ -1585,7 +1595,10 @@ def test_update_user_v2_standard_user_cannot_update_own_email():
     )
 
     assert response.status_code == 403
-    assert response.json()["detail"] == "Unauthorized access."
+    assert (
+        response.json()["detail"]
+        == "You do not have permission to perform this action."
+    )
 
 
 @pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
@@ -1613,7 +1626,10 @@ def test_update_user_v2_standard_user_cannot_approve_themselves():
     )
 
     assert response.status_code == 403
-    assert response.json()["detail"] == "Unauthorized access."
+    assert (
+        response.json()["detail"]
+        == "You do not have permission to perform this action."
+    )
 
 
 @pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
@@ -1646,7 +1662,10 @@ def test_update_user_v2_regional_admin_cannot_update_user_type():
     )
 
     assert response.status_code == 403
-    assert response.json()["detail"] == "Only global admins can update userType."
+    assert (
+        response.json()["detail"]
+        == "You do not have permission to perform this action."
+    )
 
 
 @pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
@@ -1703,7 +1722,10 @@ def test_update_user_v2_standard_user_cannot_update_name():
     )
 
     assert response.status_code == 403
-    assert response.json()["detail"] == "Unauthorized access."
+    assert (
+        response.json()["detail"]
+        == "You do not have permission to perform this action."
+    )
 
 
 @pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])

--- a/backend/src/xfd_django/xfd_api/tests/test_user.py
+++ b/backend/src/xfd_django/xfd_api/tests/test_user.py
@@ -1391,7 +1391,10 @@ def test_update_user_v2_as_global_admin():
     response = client.post(
         "/v2/update_user/{}".format(user.id),
         json=payload,
-        headers={"Authorization": "Bearer {}".format(create_jwt_token(global_admin))},
+        headers={
+            "Authorization": "Bearer {}".format(create_jwt_token(global_admin)),
+            "X-Origin-Path": "user-registration",
+        },
     )
 
     assert response.status_code == 200
@@ -1427,14 +1430,14 @@ def test_update_user_v2_as_standard_user_fails():
     response = client.post(
         "/v2/update_user/{}".format(target_user.id),
         json=payload,
-        headers={"Authorization": "Bearer {}".format(create_jwt_token(standard_user))},
+        headers={
+            "Authorization": "Bearer {}".format(create_jwt_token(standard_user)),
+            "X-Origin-Path": "user-registration",
+        },
     )
 
     assert response.status_code == 403
-    assert (
-        response.json()["detail"]
-        == "You do not have permission to perform this action."
-    )
+    assert response.json()["detail"] == "Unauthorized access."
 
 
 @pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
@@ -1475,7 +1478,10 @@ def test_update_user_v2_non_existent_user():
     response = client.post(
         "/v2/update_user/{}".format(fake_user_id),
         json=payload,
-        headers={"Authorization": "Bearer {}".format(create_jwt_token(global_admin))},
+        headers={
+            "Authorization": "Bearer {}".format(create_jwt_token(global_admin)),
+            "X-Origin-Path": "user-registration",
+        },
     )
 
     assert response.status_code == 404
@@ -1508,13 +1514,52 @@ def test_update_user_v2_update_userType_by_non_admin_fails():
     response = client.post(
         "/v2/update_user/{}".format(user.id),
         json=payload,
-        headers={"Authorization": "Bearer {}".format(create_jwt_token(regional_admin))},
+        headers={
+            "Authorization": "Bearer {}".format(create_jwt_token(regional_admin)),
+            "X-Origin-Path": "user-registration",
+        },
+    )
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Only global admins can update userType."
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
+def test_update_user_v2_from_management_screen_on_pending_user_fails():
+    """Test that modifying a pending user status is blocked from the management screen."""
+    global_admin = User.objects.create(
+        first_name="Admin",
+        last_name="Global",
+        email="{}@example.com".format(secrets.token_hex(4)),
+        user_type=UserType.GLOBAL_ADMIN,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+    user = User.objects.create(
+        first_name="User",
+        last_name="Test",
+        email="{}@example.com".format(secrets.token_hex(4)),
+        user_type=UserType.STANDARD,
+        invite_pending=True,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+    payload = {"first_name": "Attempted Edit"}
+
+    response = client.post(
+        "/v2/update_user/{}".format(user.id),
+        json=payload,
+        headers={
+            "Authorization": "Bearer {}".format(create_jwt_token(global_admin)),
+            "X-Origin-Path": "user-management",
+        },
     )
 
     assert response.status_code == 403
     assert (
         response.json()["detail"]
-        == "You do not have permission to perform this action."
+        == "Modifying a pending user status is not permitted from the manage users screen."
     )
 
 
@@ -1533,14 +1578,14 @@ def test_update_user_v2_standard_user_cannot_update_own_email():
     response = client.post(
         "/v2/update_user/{}".format(user.id),
         json=payload,
-        headers={"Authorization": "Bearer {}".format(create_jwt_token(user))},
+        headers={
+            "Authorization": "Bearer {}".format(create_jwt_token(user)),
+            "X-Origin-Path": "user-registration",
+        },
     )
 
     assert response.status_code == 403
-    assert (
-        "You do not have permission to perform this action."
-        in response.json()["detail"]
-    )
+    assert response.json()["detail"] == "Unauthorized access."
 
 
 @pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
@@ -1561,14 +1606,14 @@ def test_update_user_v2_standard_user_cannot_approve_themselves():
     response = client.post(
         "/v2/update_user/{}".format(user.id),
         json=payload,
-        headers={"Authorization": "Bearer {}".format(create_jwt_token(user))},
+        headers={
+            "Authorization": "Bearer {}".format(create_jwt_token(user)),
+            "X-Origin-Path": "user-registration",
+        },
     )
 
     assert response.status_code == 403
-    assert (
-        "You do not have permission to perform this action."
-        in response.json()["detail"]
-    )
+    assert response.json()["detail"] == "Unauthorized access."
 
 
 @pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
@@ -1594,14 +1639,14 @@ def test_update_user_v2_regional_admin_cannot_update_user_type():
     response = client.post(
         "/v2/update_user/{}".format(user.id),
         json=payload,
-        headers={"Authorization": "Bearer {}".format(create_jwt_token(regional_admin))},
+        headers={
+            "Authorization": "Bearer {}".format(create_jwt_token(regional_admin)),
+            "X-Origin-Path": "user-registration",
+        },
     )
 
     assert response.status_code == 403
-    assert (
-        "You do not have permission to perform this action."
-        in response.json()["detail"]
-    )
+    assert response.json()["detail"] == "Only global admins can update userType."
 
 
 @pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])
@@ -1627,7 +1672,10 @@ def test_update_user_v2_regional_admin_can_update_in_region_state():
     response = client.post(
         "/v2/update_user/{}".format(user.id),
         json=payload,
-        headers={"Authorization": "Bearer {}".format(create_jwt_token(regional_admin))},
+        headers={
+            "Authorization": "Bearer {}".format(create_jwt_token(regional_admin)),
+            "X-Origin-Path": "user-registration",
+        },
     )
 
     assert response.status_code == 200
@@ -1648,10 +1696,14 @@ def test_update_user_v2_standard_user_cannot_update_name():
     response = client.post(
         "/v2/update_user/{}".format(user.id),
         json=payload,
-        headers={"Authorization": "Bearer {}".format(create_jwt_token(user))},
+        headers={
+            "Authorization": "Bearer {}".format(create_jwt_token(user)),
+            "X-Origin-Path": "user-registration",
+        },
     )
 
     assert response.status_code == 403
+    assert response.json()["detail"] == "Unauthorized access."
 
 
 @pytest.mark.django_db(transaction=True, databases=["default", "mini_data_lake"])

--- a/backend/src/xfd_django/xfd_api/views.py
+++ b/backend/src/xfd_django/xfd_api/views.py
@@ -1668,10 +1668,14 @@ async def call_get_users_v2(
 async def update_user_v2_view(
     user_id: str,
     user_data: UpdateUserV2,
+    request: Request,
     current_user: User = Depends(get_current_active_user_unsafe),
 ):
     """Update a particular user."""
-    return update_user_v2(user_id, user_data, current_user)
+    origin_path = request.headers.get("x-origin-path") or request.headers.get(
+        "X-Origin-Path"
+    )
+    return update_user_v2(user_id, user_data, current_user, origin_path)
 
 
 @api_router.post(

--- a/backend/src/xfd_django/xfd_api/views.py
+++ b/backend/src/xfd_django/xfd_api/views.py
@@ -1672,9 +1672,7 @@ async def update_user_v2_view(
     current_user: User = Depends(get_current_active_user_unsafe),
 ):
     """Update a particular user."""
-    origin_path = request.headers.get("x-origin-path") or request.headers.get(
-        "X-Origin-Path"
-    )
+    origin_path = request.headers.get("X-Origin-Path")
     return update_user_v2(user_id, user_data, current_user, origin_path)
 
 

--- a/backend/src/xfd_django/xfd_django/asgi.py
+++ b/backend/src/xfd_django/xfd_django/asgi.py
@@ -178,14 +178,18 @@ def get_application() -> FastAPI:
             LOGGER.warning(
                 f"UserID: {user_id} attempted unauthorized access to {request.url} - Responded with 403 Forbidden."
             )
-            error_detail = (
-                exc.detail
-                if exc.detail
-                else "You do not have permission to perform this action."
-            )
+            # TODO: CRASM-4044 Update to include the non-overridden error details in the response. Update Backend tests.
+            # error_detail = (
+            #     exc.detail
+            #     if exc.detail
+            #     else "You do not have permission to perform this action."
+            # )
             return JSONResponse(
                 status_code=403,
-                content={"detail": error_detail},
+                # content={"detail": error_detail},
+                content={
+                    "detail": "You do not have permission to perform this action."
+                },
             )
 
         return JSONResponse(

--- a/backend/src/xfd_django/xfd_django/asgi.py
+++ b/backend/src/xfd_django/xfd_django/asgi.py
@@ -178,12 +178,14 @@ def get_application() -> FastAPI:
             LOGGER.warning(
                 f"UserID: {user_id} attempted unauthorized access to {request.url} - Responded with 403 Forbidden."
             )
-
+            error_detail = (
+                exc.detail
+                if exc.detail
+                else "You do not have permission to perform this action."
+            )
             return JSONResponse(
                 status_code=403,
-                content={
-                    "detail": "You do not have permission to perform this action."
-                },
+                content={"detail": error_detail},
             )
 
         return JSONResponse(

--- a/frontend/src/components/Dialog/ConfirmDialog.tsx
+++ b/frontend/src/components/Dialog/ConfirmDialog.tsx
@@ -10,6 +10,7 @@ type DialogComponentProps = {
   onClose?: (...args: any[]) => void;
   onConfirm: () => void;
   onCancel: () => void;
+  onSave?: () => void;
   title: string;
   content: React.ReactNode;
   disabled?: boolean;
@@ -21,6 +22,7 @@ const ConfirmDialog: React.FC<DialogComponentProps> = ({
   onClose,
   onConfirm,
   onCancel,
+  onSave,
   title,
   content,
   disabled = false,
@@ -34,6 +36,16 @@ const ConfirmDialog: React.FC<DialogComponentProps> = ({
         <Button size="large" variant="text" onClick={onCancel}>
           Cancel
         </Button>
+        {onSave && (
+          <Button
+            size="large"
+            variant="outlined"
+            onClick={onSave}
+            disabled={disabled}
+          >
+            Save
+          </Button>
+        )}
         <Button
           size="large"
           variant="contained"

--- a/frontend/src/hooks/useUpdateUser.ts
+++ b/frontend/src/hooks/useUpdateUser.ts
@@ -1,29 +1,57 @@
+import { useCallback } from 'react';
 import { usePostApi } from './usePostApi';
 import { ENDPOINTS } from '@/constants/endpoints';
 
-type UpdateUserBody = {
-  first_name?: string;
-  last_name?: string;
-  user_type?: string;
-  email?: string;
-  state: string;
-  region_id: string;
-};
-
-type UseUpdateUserResult = {
-  updateUser: (userId: string | number, body: UpdateUserBody) => Promise<void>;
-};
-
-export const useUpdateUser = (): UseUpdateUserResult => {
-  const postApi = usePostApi();
-
-  const updateUser = async (
-    userId: string | number,
-    body: UpdateUserBody
-  ): Promise<void> => {
-    const path = ENDPOINTS.USER_UPDATE_V2.replace('{user_id}', String(userId));
-    await postApi(path, { body });
+interface UpdateUserBody {
+  userId: string;
+  origin_path: 'user-registration' | 'user-management';
+  body: {
+    first_name?: string;
+    last_name?: string;
+    user_type?: string;
+    email?: string;
+    state?: string;
+    region_id?: string;
+    invite_pending?: boolean;
   };
+  onSuccess?: () => Promise<void> | void;
+  onError?: (errorMessage: string) => void;
+}
+
+export const useUpdateUser = () => {
+  const apiPost = usePostApi();
+
+  const updateUser = useCallback(
+    async ({
+      userId,
+      origin_path,
+      body,
+      onSuccess,
+      onError
+    }: UpdateUserBody): Promise<{ success: boolean; body: string }> => {
+      try {
+        const path = ENDPOINTS.USER_UPDATE_V2.replace('{user_id}', userId);
+        await apiPost(path, {
+          body,
+          headers: {
+            'X-Origin-Path': origin_path
+          }
+        });
+
+        if (onSuccess) {
+          await onSuccess();
+        }
+
+        return { success: true, body: 'User profile successfully updated.' };
+      } catch (e: any) {
+        if (onError) {
+          onError(e.message);
+        }
+        return { success: false, body: e.message };
+      }
+    },
+    [apiPost]
+  );
 
   return { updateUser };
 };

--- a/frontend/src/hooks/useUpdateUser.ts
+++ b/frontend/src/hooks/useUpdateUser.ts
@@ -14,41 +14,21 @@ interface UpdateUserBody {
     region_id?: string;
     invite_pending?: boolean;
   };
-  onSuccess?: () => Promise<void> | void;
-  onError?: (errorMessage: string) => void;
 }
 
 export const useUpdateUser = () => {
   const apiPost = usePostApi();
 
   const updateUser = useCallback(
-    async ({
-      userId,
-      origin_path,
-      body,
-      onSuccess,
-      onError
-    }: UpdateUserBody): Promise<{ success: boolean; body: string }> => {
-      try {
-        const path = ENDPOINTS.USER_UPDATE_V2.replace('{user_id}', userId);
-        await apiPost(path, {
-          body,
-          headers: {
-            'X-Origin-Path': origin_path
-          }
-        });
+    async ({ userId, origin_path, body }: UpdateUserBody): Promise<void> => {
+      const path = ENDPOINTS.USER_UPDATE_V2.replace('{user_id}', userId);
 
-        if (onSuccess) {
-          await onSuccess();
+      await apiPost(path, {
+        body,
+        headers: {
+          'X-Origin-Path': origin_path
         }
-
-        return { success: true, body: 'User profile successfully updated.' };
-      } catch (e: any) {
-        if (onError) {
-          onError(e.message);
-        }
-        return { success: false, body: e.message };
-      }
+      });
     },
     [apiPost]
   );

--- a/frontend/src/pages/UserRegistration/OrganizationSelector.tsx
+++ b/frontend/src/pages/UserRegistration/OrganizationSelector.tsx
@@ -16,7 +16,6 @@ import { organizationCols as orgCols } from './UserRegistrationColumns';
 import { User } from 'types';
 import { REGION_STATE_MAP, STATE_OPTIONS } from '@/constants/constants';
 import { ElevationControl } from '../Users/ElevationControl';
-import { isCisaEmailDomain } from '@/utils/stringUtils';
 export interface OrganizationSelectorProps {
   regionId: string | null | undefined;
   onSelectionChange: (organization: OrganizationType | null) => void;
@@ -39,14 +38,13 @@ export const OrganizationSelector: React.FC<OrganizationSelectorProps> = ({
   getUpdateError,
   pendingUsers
 }) => {
-  const { apiGet, user: loggedInUser } = useAuthContext();
+  const { apiGet } = useAuthContext();
   const [loading, setLoading] = useState<boolean>(false);
   const [organizations, setOrganizations] = useState<OrganizationType[]>([]);
   const [organizationsError, setOrganizationsError] = useState('');
   const [confirmGlobalAdminChange, setConfirmGlobalAdminChange] = useState('');
   const [isRoleElevationConfirmed, setIsRoleElevationConfirmed] =
     useState(false);
-  const isNotCisaEmail = !isCisaEmailDomain(loggedInUser?.email);
   const editedUser = pendingUsers.find(
     (userItem: User) => userItem.id === selectedUser.id
   );
@@ -187,19 +185,19 @@ export const OrganizationSelector: React.FC<OrganizationSelectorProps> = ({
               value="globalView"
               control={<Radio color="primary" />}
               label="Global View"
-              disabled={formattedUserType !== 'Global Admin' || isNotCisaEmail}
+              disabled={formattedUserType !== 'Global Admin'}
             />
             <FormControlLabel
               value="regionalAdmin"
               control={<Radio color="primary" />}
               label="Regional Administrator"
-              disabled={formattedUserType !== 'Global Admin' || isNotCisaEmail}
+              disabled={formattedUserType !== 'Global Admin'}
             />
             <FormControlLabel
               value="globalAdmin"
               control={<Radio color="primary" />}
               label="Global Administrator"
-              disabled={formattedUserType !== 'Global Admin' || isNotCisaEmail}
+              disabled={formattedUserType !== 'Global Admin'}
             />
           </RadioGroup>
           <ElevationControl

--- a/frontend/src/pages/UserRegistration/OrganizationSelector.tsx
+++ b/frontend/src/pages/UserRegistration/OrganizationSelector.tsx
@@ -26,6 +26,8 @@ export interface OrganizationSelectorProps {
   formattedUserType?: string;
   getUpdateError?: string;
   pendingUsers: User[];
+  isRoleElevationConfirmed: boolean;
+  setIsRoleElevationConfirmed: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export const OrganizationSelector: React.FC<OrganizationSelectorProps> = ({
@@ -36,15 +38,15 @@ export const OrganizationSelector: React.FC<OrganizationSelectorProps> = ({
   selectUser,
   formattedUserType,
   getUpdateError,
-  pendingUsers
+  pendingUsers,
+  isRoleElevationConfirmed,
+  setIsRoleElevationConfirmed
 }) => {
   const { apiGet } = useAuthContext();
   const [loading, setLoading] = useState<boolean>(false);
   const [organizations, setOrganizations] = useState<OrganizationType[]>([]);
   const [organizationsError, setOrganizationsError] = useState('');
   const [confirmGlobalAdminChange, setConfirmGlobalAdminChange] = useState('');
-  const [isRoleElevationConfirmed, setIsRoleElevationConfirmed] =
-    useState(false);
   const editedUser = pendingUsers.find(
     (userItem: User) => userItem.id === selectedUser.id
   );

--- a/frontend/src/pages/UserRegistration/OrganizationSelector.tsx
+++ b/frontend/src/pages/UserRegistration/OrganizationSelector.tsx
@@ -38,13 +38,17 @@ export const OrganizationSelector: React.FC<OrganizationSelectorProps> = ({
   getUpdateError,
   pendingUsers
 }) => {
-  const { apiGet } = useAuthContext();
+  const { apiGet, user: loggedInUser } = useAuthContext();
   const [loading, setLoading] = useState<boolean>(false);
   const [organizations, setOrganizations] = useState<OrganizationType[]>([]);
   const [organizationsError, setOrganizationsError] = useState('');
   const [confirmGlobalAdminChange, setConfirmGlobalAdminChange] = useState('');
   const [isRoleElevationConfirmed, setIsRoleElevationConfirmed] =
     useState(false);
+  const isNotCisaEmail = !(
+    loggedInUser?.email.endsWith('cisa.dhs.gov') ||
+    loggedInUser?.email.endsWith('associates.cisa.dhs.gov')
+  );
   const editedUser = pendingUsers.find(
     (userItem: User) => userItem.id === selectedUser.id
   );
@@ -70,8 +74,11 @@ export const OrganizationSelector: React.FC<OrganizationSelectorProps> = ({
     }
     setLoading(true);
     try {
-      const rows = await apiGet<OrganizationType[]>(
+      const orgData = await apiGet<OrganizationType[]>(
         ENDPOINTS.ORGANIZATIONS_REGION.replace('{region_id}', regionId)
+      );
+      const rows = orgData.filter(
+        (org) => org.state_name === selectedUser?.state
       );
       setOrganizations(rows);
       setOrganizationsError('');
@@ -177,25 +184,25 @@ export const OrganizationSelector: React.FC<OrganizationSelectorProps> = ({
               value="standard"
               control={<Radio color="primary" />}
               label="Standard"
-              disabled={formattedUserType !== 'Global Admin'}
+              disabled={formattedUserType !== 'Global Admin' || isNotCisaEmail}
             />
             <FormControlLabel
               value="globalView"
               control={<Radio color="primary" />}
               label="Global View"
-              disabled={formattedUserType !== 'Global Admin'}
+              disabled={formattedUserType !== 'Global Admin' || isNotCisaEmail}
             />
             <FormControlLabel
               value="regionalAdmin"
               control={<Radio color="primary" />}
               label="Regional Administrator"
-              disabled={formattedUserType !== 'Global Admin'}
+              disabled={formattedUserType !== 'Global Admin' || isNotCisaEmail}
             />
             <FormControlLabel
               value="globalAdmin"
               control={<Radio color="primary" />}
               label="Global Administrator"
-              disabled={formattedUserType !== 'Global Admin'}
+              disabled={formattedUserType !== 'Global Admin' || isNotCisaEmail}
             />
           </RadioGroup>
           <ElevationControl

--- a/frontend/src/pages/UserRegistration/OrganizationSelector.tsx
+++ b/frontend/src/pages/UserRegistration/OrganizationSelector.tsx
@@ -16,6 +16,7 @@ import { organizationCols as orgCols } from './UserRegistrationColumns';
 import { User } from 'types';
 import { REGION_STATE_MAP, STATE_OPTIONS } from '@/constants/constants';
 import { ElevationControl } from '../Users/ElevationControl';
+import { isCisaEmailDomain } from '@/utils/stringUtils';
 export interface OrganizationSelectorProps {
   regionId: string | null | undefined;
   onSelectionChange: (organization: OrganizationType | null) => void;
@@ -45,7 +46,7 @@ export const OrganizationSelector: React.FC<OrganizationSelectorProps> = ({
   const [confirmGlobalAdminChange, setConfirmGlobalAdminChange] = useState('');
   const [isRoleElevationConfirmed, setIsRoleElevationConfirmed] =
     useState(false);
-  const isNotCisaEmail = !loggedInUser?.email.endsWith('cisa.dhs.gov');
+  const isNotCisaEmail = !isCisaEmailDomain(loggedInUser?.email);
   const editedUser = pendingUsers.find(
     (userItem: User) => userItem.id === selectedUser.id
   );

--- a/frontend/src/pages/UserRegistration/OrganizationSelector.tsx
+++ b/frontend/src/pages/UserRegistration/OrganizationSelector.tsx
@@ -91,7 +91,7 @@ export const OrganizationSelector: React.FC<OrganizationSelectorProps> = ({
       setOrganizationsError(e.message);
       setLoading(false);
     }
-  }, [regionId, apiGet, initialOrgId, onSelectionChange]);
+  }, [regionId, apiGet, initialOrgId, onSelectionChange, selectedUser?.state]);
 
   useEffect(() => {
     fetchOrganizations();

--- a/frontend/src/pages/UserRegistration/OrganizationSelector.tsx
+++ b/frontend/src/pages/UserRegistration/OrganizationSelector.tsx
@@ -1,38 +1,66 @@
 import React, { useState, useEffect } from 'react';
 import { DataGrid, GridRowSelectionModel, GridToolbar } from '@mui/x-data-grid';
-import Paper from '@mui/material/Paper';
 import Alert from '@mui/material/Alert';
+import Autocomplete from '@mui/material/Autocomplete';
+import Grid from '@mui/material/Grid';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Radio from '@mui/material/Radio';
+import RadioGroup from '@mui/material/RadioGroup';
+import Paper from '@mui/material/Paper';
+import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import { Organization as OrganizationType } from 'types';
 import { ENDPOINTS } from '@/constants/endpoints';
 import { useAuthContext } from 'context';
 import { organizationCols as orgCols } from './UserRegistrationColumns';
-
+import { User } from 'types';
+import { REGION_STATE_MAP, STATE_OPTIONS } from '@/constants/constants';
+import { ElevationControl } from '../Users/ElevationControl';
 export interface OrganizationSelectorProps {
   regionId: string | null | undefined;
   onSelectionChange: (organization: OrganizationType | null) => void;
   initialOrgId?: string;
   selectedOrg?: GridRowSelectionModel;
-  selectedUser?: { full_name: string };
+  selectedUser: User;
+  selectUser?: (user: User) => void;
+  formattedUserType?: string;
+  getUpdateError?: string;
+  pendingUsers: User[];
 }
 
 export const OrganizationSelector: React.FC<OrganizationSelectorProps> = ({
   regionId,
   onSelectionChange,
   initialOrgId,
-  selectedUser
+  selectedUser,
+  selectUser,
+  formattedUserType,
+  getUpdateError,
+  pendingUsers
 }) => {
   const { apiGet } = useAuthContext();
   const [loading, setLoading] = useState<boolean>(false);
   const [organizations, setOrganizations] = useState<OrganizationType[]>([]);
   const [organizationsError, setOrganizationsError] = useState('');
-
+  const [confirmGlobalAdminChange, setConfirmGlobalAdminChange] = useState('');
+  const [isRoleElevationConfirmed, setIsRoleElevationConfirmed] =
+    useState(false);
+  const editedUser = pendingUsers.find(
+    (userItem: User) => userItem.id === selectedUser.id
+  );
+  const userRoleChanged = editedUser?.user_type !== selectedUser.user_type;
   // Local state to manage the grid selection, matching your original logic
   const [localSelectedOrg, setLocalSelectedOrg] =
     useState<GridRowSelectionModel>({
       type: 'include',
       ids: new Set<string | number>(initialOrgId ? [initialOrgId] : [])
     });
+  useEffect(() => {
+    setLocalSelectedOrg({
+      type: 'include',
+      ids: new Set<string | number>(initialOrgId ? [initialOrgId] : [])
+    });
+  }, [initialOrgId]);
 
   const fetchOrganizations = React.useCallback(async () => {
     if (!regionId) {
@@ -103,10 +131,84 @@ export const OrganizationSelector: React.FC<OrganizationSelectorProps> = ({
   return (
     <>
       <Typography mb={3}>
-        To complete the approval process, select one organization for this user
-        to join.
+        To complete the approval process, ensure the user is in the correct
+        state and select one organization for this user to join.
       </Typography>
-      <Paper sx={{ height: 600, margin: 'auto' }}>
+      <Grid container spacing={5} mb={2}>
+        <Grid size={{ xs: 12, sm: 5 }}>
+          <Typography mb={1}>State</Typography>
+          <Autocomplete
+            id="state"
+            size="small"
+            options={STATE_OPTIONS}
+            value={selectedUser?.state || null}
+            onChange={(_, newValue) => {
+              if (!selectedUser || !selectUser) {
+                return;
+              }
+              selectUser({
+                ...selectedUser,
+                state: newValue || '',
+                region_id: newValue ? REGION_STATE_MAP[String(newValue)] : ''
+              });
+            }}
+            renderInput={(params) => <TextField {...params} label="State" />}
+            isOptionEqualToValue={(option, value) => option === value}
+          />
+        </Grid>
+        <Grid size={{ xs: 12, sm: 6 }}>
+          <Typography mb={1}>User Type</Typography>
+          <RadioGroup
+            aria-label="User Type"
+            name="user_type"
+            value={selectedUser?.user_type}
+            onChange={(event) => {
+              if (!selectedUser || !selectUser) {
+                return;
+              }
+              selectUser({
+                ...selectedUser,
+                user_type: event.target.value as User['user_type']
+              });
+              setIsRoleElevationConfirmed(false);
+            }}
+          >
+            <FormControlLabel
+              value="standard"
+              control={<Radio color="primary" />}
+              label="Standard"
+              disabled={formattedUserType !== 'Global Admin'}
+            />
+            <FormControlLabel
+              value="globalView"
+              control={<Radio color="primary" />}
+              label="Global View"
+              disabled={formattedUserType !== 'Global Admin'}
+            />
+            <FormControlLabel
+              value="regionalAdmin"
+              control={<Radio color="primary" />}
+              label="Regional Administrator"
+              disabled={formattedUserType !== 'Global Admin'}
+            />
+            <FormControlLabel
+              value="globalAdmin"
+              control={<Radio color="primary" />}
+              label="Global Administrator"
+              disabled={formattedUserType !== 'Global Admin'}
+            />
+          </RadioGroup>
+          <ElevationControl
+            confirmGlobalAdminChange={confirmGlobalAdminChange}
+            setConfirmGlobalAdminChange={setConfirmGlobalAdminChange}
+            userRoleChanged={userRoleChanged}
+            values={selectedUser}
+            isRoleElevationConfirmed={isRoleElevationConfirmed}
+            setIsRoleElevationConfirmed={setIsRoleElevationConfirmed}
+          />
+        </Grid>
+      </Grid>
+      <Paper sx={{ height: 400, margin: 'auto' }}>
         <DataGrid
           checkboxSelection
           onRowSelectionModelChange={onRowSelectionModelChange}
@@ -136,6 +238,11 @@ export const OrganizationSelector: React.FC<OrganizationSelectorProps> = ({
       {organizationsError.length > 0 && (
         <Alert severity="error">
           Error retrieving organizations: {organizationsError}
+        </Alert>
+      )}
+      {getUpdateError && getUpdateError.length > 0 && (
+        <Alert severity="error" sx={{ mt: 2 }}>
+          Error updating pending user: {getUpdateError}
         </Alert>
       )}
 

--- a/frontend/src/pages/UserRegistration/OrganizationSelector.tsx
+++ b/frontend/src/pages/UserRegistration/OrganizationSelector.tsx
@@ -182,7 +182,6 @@ export const OrganizationSelector: React.FC<OrganizationSelectorProps> = ({
               value="standard"
               control={<Radio color="primary" />}
               label="Standard"
-              disabled={formattedUserType !== 'Global Admin' || isNotCisaEmail}
             />
             <FormControlLabel
               value="globalView"

--- a/frontend/src/pages/UserRegistration/OrganizationSelector.tsx
+++ b/frontend/src/pages/UserRegistration/OrganizationSelector.tsx
@@ -45,10 +45,7 @@ export const OrganizationSelector: React.FC<OrganizationSelectorProps> = ({
   const [confirmGlobalAdminChange, setConfirmGlobalAdminChange] = useState('');
   const [isRoleElevationConfirmed, setIsRoleElevationConfirmed] =
     useState(false);
-  const isNotCisaEmail = !(
-    loggedInUser?.email.endsWith('cisa.dhs.gov') ||
-    loggedInUser?.email.endsWith('associates.cisa.dhs.gov')
-  );
+  const isNotCisaEmail = !loggedInUser?.email.endsWith('cisa.dhs.gov');
   const editedUser = pendingUsers.find(
     (userItem: User) => userItem.id === selectedUser.id
   );

--- a/frontend/src/pages/UserRegistration/OrganizationSelector.tsx
+++ b/frontend/src/pages/UserRegistration/OrganizationSelector.tsx
@@ -28,6 +28,8 @@ export interface OrganizationSelectorProps {
   pendingUsers: User[];
   isRoleElevationConfirmed: boolean;
   setIsRoleElevationConfirmed: React.Dispatch<React.SetStateAction<boolean>>;
+  confirmGlobalAdminChange: string | undefined;
+  setConfirmGlobalAdminChange: React.Dispatch<React.SetStateAction<string>>;
 }
 
 export const OrganizationSelector: React.FC<OrganizationSelectorProps> = ({
@@ -40,13 +42,14 @@ export const OrganizationSelector: React.FC<OrganizationSelectorProps> = ({
   getUpdateError,
   pendingUsers,
   isRoleElevationConfirmed,
-  setIsRoleElevationConfirmed
+  setIsRoleElevationConfirmed,
+  confirmGlobalAdminChange = '',
+  setConfirmGlobalAdminChange
 }) => {
   const { apiGet } = useAuthContext();
   const [loading, setLoading] = useState<boolean>(false);
   const [organizations, setOrganizations] = useState<OrganizationType[]>([]);
   const [organizationsError, setOrganizationsError] = useState('');
-  const [confirmGlobalAdminChange, setConfirmGlobalAdminChange] = useState('');
   const editedUser = pendingUsers.find(
     (userItem: User) => userItem.id === selectedUser.id
   );

--- a/frontend/src/pages/UserRegistration/RegionUsers.tsx
+++ b/frontend/src/pages/UserRegistration/RegionUsers.tsx
@@ -28,7 +28,6 @@ import {
   getMemberUserColumns
 } from './UserRegistrationColumns';
 import { OrganizationSelector } from './OrganizationSelector';
-import { isCisaEmailDomain } from '@/utils/stringUtils';
 
 type DialogStates = {
   isOrgDialogOpen: boolean;
@@ -61,7 +60,6 @@ export const RegionUsers: React.FC = () => {
   const { formattedUserType } = useUserLevel();
   const getUsersURL = ENDPOINTS.USERS_V2 + '?invite_pending=';
   const theme = useTheme();
-  const isNotCisaEmail = !isCisaEmailDomain(loggedInUser?.email);
   const [dialogStates, setDialogStates] = useState<DialogStates>({
     isOrgDialogOpen: false,
     isDenyDialogOpen: false,
@@ -543,11 +541,7 @@ export const RegionUsers: React.FC = () => {
             getUpdateError={errorStates.getUpdateError}
           />
         }
-        disabled={
-          selectedOrg.ids.size === 0 ||
-          ((loggedInUser?.user_type !== 'globalAdmin' || isNotCisaEmail) &&
-            selectedUser.user_type !== 'standard')
-        }
+        disabled={selectedOrg.ids.size === 0}
         screenWidth="lg"
       />
       <ConfirmDialog

--- a/frontend/src/pages/UserRegistration/RegionUsers.tsx
+++ b/frontend/src/pages/UserRegistration/RegionUsers.tsx
@@ -177,7 +177,8 @@ export const RegionUsers: React.FC = () => {
               ...(loggedInUser?.user_type === 'globalAdmin' && {
                 user_type: selectedUser.user_type
               })
-            }
+            },
+            headers: { 'X-Origin-Path': 'user-registration' }
           }
         );
 

--- a/frontend/src/pages/UserRegistration/RegionUsers.tsx
+++ b/frontend/src/pages/UserRegistration/RegionUsers.tsx
@@ -47,9 +47,14 @@ type CloseReason = 'backdropClick' | 'escapeKeyDown' | 'closeButtonClick';
 
 /** Refresh pending/member tables while admins work on this page (ms). */
 const REGISTRATION_USERS_REFRESH_INTERVAL_MS = 30_000;
+const INITIAL_ERROR_STATES: ErrorStates = {
+  getUsersError: '',
+  getUpdateError: '',
+  getDeleteError: ''
+};
 
 export const RegionUsers: React.FC = () => {
-  const { apiDelete, apiGet, apiPost, user } = useAuthContext();
+  const { apiDelete, apiGet, apiPost, user: loggedInUser } = useAuthContext();
   const apiRefPendingUsers = useGridApiRef();
   const apiRefCurrentUsers = useGridApiRef();
   const { formattedUserType } = useUserLevel();
@@ -63,11 +68,8 @@ export const RegionUsers: React.FC = () => {
     isInfoDialogOpen: false,
     isUserAlreadyApprovedDialogOpen: false
   });
-  const [errorStates, setErrorStates] = useState<ErrorStates>({
-    getUsersError: '',
-    getUpdateError: '',
-    getDeleteError: ''
-  });
+  const [errorStates, setErrorStates] =
+    useState<ErrorStates>(INITIAL_ERROR_STATES);
   const [selectedUser, selectUser] = useState<User>(initializeUser);
   const [selectedOrg, setSelectedOrg] = React.useState<GridRowSelectionModel>({
     type: 'include',
@@ -77,23 +79,28 @@ export const RegionUsers: React.FC = () => {
   const [pendingUsers, setPendingUsers] = useState<User[]>([]);
   const [currentUsers, setCurrentUsers] = useState<User[]>([]);
   const [infoDialogContent, setInfoDialogContent] = useState<String>('');
-
+  // console.log(selectedUser);
   const fetchPendingUsers = useCallback(async () => {
     try {
       const rows = await apiGet<User[]>(`${getUsersURL}true`);
       setPendingUsers(rows);
       setErrorStates((prev) => ({ ...prev, getUsersError: '' }));
+      return rows;
     } catch (e: any) {
       setErrorStates((prev) => ({ ...prev, getUsersError: e.message }));
+      throw e;
     }
   }, [apiGet, getUsersURL]);
+
   const fetchCurrentUsers = useCallback(async () => {
     try {
       const rows = await apiGet<User[]>(`${getUsersURL}false`);
       setCurrentUsers(transformUserData(rows));
       setErrorStates((prev) => ({ ...prev, getUsersError: '' }));
+      return rows;
     } catch (e: any) {
       setErrorStates((prev) => ({ ...prev, getUsersError: e.message }));
+      throw e;
     }
   }, [apiGet, getUsersURL]);
 
@@ -139,15 +146,10 @@ export const RegionUsers: React.FC = () => {
   }, [fetchPendingUsers, fetchCurrentUsers, isRegistrationDialogOpen]);
 
   const deleteUser = useCallback(
-    (user_id: string): Promise<boolean> => {
+    async (user_id: string): Promise<boolean> => {
       return apiDelete(ENDPOINTS.USER.replace('{user_id}', user_id)).then(
-        () => {
-          apiRefPendingUsers.current?.updateRows([
-            { id: user_id, _action: 'delete' }
-          ]);
-          setPendingUsers((prevPendingUsers) =>
-            prevPendingUsers.filter((user) => user.id !== user_id)
-          );
+        async () => {
+          await fetchPendingUsers();
           setInfoDialogContent('This user has been successfully removed.');
           return true;
         },
@@ -162,47 +164,42 @@ export const RegionUsers: React.FC = () => {
 
   const updateUser = useCallback(
     async (
-      user_id: string,
-      selectedOrgObject: any
+      selectedUser: User,
+      isSaveAction: boolean
     ): Promise<{ success: boolean; body: string }> => {
       try {
-        const res = await apiPost(
-          ENDPOINTS.USER_UPDATE_V2.replace('{user_id}', user_id),
+        await apiPost(
+          ENDPOINTS.USER_UPDATE_V2.replace('{user_id}', selectedUser.id),
           {
-            body: { invite_pending: false }
-          }
-        );
-        const mockRoles = [
-          {
-            organization: {
-              id: selectedOrgObject.id,
-              name: selectedOrgObject.name,
-              acronym: selectedOrgObject.acronym
+            body: {
+              invite_pending: isSaveAction,
+              state: selectedUser.state,
+              ...(loggedInUser?.user_type === 'globalAdmin' && {
+                user_type: selectedUser.user_type
+              })
             }
           }
-        ];
-        // Combine the API response with selection data
-        const updatedUserWithRoles = { ...res, roles: mockRoles };
-        const transformedUser = transformUserData([updatedUserWithRoles])[0];
-        apiRefPendingUsers.current?.updateRows([
-          { id: user_id, _action: 'delete' }
-        ]);
-        setPendingUsers((prev) => prev.filter((u) => u.id !== user_id));
-        apiRefCurrentUsers.current?.updateRows([transformedUser]);
-        setCurrentUsers((prev) => [...prev, transformedUser]);
-        return { success: true, body: 'User registration approved' };
+        );
+
+        await fetchPendingUsers();
+        if (!isSaveAction) {
+          await fetchCurrentUsers();
+        }
+
+        return { success: true, body: 'Pending User Updated' };
       } catch (e: any) {
         setErrorStates({ ...errorStates, getUpdateError: e.message });
         return { success: false, body: e.message };
       }
     },
-    [apiPost, apiRefCurrentUsers, apiRefPendingUsers, errorStates]
+    [apiPost, fetchPendingUsers, fetchCurrentUsers, errorStates]
   );
 
   const addOrgToUser = useCallback(
     async (
-      user_id: string,
-      orgObject: any
+      selectedUser: User,
+      orgObject: any,
+      isSaveAction: boolean
     ): Promise<{ success: boolean; body: string }> => {
       try {
         await apiPost(
@@ -210,9 +207,9 @@ export const RegionUsers: React.FC = () => {
             '{organization_id}',
             orgObject.id // Extract ID for the API call
           ),
-          { body: { user_id, role: 'user' } }
+          { body: { user_id: selectedUser.id, role: 'user' } }
         );
-        return updateUser(user_id, orgObject);
+        return updateUser(selectedUser, isSaveAction);
       } catch (e: any) {
         setErrorStates({ ...errorStates, getUpdateError: e.message });
         return { success: false, body: e.message };
@@ -284,7 +281,7 @@ export const RegionUsers: React.FC = () => {
   };
 
   const pendingCols = getPendingUserColumns({
-    userType: user?.user_type,
+    userType: loggedInUser?.user_type,
     handleApproveClick,
     handleDenyClick
   });
@@ -304,11 +301,17 @@ export const RegionUsers: React.FC = () => {
     }));
     setSelectedOrgObject(null);
     selectUser(initializeUser);
+    setErrorStates(INITIAL_ERROR_STATES);
   };
 
   const removeOrgFromUser = useCallback(
-    (org_id: String, roleId: String) => {
-      apiPost(
+    (org_id: String | undefined | null, roleId: String | undefined | null) => {
+      // Fail if parameters are completely missing
+      if (!org_id || !roleId) {
+        logger.warn('RegionUsers: Missing org_id or roleId for removal bypass');
+        return Promise.resolve();
+      }
+      return apiPost(
         ENDPOINTS.ORGANIZATION_REMOVE_ROLE.replace(
           '{organization_id}',
           org_id.toString()
@@ -326,106 +329,124 @@ export const RegionUsers: React.FC = () => {
         },
         (e) => {
           setErrorStates({ ...errorStates, getUpdateError: e.message });
+          throw e;
         }
       );
     }, // eslint-disable-next-line react-hooks/exhaustive-deps
     [apiPost]
   );
 
-  const handleApproveConfirmClick = async () => {
+  const handleApproveConfirmClick = async (isSaveAction = false) => {
     try {
-      const emailResult = await sendApprovalEmail(selectedUser.id);
-      const userHadOrg = selectedUser.roles.length > 0;
-      const originalOrgId = userHadOrg
-        ? selectedUser.roles[0].organization.id
-        : '';
+      // Check if roles and ids exist
+      const userHadOrg = (selectedUser?.roles?.length ?? 0) > 0;
+      const originalOrgId = selectedUser?.roles?.[0]?.organization?.id || '';
+      const originalRoleId = selectedUser?.roles?.[0]?.id || '';
       const selectedOrgId = selectedOrgObject?.id || null;
       let success = false;
+      if (!isSaveAction) {
+        const emailResult = await sendApprovalEmail(selectedUser.id);
 
-      // User was approved earlier (e.g. register/approve succeeded but invite_pending was
-      // never cleared). Finish approval by assigning org if needed, then clear pending.
-      if (
-        emailResult.status_code === 200 &&
-        emailResult.body === 'User registration already approved.'
-      ) {
-        let alreadyApprovedSuccess = false;
+        if (
+          emailResult.status_code === 200 &&
+          emailResult.body === 'User registration already approved.'
+        ) {
+          let alreadyApprovedSuccess = false;
 
-        if (userHadOrg && originalOrgId === selectedOrgId) {
-          const updateUserResult = await updateUser(
-            selectedUser.id,
-            selectedUser.roles[0].organization
-          );
-          alreadyApprovedSuccess = updateUserResult.success;
-        } else if (selectedOrgObject) {
-          const addOrgResult = await addOrgToUser(
-            selectedUser.id,
-            selectedOrgObject
-          );
-          alreadyApprovedSuccess = addOrgResult.success;
-        } else if (selectedUser.roles[0]?.organization) {
-          const updateUserResult = await updateUser(
-            selectedUser.id,
-            selectedUser.roles[0].organization
-          );
-          alreadyApprovedSuccess = updateUserResult.success;
+          if (userHadOrg && originalOrgId === selectedOrgId) {
+            const updateUserResult = await updateUser(
+              selectedUser,
+              isSaveAction
+            );
+            alreadyApprovedSuccess = updateUserResult.success;
+          } else if (selectedOrgObject) {
+            const addOrgResult = await addOrgToUser(
+              selectedUser,
+              selectedOrgObject,
+              isSaveAction
+            );
+            alreadyApprovedSuccess = addOrgResult.success;
+          } else if (selectedUser.roles[0]?.organization) {
+            const updateUserResult = await updateUser(
+              selectedUser,
+              isSaveAction
+            );
+            alreadyApprovedSuccess = updateUserResult.success;
+          }
+
+          if (alreadyApprovedSuccess) {
+            const approvedOrgName =
+              selectedOrgObject?.name ??
+              selectedUser.roles[0]?.organization?.name ??
+              'the selected organization';
+            handleCloseDialog('closeButtonClick');
+            setDialogStates((prevState) => ({
+              ...prevState,
+              isInfoDialogOpen: true
+            }));
+            setInfoDialogContent(
+              `This user was previously approved. Their registration is now complete and they are a member of ${approvedOrgName} in Region ${selectedUser.region_id}.`
+            );
+          } else {
+            setDialogStates((prevState) => ({
+              ...prevState,
+              isOrgDialogOpen: false,
+              isUserAlreadyApprovedDialogOpen: true
+            }));
+          }
+          return;
         }
-
-        if (alreadyApprovedSuccess) {
-          const approvedOrgName =
-            selectedOrgObject?.name ??
-            selectedUser.roles[0]?.organization?.name ??
-            'the selected organization';
-          handleCloseDialog('closeButtonClick');
-          setDialogStates((prevState) => ({
-            ...prevState,
-            isInfoDialogOpen: true
-          }));
-          setInfoDialogContent(
-            `This user was previously approved. Their registration is now complete and they are a member of ${approvedOrgName} in Region ${selectedUser.region_id}.`
-          );
-        } else {
-          setDialogStates((prevState) => ({
-            ...prevState,
-            isOrgDialogOpen: false,
-            isUserAlreadyApprovedDialogOpen: true
-          }));
-        }
-        return;
       }
 
       // If the user's org was already added and not modified, only update the user.
       if (userHadOrg && originalOrgId === selectedOrgId) {
-        const existingOrg = selectedUser.roles[0].organization;
-        const updateUserResult = await updateUser(selectedUser.id, existingOrg);
+        const updateUserResult = await updateUser(selectedUser, isSaveAction);
         success = updateUserResult.success;
       } else if (userHadOrg && originalOrgId !== selectedOrgId) {
         // TODO: Make a new API endpoint to update Org for User instead of doing a removal and addition.
-        removeOrgFromUser(originalOrgId, selectedUser.roles[0].id);
+        if (originalOrgId && originalRoleId) {
+          await removeOrgFromUser(originalOrgId, originalRoleId);
+        }
         // Pass the full selected object to both
         const addOrgResult = await addOrgToUser(
-          selectedUser.id,
-          selectedOrgObject
+          selectedUser,
+          selectedOrgObject,
+          isSaveAction
         );
         success = addOrgResult.success;
       } else {
         // Pass the full selected object
         const addOrgResult = await addOrgToUser(
-          selectedUser.id,
-          selectedOrgObject
+          selectedUser,
+          selectedOrgObject,
+          isSaveAction
         );
         success = addOrgResult.success;
       }
       if (success) {
+        setPendingUsers((freshPendingList) => {
+          const updatedProfile = freshPendingList.find(
+            (u) => u.id === selectedUser.id
+          );
+          if (updatedProfile) {
+            selectUser(updatedProfile);
+          }
+          return freshPendingList;
+        });
         handleCloseDialog('closeButtonClick');
         setDialogStates((prevState) => ({
           ...prevState,
           isInfoDialogOpen: true
         }));
         setInfoDialogContent(
-          `The user has been approved and is a member of Region ${selectedUser.region_id}.`
+          `The user has been ${isSaveAction ? 'saved.' : `approved and is a member of Region ${selectedUser.region_id}.`}`
         );
       } else {
-        throw new Error('Failed to approve the user.');
+        setErrorStates({
+          ...errorStates,
+          getUpdateError: 'Failed to update the user.'
+        });
+        throw new Error('Failed to update the user.');
       }
     } catch (e: any) {
       setErrorStates({ ...errorStates, getUpdateError: e.message });
@@ -498,15 +519,20 @@ export const RegionUsers: React.FC = () => {
       <ConfirmDialog
         isOpen={dialogStates.isOrgDialogOpen}
         onClose={(_, reason) => handleCloseDialog(reason)}
-        onConfirm={handleApproveConfirmClick}
+        onConfirm={() => handleApproveConfirmClick(false)}
+        onSave={() => handleApproveConfirmClick(true)}
         onCancel={handleApproveCancelClick}
         title={`Add ${selectedUser.full_name} to an organization in Region ${selectedUser.region_id}`}
         content={
           <OrganizationSelector
+            pendingUsers={pendingUsers}
             regionId={selectedUser.region_id}
             selectedUser={selectedUser}
+            selectUser={selectUser}
+            formattedUserType={formattedUserType}
             initialOrgId={selectedUser.roles[0]?.organization.id}
             onSelectionChange={handleOrgSelectionChange}
+            getUpdateError={errorStates.getUpdateError}
           />
         }
         disabled={selectedOrg.ids.size === 0}

--- a/frontend/src/pages/UserRegistration/RegionUsers.tsx
+++ b/frontend/src/pages/UserRegistration/RegionUsers.tsx
@@ -78,6 +78,18 @@ export const RegionUsers: React.FC = () => {
   const [pendingUsers, setPendingUsers] = useState<User[]>([]);
   const [currentUsers, setCurrentUsers] = useState<User[]>([]);
   const [infoDialogContent, setInfoDialogContent] = useState<String>('');
+  const [isRoleElevationConfirmed, setIsRoleElevationConfirmed] =
+    useState(false);
+
+  const isNewGlobalAdmin =
+    pendingUsers?.find((userItem: User) => userItem.id === selectedUser.id)
+      ?.user_type !== selectedUser.user_type &&
+    selectedUser.user_type === 'globalAdmin';
+  const isNewRegionalOrGlobalView =
+    pendingUsers?.find((userItem: User) => userItem.id === selectedUser.id)
+      ?.user_type !== selectedUser.user_type &&
+    (selectedUser.user_type === 'regionalAdmin' ||
+      selectedUser.user_type === 'globalView');
 
   const fetchPendingUsers = useCallback(async () => {
     try {
@@ -539,9 +551,15 @@ export const RegionUsers: React.FC = () => {
             initialOrgId={selectedUser.roles[0]?.organization.id}
             onSelectionChange={handleOrgSelectionChange}
             getUpdateError={errorStates.getUpdateError}
+            isRoleElevationConfirmed={isRoleElevationConfirmed}
+            setIsRoleElevationConfirmed={setIsRoleElevationConfirmed}
           />
         }
-        disabled={selectedOrg.ids.size === 0}
+        disabled={
+          selectedOrg.ids.size === 0 ||
+          ((isNewGlobalAdmin || isNewRegionalOrGlobalView) &&
+            !isRoleElevationConfirmed)
+        }
         screenWidth="lg"
       />
       <ConfirmDialog

--- a/frontend/src/pages/UserRegistration/RegionUsers.tsx
+++ b/frontend/src/pages/UserRegistration/RegionUsers.tsx
@@ -79,7 +79,7 @@ export const RegionUsers: React.FC = () => {
   const [pendingUsers, setPendingUsers] = useState<User[]>([]);
   const [currentUsers, setCurrentUsers] = useState<User[]>([]);
   const [infoDialogContent, setInfoDialogContent] = useState<String>('');
-  // console.log(selectedUser);
+
   const fetchPendingUsers = useCallback(async () => {
     try {
       const rows = await apiGet<User[]>(`${getUsersURL}true`);

--- a/frontend/src/pages/UserRegistration/RegionUsers.tsx
+++ b/frontend/src/pages/UserRegistration/RegionUsers.tsx
@@ -28,6 +28,7 @@ import {
   getMemberUserColumns
 } from './UserRegistrationColumns';
 import { OrganizationSelector } from './OrganizationSelector';
+import { isCisaEmailDomain } from '@/utils/stringUtils';
 
 type DialogStates = {
   isOrgDialogOpen: boolean;
@@ -60,7 +61,7 @@ export const RegionUsers: React.FC = () => {
   const { formattedUserType } = useUserLevel();
   const getUsersURL = ENDPOINTS.USERS_V2 + '?invite_pending=';
   const theme = useTheme();
-
+  const isNotCisaEmail = !isCisaEmailDomain(loggedInUser?.email);
   const [dialogStates, setDialogStates] = useState<DialogStates>({
     isOrgDialogOpen: false,
     isDenyDialogOpen: false,
@@ -542,7 +543,11 @@ export const RegionUsers: React.FC = () => {
             getUpdateError={errorStates.getUpdateError}
           />
         }
-        disabled={selectedOrg.ids.size === 0}
+        disabled={
+          selectedOrg.ids.size === 0 ||
+          ((loggedInUser?.user_type !== 'globalAdmin' || isNotCisaEmail) &&
+            selectedUser.user_type !== 'standard')
+        }
         screenWidth="lg"
       />
       <ConfirmDialog

--- a/frontend/src/pages/UserRegistration/RegionUsers.tsx
+++ b/frontend/src/pages/UserRegistration/RegionUsers.tsx
@@ -193,7 +193,13 @@ export const RegionUsers: React.FC = () => {
         return { success: false, body: e.message };
       }
     },
-    [apiPost, fetchPendingUsers, fetchCurrentUsers, errorStates]
+    [
+      apiPost,
+      fetchPendingUsers,
+      fetchCurrentUsers,
+      errorStates,
+      loggedInUser?.user_type
+    ]
   );
 
   const addOrgToUser = useCallback(

--- a/frontend/src/pages/UserRegistration/RegionUsers.tsx
+++ b/frontend/src/pages/UserRegistration/RegionUsers.tsx
@@ -80,7 +80,7 @@ export const RegionUsers: React.FC = () => {
   const [infoDialogContent, setInfoDialogContent] = useState<String>('');
   const [isRoleElevationConfirmed, setIsRoleElevationConfirmed] =
     useState(false);
-
+  const [confirmGlobalAdminChange, setConfirmGlobalAdminChange] = useState('');
   const isNewGlobalAdmin =
     pendingUsers?.find((userItem: User) => userItem.id === selectedUser.id)
       ?.user_type !== selectedUser.user_type &&
@@ -553,12 +553,15 @@ export const RegionUsers: React.FC = () => {
             getUpdateError={errorStates.getUpdateError}
             isRoleElevationConfirmed={isRoleElevationConfirmed}
             setIsRoleElevationConfirmed={setIsRoleElevationConfirmed}
+            confirmGlobalAdminChange={confirmGlobalAdminChange}
+            setConfirmGlobalAdminChange={setConfirmGlobalAdminChange}
           />
         }
         disabled={
           selectedOrg.ids.size === 0 ||
-          ((isNewGlobalAdmin || isNewRegionalOrGlobalView) &&
-            !isRoleElevationConfirmed)
+          (isNewGlobalAdmin &&
+            confirmGlobalAdminChange !== 'Global Administrator') ||
+          (isNewRegionalOrGlobalView && !isRoleElevationConfirmed)
         }
         screenWidth="lg"
       />

--- a/frontend/src/pages/Users/ElevationControl.tsx
+++ b/frontend/src/pages/Users/ElevationControl.tsx
@@ -30,6 +30,14 @@ export const ElevationControl: React.FC<ElevationControlProps> = ({
       }
     }
   };
+
+  if (
+    values.user_type === 'globalAdmin' &&
+    confirmGlobalAdminChange === 'Global Administrator'
+  ) {
+    setIsRoleElevationConfirmed(true);
+  }
+
   if (!userRoleChanged || values.user_type === 'standard') return <></>;
   if (values.user_type === 'globalAdmin') {
     return (
@@ -57,7 +65,9 @@ export const ElevationControl: React.FC<ElevationControlProps> = ({
           type="text"
           fullWidth
           value={confirmGlobalAdminChange}
-          onChange={(event) => setConfirmGlobalAdminChange(event.target.value)}
+          onChange={(event) => {
+            setConfirmGlobalAdminChange(event.target.value);
+          }}
         />
       </>
     );

--- a/frontend/src/pages/Users/ElevationControl.tsx
+++ b/frontend/src/pages/Users/ElevationControl.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import Alert from '@mui/material/Alert';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import { User, UserFormValues } from 'types';
+
+type ElevationControlProps = {
+  confirmGlobalAdminChange: string;
+  setConfirmGlobalAdminChange: React.Dispatch<React.SetStateAction<string>>;
+  userRoleChanged: boolean;
+  values: UserFormValues | User;
+  isRoleElevationConfirmed: boolean;
+  setIsRoleElevationConfirmed: React.Dispatch<React.SetStateAction<boolean>>;
+  userOrg?: string | null;
+};
+
+export const ElevationControl: React.FC<ElevationControlProps> = ({
+  confirmGlobalAdminChange,
+  setConfirmGlobalAdminChange,
+  userRoleChanged,
+  values,
+  isRoleElevationConfirmed,
+  setIsRoleElevationConfirmed,
+  userOrg
+}) => {
+  const textFieldStyling = {
+    '& .MuiOutlinedInput-root': {
+      '&.Mui-focused fieldset': {
+        borderRadius: '0px'
+      }
+    }
+  };
+  if (!userRoleChanged || values.user_type === 'standard') return <></>;
+  if (values.user_type === 'globalAdmin') {
+    return (
+      <>
+        <Alert severity="warning">
+          You are attempting to change user{' '}
+          <strong>
+            {userOrg ? `${values.email} - ${userOrg}` : values.email}
+          </strong>{' '}
+          to a Global Administrator. This will give them access to all
+          organizations and data in the system. Please type{' '}
+          <strong>Global Administrator</strong> in the field below to confirm
+          this change.
+        </Alert>
+        <TextField
+          sx={textFieldStyling}
+          placeholder="Enter Global Administrator to confirm"
+          size="small"
+          margin="dense"
+          id="first_name"
+          slotProps={{
+            htmlInput: { maxLength: 250 }
+          }}
+          name="first_name"
+          type="text"
+          fullWidth
+          value={confirmGlobalAdminChange}
+          onChange={(event) => setConfirmGlobalAdminChange(event.target.value)}
+        />
+      </>
+    );
+  }
+  if (values.user_type === 'regionalAdmin' || values.user_type === 'globalView')
+    return (
+      <>
+        <Alert severity={isRoleElevationConfirmed ? 'success' : 'warning'}>
+          You are attempting to change this user to{' '}
+          <strong>
+            {values.user_type === 'regionalAdmin'
+              ? 'Regional Administrator'
+              : 'Global View'}
+          </strong>
+          . This will give them access to more organizations and data in the
+          system.
+          <br />
+          <Button
+            sx={{ mt: 1 }}
+            size="small"
+            variant="contained"
+            onClick={() => setIsRoleElevationConfirmed(true)}
+            disabled={isRoleElevationConfirmed}
+          >
+            {isRoleElevationConfirmed
+              ? 'Confirmed Privilege Elevation'
+              : 'Confirm Privilege Elevation'}
+          </Button>
+        </Alert>
+      </>
+    );
+
+  return <></>;
+};

--- a/frontend/src/pages/Users/UserForm.tsx
+++ b/frontend/src/pages/Users/UserForm.tsx
@@ -224,7 +224,7 @@ export const UserForm: React.FC<UserFormProps> = ({
   setInfoDialogContent
 }) => {
   const initialValuesRef = useRef(values);
-  const { user } = useAuthContext();
+  const { user: loggedInUser } = useAuthContext();
 
   const [formErrors, setFormErrors] = useState({
     first_name: false,
@@ -321,14 +321,14 @@ export const UserForm: React.FC<UserFormProps> = ({
     }
 
     const oldRoleLevel =
-      USER_TYPE_MAP[user?.user_type as keyof typeof USER_TYPE_MAP] ?? 0;
+      USER_TYPE_MAP[loggedInUser?.user_type as keyof typeof USER_TYPE_MAP] ?? 0;
     const newRoleLevel =
       USER_TYPE_MAP[values?.user_type as keyof typeof USER_TYPE_MAP] ?? 0;
 
     if (newRoleLevel > oldRoleLevel) {
       logger.info(
         'UserForm: User role elevation detected, confirming with user',
-        { oldRole: user?.user_type, newRole: values?.user_type }
+        { oldRole: loggedInUser?.user_type, newRole: values?.user_type }
       );
     }
 
@@ -339,7 +339,7 @@ export const UserForm: React.FC<UserFormProps> = ({
       region_id: values.region_id
     };
 
-    if (user?.user_type === 'globalAdmin') {
+    if (loggedInUser?.user_type === 'globalAdmin') {
       body.user_type = values.user_type;
     }
 
@@ -394,7 +394,7 @@ export const UserForm: React.FC<UserFormProps> = ({
       setInfoDialogOpen(true);
       logger.error('UserForm.handleEditUserSubmit failed:', {
         error,
-        userId: user?.id
+        userId: loggedInUser?.id
       });
     }
   };
@@ -475,7 +475,10 @@ export const UserForm: React.FC<UserFormProps> = ({
             fullWidth
             value={values.first_name}
             onChange={onTextChange}
-            disabled={user?.user_type !== 'globalAdmin'}
+            disabled={
+              loggedInUser?.user_type !== 'globalAdmin' ||
+              values?.invite_pending === true
+            }
           />
         </Grid>
         <Grid size={{ xs: 12, md: 6 }}>
@@ -499,7 +502,10 @@ export const UserForm: React.FC<UserFormProps> = ({
             fullWidth
             value={values.last_name}
             onChange={onTextChange}
-            disabled={user?.user_type !== 'globalAdmin'}
+            disabled={
+              loggedInUser?.user_type !== 'globalAdmin' ||
+              values?.invite_pending === true
+            }
           />
         </Grid>
         <Grid size={{ xs: 12 }}>
@@ -532,7 +538,10 @@ export const UserForm: React.FC<UserFormProps> = ({
             id="state"
             size="small"
             options={STATE_OPTIONS}
-            disabled={!['globalAdmin'].includes(user?.user_type || '')}
+            disabled={
+              !['globalAdmin'].includes(loggedInUser?.user_type || '') ||
+              values?.invite_pending === true
+            }
             value={values.state || null}
             onChange={(_, newValue) => {
               setValues((previousValues: any) => ({
@@ -557,8 +566,8 @@ export const UserForm: React.FC<UserFormProps> = ({
                 }
                 disabled={
                   !['globalAdmin', 'regionalAdmin'].includes(
-                    user?.user_type || ''
-                  )
+                    loggedInUser?.user_type || ''
+                  ) || values?.invite_pending === true
                 }
               />
             )}
@@ -567,7 +576,14 @@ export const UserForm: React.FC<UserFormProps> = ({
         </Grid>
         <Grid size={{ xs: 12 }}>
           <Typography mb={1}>Organization</Typography>
-          {isLoading ? (
+          {values?.invite_pending === true ? (
+            <TextField
+              placeholder="Pending Invitation Approval..."
+              disabled
+              fullWidth
+              size="small"
+            />
+          ) : isLoading ? (
             <Alert severity="info">Loading organization selections..</Alert>
           ) : apiErrorStates.getOrgsError ? (
             <Alert severity="info">
@@ -640,13 +656,19 @@ export const UserForm: React.FC<UserFormProps> = ({
               value="standard"
               control={<Radio color="primary" />}
               label="Standard"
-              disabled={user?.user_type !== 'globalAdmin'}
+              disabled={
+                loggedInUser?.user_type !== 'globalAdmin' ||
+                values?.invite_pending === true
+              }
             />
             <FormControlLabel
               value="globalView"
               control={<Radio color="primary" />}
               label="Global View"
-              disabled={user?.user_type !== 'globalAdmin'}
+              disabled={
+                loggedInUser?.user_type !== 'globalAdmin' ||
+                values?.invite_pending === true
+              }
             />
             {isPermittedEmail(values.email) && (
               <>
@@ -654,13 +676,19 @@ export const UserForm: React.FC<UserFormProps> = ({
                   value="regionalAdmin"
                   control={<Radio color="primary" />}
                   label="Regional Administrator"
-                  disabled={user?.user_type !== 'globalAdmin'}
+                  disabled={
+                    loggedInUser?.user_type !== 'globalAdmin' ||
+                    values?.invite_pending === true
+                  }
                 />
                 <FormControlLabel
                   value="globalAdmin"
                   control={<Radio color="primary" />}
                   label="Global Administrator"
-                  disabled={user?.user_type !== 'globalAdmin'}
+                  disabled={
+                    loggedInUser?.user_type !== 'globalAdmin' ||
+                    values?.invite_pending === true
+                  }
                 />
               </>
             )}
@@ -684,6 +712,12 @@ export const UserForm: React.FC<UserFormProps> = ({
               Error updating user in the database:{' '}
               {apiErrorStates.getUpdateUserError}. See the network tab for more
               details.
+            </Alert>
+          )}
+          {values?.invite_pending === true && (
+            <Alert severity="info">
+              This is a Pending User that cannot be edited until approved in
+              User Registration by an Administrator.
             </Alert>
           )}
         </Grid>

--- a/frontend/src/pages/Users/UserForm.tsx
+++ b/frontend/src/pages/Users/UserForm.tsx
@@ -21,7 +21,6 @@ import { useUpdateUser } from '@/hooks/useUpdateUser';
 import { useAddUserToOrganization } from '@/hooks/useAddUserToOrganization';
 import { useRemoveUserFromOrganization } from '@/hooks/useRemoveUserFromOrganization';
 import { ElevationControl } from './ElevationControl';
-import { isCisaEmailDomain } from '@/utils/stringUtils';
 
 type ApiErrorStates = {
   getUsersError: string;
@@ -149,7 +148,6 @@ export const UserForm: React.FC<UserFormProps> = ({
   const [confirmGlobalAdminChange, setConfirmGlobalAdminChange] = useState('');
   const [isRoleElevationConfirmed, setIsRoleElevationConfirmed] =
     useState(false);
-  const isNotCisaEmail = !isCisaEmailDomain(loggedInUser?.email);
   const {
     organizations: organizationsInRegion,
     isLoading,
@@ -579,8 +577,7 @@ export const UserForm: React.FC<UserFormProps> = ({
               label="Global View"
               disabled={
                 loggedInUser?.user_type !== 'globalAdmin' ||
-                values?.invite_pending === true ||
-                isNotCisaEmail
+                values?.invite_pending === true
               }
             />
             {isPermittedEmail(values.email) && (
@@ -591,8 +588,7 @@ export const UserForm: React.FC<UserFormProps> = ({
                   label="Regional Administrator"
                   disabled={
                     loggedInUser?.user_type !== 'globalAdmin' ||
-                    values?.invite_pending === true ||
-                    isNotCisaEmail
+                    values?.invite_pending === true
                   }
                 />
                 <FormControlLabel
@@ -601,8 +597,7 @@ export const UserForm: React.FC<UserFormProps> = ({
                   label="Global Administrator"
                   disabled={
                     loggedInUser?.user_type !== 'globalAdmin' ||
-                    values?.invite_pending === true ||
-                    isNotCisaEmail
+                    values?.invite_pending === true
                   }
                 />
               </>
@@ -671,9 +666,7 @@ export const UserForm: React.FC<UserFormProps> = ({
         values.org_id === '' ||
         (isNewGlobalAdmin &&
           confirmGlobalAdminChange !== 'Global Administrator') ||
-        (isNewRegionalOrGlobalView && !isRoleElevationConfirmed) ||
-        ((loggedInUser?.user_type !== 'globalAdmin' || isNotCisaEmail) &&
-          values.user_type !== 'standard')
+        (isNewRegionalOrGlobalView && !isRoleElevationConfirmed)
       }
     />
   );

--- a/frontend/src/pages/Users/UserForm.tsx
+++ b/frontend/src/pages/Users/UserForm.tsx
@@ -21,6 +21,7 @@ import { useUpdateUser } from '@/hooks/useUpdateUser';
 import { useAddUserToOrganization } from '@/hooks/useAddUserToOrganization';
 import { useRemoveUserFromOrganization } from '@/hooks/useRemoveUserFromOrganization';
 import { ElevationControl } from './ElevationControl';
+import { isCisaEmailDomain } from '@/utils/stringUtils';
 
 type ApiErrorStates = {
   getUsersError: string;
@@ -148,7 +149,7 @@ export const UserForm: React.FC<UserFormProps> = ({
   const [confirmGlobalAdminChange, setConfirmGlobalAdminChange] = useState('');
   const [isRoleElevationConfirmed, setIsRoleElevationConfirmed] =
     useState(false);
-
+  const isNotCisaEmail = !isCisaEmailDomain(loggedInUser?.email);
   const {
     organizations: organizationsInRegion,
     isLoading,
@@ -578,7 +579,8 @@ export const UserForm: React.FC<UserFormProps> = ({
               label="Global View"
               disabled={
                 loggedInUser?.user_type !== 'globalAdmin' ||
-                values?.invite_pending === true
+                values?.invite_pending === true ||
+                isNotCisaEmail
               }
             />
             {isPermittedEmail(values.email) && (
@@ -589,7 +591,8 @@ export const UserForm: React.FC<UserFormProps> = ({
                   label="Regional Administrator"
                   disabled={
                     loggedInUser?.user_type !== 'globalAdmin' ||
-                    values?.invite_pending === true
+                    values?.invite_pending === true ||
+                    isNotCisaEmail
                   }
                 />
                 <FormControlLabel
@@ -598,7 +601,8 @@ export const UserForm: React.FC<UserFormProps> = ({
                   label="Global Administrator"
                   disabled={
                     loggedInUser?.user_type !== 'globalAdmin' ||
-                    values?.invite_pending === true
+                    values?.invite_pending === true ||
+                    isNotCisaEmail
                   }
                 />
               </>
@@ -667,7 +671,9 @@ export const UserForm: React.FC<UserFormProps> = ({
         values.org_id === '' ||
         (isNewGlobalAdmin &&
           confirmGlobalAdminChange !== 'Global Administrator') ||
-        (isNewRegionalOrGlobalView && !isRoleElevationConfirmed)
+        (isNewRegionalOrGlobalView && !isRoleElevationConfirmed) ||
+        ((loggedInUser?.user_type !== 'globalAdmin' || isNotCisaEmail) &&
+          values.user_type !== 'standard')
       }
     />
   );

--- a/frontend/src/pages/Users/UserForm.tsx
+++ b/frontend/src/pages/Users/UserForm.tsx
@@ -255,7 +255,7 @@ export const UserForm: React.FC<UserFormProps> = ({
     }
 
     try {
-      await updateUser(userId, body);
+      await updateUser({ userId, origin_path: 'user-management', body });
 
       if (values.originalOrgId !== values.org_id) {
         if (values.originalOrgId && values.originalRoleId) {

--- a/frontend/src/pages/Users/UserForm.tsx
+++ b/frontend/src/pages/Users/UserForm.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useRef, useState } from 'react';
 import { isEqual } from 'lodash';
 import Alert from '@mui/material/Alert';
 import Autocomplete from '@mui/material/Autocomplete';
-import Button from '@mui/material/Button';
 import DialogContent from '@mui/material/DialogContent';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Grid from '@mui/material/Grid';
@@ -21,6 +20,7 @@ import { useOrganizationsByRegion } from '@/hooks/useOrganizationsByRegion';
 import { useUpdateUser } from '@/hooks/useUpdateUser';
 import { useAddUserToOrganization } from '@/hooks/useAddUserToOrganization';
 import { useRemoveUserFromOrganization } from '@/hooks/useRemoveUserFromOrganization';
+import { ElevationControl } from './ElevationControl';
 
 type ApiErrorStates = {
   getUsersError: string;
@@ -74,16 +74,6 @@ const USER_TYPE_MAP = {
   globalAdmin: 3
 };
 
-type ElevationControlProps = {
-  confirmGlobalAdminChange: string;
-  setConfirmGlobalAdminChange: React.Dispatch<React.SetStateAction<string>>;
-  userRoleChanged: boolean;
-  values: UserFormValues;
-  isRoleElevationConfirmed: boolean;
-  setIsRoleElevationConfirmed: React.Dispatch<React.SetStateAction<boolean>>;
-  userOrg?: string | null;
-};
-
 const getAllowedDomains = (): string[] => {
   const raw = import.meta.env.VITE_ALLOWED_ADMIN_EMAIL_DOMAINS;
 
@@ -130,85 +120,6 @@ const isPermittedEmail = (email: string): boolean => {
     const candidate = allowedDomain.toLowerCase();
     return domain === candidate;
   });
-};
-
-const ElevationControl: React.FC<ElevationControlProps> = ({
-  confirmGlobalAdminChange,
-  setConfirmGlobalAdminChange,
-  userRoleChanged,
-  values,
-  isRoleElevationConfirmed,
-  setIsRoleElevationConfirmed,
-  userOrg
-}) => {
-  const textFieldStyling = {
-    '& .MuiOutlinedInput-root': {
-      '&.Mui-focused fieldset': {
-        borderRadius: '0px'
-      }
-    }
-  };
-  if (!userRoleChanged || values.user_type === 'standard') return <></>;
-  if (values.user_type === 'globalAdmin') {
-    return (
-      <>
-        <Alert severity="warning">
-          You are attempting to change user{' '}
-          <strong>
-            {userOrg ? `${values.email} - ${userOrg}` : values.email}
-          </strong>{' '}
-          to a Global Administrator. This will give them access to all
-          organizations and data in the system. Please type{' '}
-          <strong>Global Administrator</strong> in the field below to confirm
-          this change.
-        </Alert>
-        <TextField
-          sx={textFieldStyling}
-          placeholder="Enter Global Administrator to confirm"
-          size="small"
-          margin="dense"
-          id="first_name"
-          slotProps={{
-            htmlInput: { maxLength: 250 }
-          }}
-          name="first_name"
-          type="text"
-          fullWidth
-          value={confirmGlobalAdminChange}
-          onChange={(event) => setConfirmGlobalAdminChange(event.target.value)}
-        />
-      </>
-    );
-  }
-  if (values.user_type === 'regionalAdmin' || values.user_type === 'globalView')
-    return (
-      <>
-        <Alert severity={isRoleElevationConfirmed ? 'success' : 'warning'}>
-          You are attempting to change this user to{' '}
-          <strong>
-            {values.user_type === 'regionalAdmin'
-              ? 'Regional Administrator'
-              : 'Global View'}
-          </strong>
-          . This will give them access to more organizations and data in the
-          system.
-          <br />
-          <Button
-            sx={{ mt: 1 }}
-            size="small"
-            variant="contained"
-            onClick={() => setIsRoleElevationConfirmed(true)}
-            disabled={isRoleElevationConfirmed}
-          >
-            {isRoleElevationConfirmed
-              ? 'Confirmed Privilege Elevation'
-              : 'Confirm Privilege Elevation'}
-          </Button>
-        </Alert>
-      </>
-    );
-
-  return <></>;
 };
 
 export const UserForm: React.FC<UserFormProps> = ({

--- a/frontend/src/pages/Users/Users.tsx
+++ b/frontend/src/pages/Users/Users.tsx
@@ -58,7 +58,7 @@ interface UserType extends User {
 }
 
 export const Users: React.FC = () => {
-  const { user, apiDelete, apiGet } = useAuthContext();
+  const { user: loggedInUser, apiDelete, apiGet } = useAuthContext();
   const [selectedRow, setSelectedRow] = useState<UserType>(initializeUser);
   const [users, setUsers] = useState<UserType[]>([]);
   const [editUserDialogOpen, setEditUserDialogOpen] = useState(false);
@@ -83,7 +83,7 @@ export const Users: React.FC = () => {
   const fetchUsers = useCallback(async () => {
     setIsLoading(true);
     try {
-      const rows = await apiGet<UserType[]>(ENDPOINTS.USERS);
+      const rows = await apiGet<UserType[]>(ENDPOINTS.USERS_V2);
       rows.forEach((row) => {
         row.lastLoggedInString = row.last_logged_in
           ? format(new Date(row.last_logged_in), 'MM-dd-yyyy hh:mm a')
@@ -118,7 +118,7 @@ export const Users: React.FC = () => {
   }, [fetchUsers]);
 
   const userCols = useUserColumns({
-    user,
+    loggedInUser,
     setSelectedRow,
     setFormValues,
     setEditUserDialogOpen,
@@ -256,7 +256,8 @@ export const Users: React.FC = () => {
               columns: {
                 columnVisibilityModel: {
                   dateToUSigned: false,
-                  accepted_terms_version: false
+                  accepted_terms_version: false,
+                  invite_pending: false
                 }
               }
             }}

--- a/frontend/src/pages/Users/useUserColumns.tsx
+++ b/frontend/src/pages/Users/useUserColumns.tsx
@@ -9,7 +9,7 @@ import { format } from 'date-fns';
 import { textFilterOperators } from '@/utils/transformTableData';
 
 type UseUserColumnsProps = {
-  user: { user_type?: string } | null | undefined;
+  loggedInUser: { user_type?: string } | null | undefined;
   setSelectedRow: (row: any) => void;
   setFormValues: (values: any) => void;
   setEditUserDialogOpen: (open: boolean) => void;
@@ -17,7 +17,7 @@ type UseUserColumnsProps = {
 };
 
 export const useUserColumns = ({
-  user,
+  loggedInUser,
   setSelectedRow,
   setFormValues,
   setEditUserDialogOpen,
@@ -115,6 +115,21 @@ export const useUserColumns = ({
       )
     },
     {
+      field: 'invite_pending',
+      headerName: 'Invite Pending',
+      minWidth: 100,
+      flex: 1,
+      filterOperators: textFilterOperators,
+      renderCell: ({ row }: GridRenderCellParams) => (
+        <Box
+          component="span"
+          aria-label={`Invite Pending for User ${row.full_name}: ${row.invite_pending}`}
+        >
+          {row.invite_pending ? 'Yes' : 'No'}
+        </Box>
+      )
+    },
+    {
       field: 'date_approved',
       headerName: 'Approval Date',
       minWidth: 100,
@@ -203,7 +218,8 @@ export const useUserColumns = ({
               org_name: row.roles[0]?.organization?.name || '',
               org_id: row.roles[0]?.organization?.id || '',
               originalOrgId: row.roles[0]?.organization?.id || '',
-              originalRoleId: row.roles[0]?.id || ''
+              originalRoleId: row.roles[0]?.id || '',
+              invite_pending: row.invite_pending || false
             });
             setEditUserDialogOpen(true);
           }}
@@ -214,7 +230,7 @@ export const useUserColumns = ({
     }
   ];
 
-  if (user?.user_type === 'globalAdmin') {
+  if (loggedInUser?.user_type === 'globalAdmin') {
     columns.push({
       field: 'delete',
       headerName: 'Delete',

--- a/frontend/src/test-utils/searchOrg.ts
+++ b/frontend/src/test-utils/searchOrg.ts
@@ -2,6 +2,7 @@ export const mockOrganizations = [
   {
     id: 'org-1',
     name: 'Organization 1',
+    state_name: 'VA',
     region_id: '1',
     acronym: 'ORG1',
     root_domains: ['org1.com']
@@ -9,6 +10,7 @@ export const mockOrganizations = [
   {
     id: 'org-2',
     name: 'Organization 2',
+    state_name: 'VA',
     region_id: '2',
     acronym: 'ORG2',
     root_domains: ['org2.com']
@@ -16,6 +18,7 @@ export const mockOrganizations = [
   {
     id: 'org-3',
     name: 'Organization 3',
+    state_name: 'VA',
     region_id: '3',
     acronym: 'ORG3',
     root_domains: ['org3.com']
@@ -23,6 +26,7 @@ export const mockOrganizations = [
   {
     id: 'org-4',
     name: 'Organization 4',
+    state_name: 'VA',
     region_id: '4',
     acronym: 'ORG4',
     root_domains: ['org4.com']

--- a/frontend/src/tests/hooks/useUpdateUser.test.ts
+++ b/frontend/src/tests/hooks/useUpdateUser.test.ts
@@ -15,17 +15,15 @@ describe('useUpdateUser', () => {
 
   /**
    * Verifies the hook calls the update endpoint with the correct user id
-   * and passes the provided body as the request payload.
+   * and passes the context headers and matching payload cleanly.
    */
-  it('calls the correct endpoint with the provided body', async () => {
+  it('calls the correct endpoint with the provided body and headers', async () => {
     const mockPostApi = vi.fn().mockResolvedValue(undefined);
-
-    // usePostApi is a vi.fn() because of the vi.mock above
     vi.mocked(postApiModule.usePostApi).mockReturnValue(mockPostApi);
 
     const { result } = renderHook(() => useUpdateUser());
 
-    const body = {
+    const userPayload = {
       first_name: 'Jane',
       last_name: 'Doe',
       state: 'VA',
@@ -33,37 +31,61 @@ describe('useUpdateUser', () => {
       user_type: 'standard'
     };
 
+    let response;
     await act(async () => {
-      await result.current.updateUser(123, body);
+      response = await result.current.updateUser({
+        userId: '123',
+        origin_path: 'user-management',
+        body: userPayload
+      });
     });
 
     expect(mockPostApi).toHaveBeenCalledTimes(1);
 
     const [calledPath, calledInit] = mockPostApi.mock.calls[0];
 
+    // Verifies path and body separation
     expect(String(calledPath)).toContain('/123');
-    expect(calledInit.body).toEqual(body);
+    expect(calledInit.body).toEqual(userPayload);
+
+    expect(calledInit.headers).toEqual({
+      'X-Origin-Path': 'user-management'
+    });
+
+    expect(response).toEqual({
+      success: true,
+      body: 'User profile successfully updated.'
+    });
   });
 
   /**
-   * Verifies the hook does not swallow errors and re-throws failures
-   * from the underlying post request.
+   * Verifies the hook catches underlying network errors and
+   * returns a failed object state instead of throwing.
    */
-  it('propagates errors from postApi', async () => {
+  it('gracefully handles and returns errors from postApi', async () => {
     const error = new Error('Request failed');
     const mockPostApi = vi.fn().mockRejectedValue(error);
-
     vi.mocked(postApiModule.usePostApi).mockReturnValue(mockPostApi);
 
     const { result } = renderHook(() => useUpdateUser());
 
-    await expect(
-      result.current.updateUser(456, {
-        first_name: 'John',
-        last_name: 'Smith',
-        state: 'CA',
-        region_id: '2'
-      })
-    ).rejects.toThrow('Request failed');
+    let response;
+    await act(async () => {
+      response = await result.current.updateUser({
+        userId: '456',
+        origin_path: 'user-registration',
+        body: {
+          first_name: 'John',
+          last_name: 'Smith',
+          state: 'CA',
+          region_id: '2'
+        }
+      });
+    });
+
+    expect(response).toEqual({
+      success: false,
+      body: 'Request failed'
+    });
   });
 });

--- a/frontend/src/tests/hooks/useUpdateUser.test.ts
+++ b/frontend/src/tests/hooks/useUpdateUser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import { useUpdateUser } from '@/hooks/useUpdateUser';
 
 vi.mock('@/hooks/usePostApi', () => ({
@@ -31,15 +31,19 @@ describe('useUpdateUser', () => {
       user_type: 'standard'
     };
 
-    let response;
-    await act(async () => {
-      response = await result.current.updateUser({
+    let errorThrown = null;
+    try {
+      await result.current.updateUser({
         userId: '123',
         origin_path: 'user-management',
         body: userPayload
       });
-    });
+    } catch (err) {
+      errorThrown = err;
+    }
 
+    // Ensure it ran without throwing any unexpected errors
+    expect(errorThrown).toBeNull();
     expect(mockPostApi).toHaveBeenCalledTimes(1);
 
     const [calledPath, calledInit] = mockPostApi.mock.calls[0];
@@ -51,27 +55,21 @@ describe('useUpdateUser', () => {
     expect(calledInit.headers).toEqual({
       'X-Origin-Path': 'user-management'
     });
-
-    expect(response).toEqual({
-      success: true,
-      body: 'User profile successfully updated.'
-    });
   });
 
   /**
-   * Verifies the hook catches underlying network errors and
-   * returns a failed object state instead of throwing.
+   * Verifies the hook bubbles up underlying network errors to the caller.
    */
-  it('gracefully handles and returns errors from postApi', async () => {
+  it('bubbles up errors thrown by postApi', async () => {
     const error = new Error('Request failed');
     const mockPostApi = vi.fn().mockRejectedValue(error);
     vi.mocked(postApiModule.usePostApi).mockReturnValue(mockPostApi);
 
     const { result } = renderHook(() => useUpdateUser());
 
-    let response;
-    await act(async () => {
-      response = await result.current.updateUser({
+    let errorThrown: any = null;
+    try {
+      await result.current.updateUser({
         userId: '456',
         origin_path: 'user-registration',
         body: {
@@ -81,11 +79,11 @@ describe('useUpdateUser', () => {
           region_id: '2'
         }
       });
-    });
-
-    expect(response).toEqual({
-      success: false,
-      body: 'Request failed'
-    });
+    } catch (err) {
+      errorThrown = err;
+    }
+    // Verify that the error was thrown and matches the backend failure message
+    expect(errorThrown).toBeInstanceOf(Error);
+    expect(errorThrown.message).toBe('Request failed');
   });
 });

--- a/frontend/src/tests/pages/UserRegistration/organizationSelector.test.tsx
+++ b/frontend/src/tests/pages/UserRegistration/organizationSelector.test.tsx
@@ -18,11 +18,16 @@ describe('OrganizationSelector', () => {
 
   const renderComponent = (props?: Partial<OrganizationSelectorProps>) => {
     const onSelectionChange = vi.fn();
+    const selectUserMock = vi.fn();
     render(
       <OrganizationSelector
         regionId="123"
         onSelectionChange={onSelectionChange}
-        selectedUser={{ full_name: 'Jane Doe' }}
+        selectedUser={testUser}
+        pendingUsers={[testUser]}
+        selectUser={selectUserMock}
+        formattedUserType="Standard User"
+        getUpdateError=""
         {...props}
       />,
       {
@@ -58,7 +63,15 @@ describe('OrganizationSelector', () => {
 
   it('renders error when regionId is missing', async () => {
     render(
-      <OrganizationSelector regionId={null} onSelectionChange={vi.fn()} />,
+      <OrganizationSelector
+        regionId={null}
+        onSelectionChange={vi.fn()}
+        selectedUser={testUser}
+        pendingUsers={[testUser]}
+        selectUser={vi.fn()}
+        formattedUserType="Standard User"
+        getUpdateError=""
+      />,
       {
         authContext: {
           ...authCtx,
@@ -89,14 +102,16 @@ describe('OrganizationSelector', () => {
     renderComponent();
 
     const user = userEvent.setup();
+
+    expect(await screen.findByText('Organization 1')).toBeInTheDocument();
+
     const checkboxes = await screen.findAllByRole('checkbox');
 
-    // Use userEvent for clicks to properly wrap in act
     await user.click(checkboxes[1]);
 
     expect(
       await screen.findByText(
-        /jane doe will become a member of the selected organization/i
+        /will become a member of the selected organization/i
       )
     ).toBeInTheDocument();
   });

--- a/frontend/src/tests/pages/Users/ElevationControl.test.tsx
+++ b/frontend/src/tests/pages/Users/ElevationControl.test.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ElevationControl } from '@/pages/Users/ElevationControl';
+import { User } from 'types';
+
+describe('ElevationControl Component', () => {
+  // Helper to construct baseline mock mock props
+  const createMockProps = (overrides = {}) => ({
+    confirmGlobalAdminChange: '',
+    setConfirmGlobalAdminChange: vi.fn(),
+    userRoleChanged: false,
+    values: {
+      user_type: 'standard',
+      email: 'test@example.com'
+    } as unknown as User,
+    isRoleElevationConfirmed: false,
+    setIsRoleElevationConfirmed: vi.fn(),
+    userOrg: 'CISA',
+    ...overrides
+  });
+
+  it('renders nothing if userRoleChanged is false', () => {
+    const props = createMockProps({ userRoleChanged: false });
+    const { container } = render(<ElevationControl {...props} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing if values.user_type is "standard"', () => {
+    const props = createMockProps({
+      userRoleChanged: true,
+      values: { user_type: 'standard' }
+    });
+    const { container } = render(<ElevationControl {...props} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  describe('Global Admin Elevation Flow', () => {
+    it('renders warning alert and textfield with userOrg when elevating to globalAdmin', () => {
+      const props = createMockProps({
+        userRoleChanged: true,
+        values: { user_type: 'globalAdmin', email: 'admin@example.com' },
+        userOrg: 'CISA'
+      });
+
+      render(<ElevationControl {...props} />);
+
+      // Verify warning message is present and correctly formats email + org combination
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'You are attempting to change user admin@example.com - CISA to a Global Administrator'
+      );
+
+      // Verify placeholder configuration matches
+      expect(
+        screen.getByPlaceholderText('Enter Global Administrator to confirm')
+      ).toBeInTheDocument();
+    });
+
+    it('renders alert without userOrg formatting if userOrg is missing', () => {
+      const props = createMockProps({
+        userRoleChanged: true,
+        values: { user_type: 'globalAdmin', email: 'admin@example.com' },
+        userOrg: null
+      });
+
+      render(<ElevationControl {...props} />);
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'You are attempting to change user admin@example.com to a Global Administrator'
+      );
+    });
+
+    it('invokes setConfirmGlobalAdminChange whenever typing into the TextField', async () => {
+      const setConfirmGlobalAdminChangeMock = vi.fn();
+      const props = createMockProps({
+        userRoleChanged: true,
+        values: { user_type: 'globalAdmin', email: 'admin@example.com' },
+        setConfirmGlobalAdminChange: setConfirmGlobalAdminChangeMock
+      });
+
+      render(<ElevationControl {...props} />);
+
+      const input = screen.getByPlaceholderText(
+        'Enter Global Administrator to confirm'
+      );
+      await userEvent.type(input, 'G');
+
+      expect(setConfirmGlobalAdminChangeMock).toHaveBeenCalledWith('G');
+    });
+  });
+
+  describe('Regional Admin / Global View Elevation Flow', () => {
+    it('renders target message and active confirmation button when unconfirmed', async () => {
+      const setIsRoleElevationConfirmedMock = vi.fn();
+      const props = createMockProps({
+        userRoleChanged: true,
+        values: { user_type: 'regionalAdmin' },
+        isRoleElevationConfirmed: false,
+        setIsRoleElevationConfirmed: setIsRoleElevationConfirmedMock
+      });
+
+      render(<ElevationControl {...props} />);
+
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'You are attempting to change this user to Regional Administrator.'
+      );
+
+      const confirmButton = screen.getByRole('button', {
+        name: 'Confirm Privilege Elevation'
+      });
+      expect(confirmButton).toBeEnabled();
+
+      await userEvent.click(confirmButton);
+      expect(setIsRoleElevationConfirmedMock).toHaveBeenCalledWith(true);
+    });
+
+    it('renders globalView message options cleanly', () => {
+      const props = createMockProps({
+        userRoleChanged: true,
+        values: { user_type: 'globalView' }
+      });
+
+      render(<ElevationControl {...props} />);
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'You are attempting to change this user to Global View.'
+      );
+    });
+
+    it('disables confirmation button and switches label text when isRoleElevationConfirmed is true', () => {
+      const props = createMockProps({
+        userRoleChanged: true,
+        values: { user_type: 'regionalAdmin' },
+        isRoleElevationConfirmed: true
+      });
+
+      render(<ElevationControl {...props} />);
+
+      const confirmedButton = screen.getByRole('button', {
+        name: 'Confirmed Privilege Elevation'
+      });
+      expect(confirmedButton).toBeDisabled();
+    });
+  });
+});

--- a/frontend/src/tests/pages/Users/UserForm.test.tsx
+++ b/frontend/src/tests/pages/Users/UserForm.test.tsx
@@ -207,10 +207,13 @@ describe('UserForm', () => {
       expect(mockUpdateUser).toHaveBeenCalledTimes(1);
     });
 
-    const [calledId, calledBody] = mockUpdateUser.mock.calls[0];
+    // 🟢 Fix: Extract the single structured object parameter from the first argument position
+    const [calledArgs] = mockUpdateUser.mock.calls[0];
 
-    expect(calledId).toBe(1);
-    expect(calledBody).toMatchObject({
+    // 🟢 Verify parameters match the new unified payload architecture
+    expect(calledArgs.userId).toBe(1);
+    expect(calledArgs.origin_path).toBe('user-management'); // Or 'user-registration' depending on this form's context
+    expect(calledArgs.body).toMatchObject({
       first_name: 'Jane',
       last_name: 'Doe',
       state: 'VA',

--- a/frontend/src/tests/pages/Users/UserForm.test.tsx
+++ b/frontend/src/tests/pages/Users/UserForm.test.tsx
@@ -401,7 +401,8 @@ describe('UserForm', () => {
     const valuesWithoutOrg = {
       ...baseValues,
       org_id: '',
-      org_name: ''
+      org_name: '',
+      invite_pending: false
     };
 
     render(
@@ -652,5 +653,59 @@ describe('UserForm', () => {
     await waitFor(() => {
       expect(mockSetEditUserDialogOpen).toHaveBeenCalledWith(false);
     });
+  });
+
+  it('does not show organization required error when user is invite pending', () => {
+    const valuesInvitePending = {
+      ...baseValues,
+      org_id: '',
+      org_name: '',
+      invite_pending: true
+    };
+
+    render(
+      <UserForm
+        users={baseUsers}
+        setUsers={mockSetUsers}
+        values={valuesInvitePending}
+        setValues={mockSetValues}
+        editUserDialogOpen={true}
+        setEditUserDialogOpen={mockSetEditUserDialogOpen}
+        apiErrorStates={baseApiErrorStates}
+        setApiErrorStates={mockSetApiErrorStates}
+        setInfoDialogOpen={mockSetInfoDialogOpen}
+        setInfoDialogContent={mockSetInfoDialogContent}
+      />
+    );
+
+    expect(
+      screen.queryByText('Organization is required')
+    ).not.toBeInTheDocument();
+  });
+
+  it('disables the state autocomplete field when invite pending is true', () => {
+    const valuesInvitePending = {
+      ...baseValues,
+      invite_pending: true
+    };
+
+    render(
+      <UserForm
+        users={baseUsers}
+        setUsers={mockSetUsers}
+        values={valuesInvitePending}
+        setValues={mockSetValues}
+        editUserDialogOpen={true}
+        setEditUserDialogOpen={mockSetEditUserDialogOpen}
+        apiErrorStates={baseApiErrorStates}
+        setApiErrorStates={mockSetApiErrorStates}
+        setInfoDialogOpen={mockSetInfoDialogOpen}
+        setInfoDialogContent={mockSetInfoDialogContent}
+      />
+    );
+
+    // Find the Autocomplete input wrapper element or input itself by its ID or placeholder
+    const stateCombobox = screen.getByRole('combobox', { name: /state/i });
+    expect(stateCombobox).toBeDisabled();
   });
 });

--- a/frontend/src/tests/pages/Users/useUserColumns.test.tsx
+++ b/frontend/src/tests/pages/Users/useUserColumns.test.tsx
@@ -14,7 +14,7 @@ const baseProps = {
 it('returns user columns', () => {
   const { result } = renderHook(() =>
     useUserColumns({
-      user: null,
+      loggedInUser: null,
       ...baseProps
     })
   );
@@ -29,7 +29,7 @@ it('returns user columns', () => {
 it('limits string columns to equals and contains filters', () => {
   const { result } = renderHook(() =>
     useUserColumns({
-      user: null,
+      loggedInUser: null,
       ...baseProps
     })
   );
@@ -44,7 +44,7 @@ it('limits string columns to equals and contains filters', () => {
 it('restricts Approval Date filter operators', () => {
   const { result } = renderHook(() =>
     useUserColumns({
-      user: null,
+      loggedInUser: null,
       ...baseProps
     })
   );
@@ -62,7 +62,7 @@ it('restricts Approval Date filter operators', () => {
 it('restricts Last Logged In filter operators', () => {
   const { result } = renderHook(() =>
     useUserColumns({
-      user: null,
+      loggedInUser: null,
       ...baseProps
     })
   );
@@ -80,7 +80,7 @@ it('restricts Last Logged In filter operators', () => {
 it('adds delete column for global admin users', () => {
   const { result } = renderHook(() =>
     useUserColumns({
-      user: { user_type: 'globalAdmin' },
+      loggedInUser: { user_type: 'globalAdmin' },
       ...baseProps
     })
   );
@@ -94,7 +94,7 @@ it('adds delete column for global admin users', () => {
 it('does not add delete column for non-admin users', () => {
   const { result } = renderHook(() =>
     useUserColumns({
-      user: { user_type: 'regionalAdmin' },
+      loggedInUser: { user_type: 'regionalAdmin' },
       ...baseProps
     })
   );
@@ -107,7 +107,7 @@ it('does not add delete column for non-admin users', () => {
 it('keeps action columns non-filterable', () => {
   const { result } = renderHook(() =>
     useUserColumns({
-      user: null,
+      loggedInUser: null,
       ...baseProps
     })
   );

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -36,4 +36,5 @@ export type UserFormValues = {
   org_id: string;
   originalOrgId: string;
   originalRoleId: string;
+  invite_pending: boolean;
 };

--- a/frontend/src/utils/stringUtils.ts
+++ b/frontend/src/utils/stringUtils.ts
@@ -31,3 +31,12 @@ export function truncateString(inputString: string) {
   }
   return inputString.substring(0, cutOffIndex);
 }
+
+export const isCisaEmailDomain = (email?: string | null): boolean => {
+  if (!email) return false;
+  const atIndex = email.lastIndexOf('@');
+  if (atIndex <= 0 || atIndex === email.length - 1) return false;
+  const domain = email.slice(atIndex + 1).toLowerCase();
+  const allowedDomain = 'cisa.dhs.gov';
+  return domain === allowedDomain || domain.endsWith(`.${allowedDomain}`);
+};

--- a/frontend/src/utils/stringUtils.ts
+++ b/frontend/src/utils/stringUtils.ts
@@ -31,12 +31,3 @@ export function truncateString(inputString: string) {
   }
   return inputString.substring(0, cutOffIndex);
 }
-
-export const isCisaEmailDomain = (email?: string | null): boolean => {
-  if (!email) return false;
-  const atIndex = email.lastIndexOf('@');
-  if (atIndex <= 0 || atIndex === email.length - 1) return false;
-  const domain = email.slice(atIndex + 1).toLowerCase();
-  const allowedDomain = 'cisa.dhs.gov';
-  return domain === allowedDomain || domain.endsWith(`.${allowedDomain}`);
-};


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds the ability to edit pending user fields (State, Organization, and User Type) directly in the User Registration approval form and prevents pending user edits from the Manage Users screen. It requires admins to safely edit pending users only through the User Registration workflow. (CRASM-3999)

- **What's New:** Added more profile fields and a Save button directly to the User Registration approval form. Disables edits in the User form in Manage Users.
- **The Problem It Solves:** Admins were trying to edit pending users from the main Manage Users screen, which caused data issues and disruptions.
- **How It Works Now:** Editing pending users is now locked on the Manage Users screen. All updates to a user's details must now be safely made within the User Registration screen before approving them.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

**High level Acceptance Criteria**
- A pending user’s State, Organization, and User Type fields must be editable on the User Registration page.
- A Save button must be available and functional on the User Registration detail view for pending users.
- Upon saving, the system must updates and display success or failure message.
- Pending users must not be editable from the Manage Users table.

**Technical changes**

Backend:
- Added invite_pending field to user response schemas and endpoints for clarity
- Added x_origin_path parameter to update_user_v2() to block pending user edits from "user-management" origin
- Added a TODO with new ticket, CRASM-4044, so that all custom 403 errors will return with the correct error message instead of the generic one

Frontend:
- Added the origin path parameter to the update user endpoint
- Added State and User Type selectors, role elevation controls, org filtering by state to Pending User form
- Updated Manage User Form to disable all fields when invite_pending is true
- Updated Pending Users form to support both Save (interim) and Approve (final) actions
- Added a hidden invite_pending column to Manage Users table which can be toggled on
- Have the Pending Users form match the Manage User Form with elevation control for user types

Tests:
- Updated and/or added frontend and backend tests

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

1. Go to Manage Users
2. Select the View/Edit button for one a known pending user.
3. Confirm that all fields are disabled from edits.
--
1. Go to User Registration
2. Select the "Approve" button for a pending user.
3. Change fields.
4. Click the save button and then the cancel button.
5. Go back to the same user form and confirm that the last edits were saved.
6. Confirm all other functionality still exists.
Check for form validation and field rendering for pending users and manage users.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots ##

How a pending user is shown in Manage Users

<img width="453" height="745" alt="image" src="https://github.com/user-attachments/assets/33c608bf-5fda-4989-ab55-cacb941f0e0a" />

How a pending user is shown In User Registration:

<img width="957" height="902" alt="image" src="https://github.com/user-attachments/assets/5befb5b8-ca63-49f8-a0ee-a6d478359485" />

Save result

<img width="465" height="330" alt="image" src="https://github.com/user-attachments/assets/91ca7118-3f5e-4998-b7bb-817235c64c8e" />

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
