### PR TITLE
CRASM-3978: Add pythonPath to P&E lambdas

### DIFF
--- a/backend/src/tasks/functions.yml
+++ b/backend/src/tasks/functions.yml
@@ -189,7 +189,9 @@ peScanController:
   memorySize: 512
   handler: pe.peScanController.handler
   environment:
-    PYTHONPATH: .
+    # pe_source lives under pe/src/ in the deployment zip; include it for keyed
+    # scan API-key validation (flare_events, shodan, ...).
+    PYTHONPATH: .:pe/src
   iamRoleStatements:
     - Effect: Allow
       Action:
@@ -221,7 +223,7 @@ peReportController:
   memorySize: 512
   handler: pe.peReportController.handler
   environment:
-    PYTHONPATH: .
+    PYTHONPATH: .:pe/src
   iamRoleStatements:
     - Effect: Allow
       Action:


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Add pe/src to PYTHONPATH on the peScanController and peReportController Lambdas so keyed scans (flare_events, flare_ident_prune) can import pe_source during Flare API key validation.

## 💭 Motivation and context ##

Invoking flare_events on staging-cd via run_scans.sh failed with:

{"statusCode": 500, "body": "{\"error\": \"No module named 'pe_source'\"}"}

Keyed scans validate API keys in the Lambda before starting Fargate workers. Flare validation imports pe_source.flare_events.flare_helpers, but the deployment zip places pe_source at pe/src/pe_source/ while PYTHONPATH was only ..

Non-keyed scans like dnstwist were unaffected because they never import pe_source in the controller — they only queue SQS messages and start workers. Scan execution itself still runs in the pe-worker Fargate image, which already has pe_source on its path.

This change aligns the deployed Lambdas with local dev, where queue_local_scans.py already runs with PYTHONPATH=/app:/app/pe/src.

## 🧪 Testing ##

Passes pre-commit and github checks

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
