### PR TITLE
CRASM-3980: Reduce Shodan rate-limit failures in keyed PE scans

### DIFF
--- a/backend/pe/requirements.txt
+++ b/backend/pe/requirements.txt
@@ -13,6 +13,7 @@ psycopg2-binary
 pydantic>=1.10,<3
 python-decouple==3.6
 requests
+retry==0.9.2
 schema
 shodan==1.27.0
 uvicorn[standard]>=0.23

--- a/backend/pe/src/pe_source/data/config_source.py
+++ b/backend/pe/src/pe_source/data/config_source.py
@@ -71,12 +71,6 @@ def shodan_api_init():
             "PE_SHODAN_API_KEY is not set; peScanController assigns one key per worker"
         )
 
-    api = shodan.Shodan(api_key)
-    try:
-        api.info()
-    except Exception as e:
-        LOGGER.error("Invalid Shodan API key: %s", e)
-        raise
-
+    # Key is validated in peScanController; skip api.info() (1 rps Shodan limit).
     LOGGER.info("Initialized Shodan API with PE_SHODAN_API_KEY")
-    return [api]
+    return [shodan.Shodan(api_key)]

--- a/backend/pe/tests/test_shodan_config.py
+++ b/backend/pe/tests/test_shodan_config.py
@@ -1,0 +1,30 @@
+"""Tests for Shodan API initialization."""
+
+# Standard Python Libraries
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Third-Party Libraries
+from pe_source.data.config_source import shodan_api_init
+
+
+class ShodanApiInitTests(unittest.TestCase):
+    """Verify workers skip redundant api.info() validation."""
+
+    @patch("pe_source.data.config_source.shodan.Shodan")
+    def test_skips_api_info_when_key_assigned(self, mock_shodan):
+        """Controller-assigned keys should not call api.info() in the worker."""
+        client = MagicMock()
+        mock_shodan.return_value = client
+
+        with patch.dict(os.environ, {"PE_SHODAN_API_KEY": "secret-key"}, clear=False):
+            apis = shodan_api_init()
+
+        mock_shodan.assert_called_once_with("secret-key")
+        client.info.assert_not_called()
+        self.assertEqual(apis, [client])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/pe/tests/test_worker_key_planner.py
+++ b/backend/pe/tests/test_worker_key_planner.py
@@ -8,6 +8,9 @@ from unittest.mock import patch
 # Third-Party Libraries
 from pe.worker_key_planner import (
     KEYED_SCANS,
+    ShodanRateLimitError,
+    _check_shodan_api_key,
+    _validate_shodan,
     api_key_label,
     plan_worker_keys,
     worker_key_env,
@@ -35,12 +38,12 @@ class PlanWorkerKeysTests(unittest.TestCase):
             "flare_events": {
                 "keys_env": "FLARE_API_KEYS",
                 "worker_env": "FLARE_API_KEY",
-                "validate": lambda keys: keys,
+                "validate": lambda keys, max_valid=None: keys,
             },
             "shodan": {
                 "keys_env": "PE_SHODAN_API_KEYS",
                 "worker_env": "PE_SHODAN_API_KEY",
-                "validate": lambda keys: keys,
+                "validate": lambda keys, max_valid=None: keys,
             },
         },
         clear=False,
@@ -58,7 +61,7 @@ class PlanWorkerKeysTests(unittest.TestCase):
             "shodan": {
                 "keys_env": "PE_SHODAN_API_KEYS",
                 "worker_env": "PE_SHODAN_API_KEY",
-                "validate": lambda keys: keys,
+                "validate": lambda keys, max_valid=None: keys,
             }
         },
         clear=False,
@@ -74,12 +77,12 @@ class PlanWorkerKeysTests(unittest.TestCase):
             "flare_events": {
                 "keys_env": "FLARE_API_KEYS",
                 "worker_env": "FLARE_API_KEY",
-                "validate": lambda keys: [],
+                "validate": lambda keys, max_valid=None: [],
             },
             "shodan": {
                 "keys_env": "PE_SHODAN_API_KEYS",
                 "worker_env": "PE_SHODAN_API_KEY",
-                "validate": lambda keys: [],
+                "validate": lambda keys, max_valid=None: [],
             },
         },
         clear=False,
@@ -99,12 +102,12 @@ class PlanWorkerKeysTests(unittest.TestCase):
             "flare_events": {
                 "keys_env": "FLARE_API_KEYS",
                 "worker_env": "FLARE_API_KEY",
-                "validate": lambda keys: keys[:3],
+                "validate": lambda keys, max_valid=None: keys[:3],
             },
             "shodan": {
                 "keys_env": "PE_SHODAN_API_KEYS",
                 "worker_env": "PE_SHODAN_API_KEY",
-                "validate": lambda keys: keys[:3],
+                "validate": lambda keys, max_valid=None: keys[:3],
             },
         },
         clear=False,
@@ -133,6 +136,58 @@ class WorkerKeyEnvTests(unittest.TestCase):
         """Shodan workers get PE_SHODAN_API_KEY only."""
         env = worker_key_env("shodan", "secret")
         self.assertEqual(env, {"PE_SHODAN_API_KEY": "secret"})
+
+
+class ShodanValidationTests(unittest.TestCase):
+    """Verify Shodan key validation and rate-limit retries."""
+
+    @patch("pe.worker_key_planner._check_shodan_api_key")
+    def test_validate_shodan_stops_at_max_valid(self, mock_check):
+        """Validation should stop once max_valid keys are found."""
+        mock_check.return_value = None
+        keys = ["k1", "k2", "k3", "k4"]
+
+        result = _validate_shodan(keys, max_valid=2)
+
+        self.assertEqual(result, ["k1", "k2"])
+        self.assertEqual(mock_check.call_count, 2)
+
+    @patch("shodan.Shodan")
+    def test_check_shodan_api_key_retries_on_rate_limit(self, mock_shodan):
+        """Rate-limit errors should be retried before failing."""
+        client = mock_shodan.return_value
+        client.info.side_effect = [
+            Exception("Rate limit reached"),
+            Exception("Rate limit reached"),
+            None,
+        ]
+
+        _check_shodan_api_key("secret-key")
+
+        self.assertEqual(client.info.call_count, 3)
+
+    @patch("shodan.Shodan")
+    def test_check_shodan_api_key_raises_after_retries_exhausted(self, mock_shodan):
+        """Rate-limit errors should fail after max retries."""
+        client = mock_shodan.return_value
+        client.info.side_effect = Exception("Rate limit reached")
+
+        with self.assertRaises(ShodanRateLimitError):
+            _check_shodan_api_key("secret-key")
+
+        self.assertEqual(client.info.call_count, 4)
+
+    @patch("shodan.Shodan")
+    def test_check_shodan_api_key_does_not_retry_other_errors(self, mock_shodan):
+        """Non-rate-limit errors should fail immediately."""
+        client = mock_shodan.return_value
+        client.info.side_effect = Exception("Invalid API key")
+
+        with self.assertRaises(Exception) as ctx:
+            _check_shodan_api_key("bad-key")
+
+        self.assertNotIsInstance(ctx.exception, ShodanRateLimitError)
+        client.info.assert_called_once()
 
 
 class RegistryTests(unittest.TestCase):

--- a/backend/pe/worker_key_planner.py
+++ b/backend/pe/worker_key_planner.py
@@ -13,11 +13,20 @@ To add a scan: write a validator and add an entry to KEYED_SCANS.
 """
 
 # Standard Python Libraries
+import importlib.util
 import logging
 import os
+import time
 from typing import Any, Dict, List
 
+# Third-Party Libraries
+from retry import retry
+
 LOGGER = logging.getLogger(__name__)
+
+
+class ShodanRateLimitError(Exception):
+    """Shodan API rate limit hit during key validation."""
 
 
 def _split_keys(raw: str) -> List[str]:
@@ -34,7 +43,8 @@ def api_key_label(api_key: str) -> str:
     return "...{}".format(key[-4:])
 
 
-def _validate_flare(keys: List[str]) -> List[str]:
+def _validate_flare(keys: List[str], max_valid=None) -> List[str]:
+    del max_valid  # Flare validation unchanged; accepts kwarg for plan_worker_keys.
     # Third-Party Libraries
     from pe_source.flare_events.flare_helpers import validate_flare_api_key
 
@@ -70,18 +80,35 @@ def _validate_flare(keys: List[str]) -> List[str]:
     return valid
 
 
-def _validate_shodan(keys: List[str]) -> List[str]:
-    try:
-        # Third-Party Libraries
-        import shodan
-    except ImportError:
-        LOGGER.warning("shodan package not installed; skipping key validation")
-        return list(keys)
+@retry(ShodanRateLimitError, tries=4, delay=1, backoff=1)
+def _check_shodan_api_key(api_key: str) -> None:
+    """Validate one Shodan API key; retries on rate-limit responses."""
+    # Third-Party Libraries
+    import shodan
 
-    valid = []
+    try:
+        shodan.Shodan(api_key).info()
+    except Exception as exc:
+        if "rate limit" in str(exc).lower():
+            raise ShodanRateLimitError(str(exc)) from exc
+        raise
+
+
+def _validate_shodan(keys: List[str], max_valid=None) -> List[str]:
+    if importlib.util.find_spec("shodan") is None:
+        LOGGER.warning("shodan package not installed; skipping key validation")
+        if max_valid is None:
+            return list(keys)
+        return list(keys)[:max_valid]
+
+    valid: List[str] = []
     for i, key in enumerate(keys, start=1):
+        if max_valid is not None and len(valid) >= max_valid:
+            break
+        if i > 1:
+            time.sleep(1)
         try:
-            shodan.Shodan(key).info()
+            _check_shodan_api_key(key)
             valid.append(key)
             LOGGER.info(
                 "Shodan API key %d/%d is valid (%s)",
@@ -139,7 +166,7 @@ def plan_worker_keys(scan_name: str, count: int) -> List[str]:
         )
 
     LOGGER.info("Validating %d %s API key(s)", len(raw), scan_name)
-    valid = config["validate"](raw)
+    valid = config["validate"](raw, max_valid=count)
     if not valid:
         raise ValueError(
             "No valid API keys found in {}; cannot start {} workers".format(


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

- Skip redundant api.info() in PE workers when PE_SHODAN_API_KEY is already validated by peScanController
- Throttle and retry Shodan key validation in the Lambda controller: 1s between keys, stop after COUNT valid keys, retry rate-limit errors via existing retry library

## 💭 Motivation and context ##

Keyed Shodan scans (shodan, asmSync) validate API keys in two places:

- peScanController (worker_key_planner._validate_shodan) — calls api.info() for each key in PE_SHODAN_API_KEYS
- PE worker (shodan_api_init) — called api.info() again on startup

Shodan enforces ~1 request/second on api.info(). With multiple keys and workers, validation calls stack up and fail with:

- Rate limit reached. Please throttle your requests to 1 request per second

On staging we saw this when running --count 4 across multiple orgs: the Lambda validated all keys, then each worker re-validated on boot.

This PR:

- Worker: Trust the controller-assigned key; create shodan.Shodan(api_key) without api.info()
- Lambda: Validate only as many keys as needed (max_valid=count), sleep 1s between key checks, and use @retry (same retry==0.9.2 as elsewhere in backend) for transient rate-limit responses during validation

Flare is unchanged — its controller validation uses token generation that workers also need at scan time.

## 🧪 Testing ##

Added unit tests and passes existing. Passes pre-commits.

Tested shodan locally with all use cases (multiple containers, 1 container, multiple orgs, etc.)

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [x] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
