### PR TITLE
Expired token localstorage fix (CRASM-4074)

### DIFF
--- a/frontend/src/context/AuthContextProvider.tsx
+++ b/frontend/src/context/AuthContextProvider.tsx
@@ -86,9 +86,15 @@ export const AuthContextProvider: React.FC<AuthContextProviderProps> = ({
   }, [cookies, cookieOpts, setToken, token]);
 
   const handleError = useCallback(
-    async (in_error: Error) => {
+    async (
+      in_error: Error & { statusCode?: number; response?: { status?: number } }
+    ) => {
       logger.error(in_error);
-      if (in_error.message.includes('401')) {
+      const status =
+        in_error.statusCode ??
+        in_error.response?.status ??
+        (in_error.message.includes('401') ? 401 : undefined);
+      if (status === 401) {
         await logout();
         const next = encodeURIComponent(window.location.pathname || '/');
         window.location.href = `${import.meta.env.VITE_API_URL}/saml/login?next=${next}`;

--- a/frontend/src/context/AuthContextProvider.tsx
+++ b/frontend/src/context/AuthContextProvider.tsx
@@ -58,32 +58,35 @@ export const AuthContextProvider: React.FC<AuthContextProviderProps> = ({
     } as const;
   }, []);
 
-  const logout = useCallback(async () => {
-    setIsLoggingOut(true);
+  const logout = useCallback(
+    async (shouldReloadPage = true) => {
+      setIsLoggingOut(true);
 
-    // If the user has a token, reload at the end to reset app state
-    const shouldReload = !!token;
+      try {
+        // 1. Clear local storage
+        localStorage.clear();
 
-    try {
-      // Clear local storage and Amplify session (if any)
-      localStorage.clear();
+        // 2. Clear token from persistent state hook
+        setToken(null);
+        setAuthUser(null);
 
-      // Remove both cookies the backend may have set
-      cookies.remove('token', cookieOpts);
-      cookies.remove('crossfeed-token', cookieOpts);
-
-      // Clear in-memory state
-      setAuthUser(null);
-      setToken(null);
-    } catch (error) {
-      logger.error(error);
-    } finally {
-      setIsLoggingOut(false);
-      if (shouldReload) {
-        window.location.reload();
+        // 3. Force-remove cookies across all path/domain combinations
+        cookies.remove('token', cookieOpts);
+        cookies.remove('crossfeed-token', cookieOpts);
+        cookies.remove('token', { path: '/' });
+        cookies.remove('crossfeed-token', { path: '/' });
+      } catch (error) {
+        logger.error(error);
+      } finally {
+        setIsLoggingOut(false);
+        // Only reload if NOT redirecting elsewhere
+        if (shouldReloadPage) {
+          window.location.reload();
+        }
       }
-    }
-  }, [cookies, cookieOpts, setToken, token]);
+    },
+    [cookies, cookieOpts, setToken]
+  );
 
   const handleError = useCallback(
     async (
@@ -93,9 +96,12 @@ export const AuthContextProvider: React.FC<AuthContextProviderProps> = ({
       const status =
         in_error.statusCode ??
         in_error.response?.status ??
-        (in_error.message.includes('401') ? 401 : undefined);
+        (in_error.message?.includes('401') ? 401 : undefined);
+
       if (status === 401) {
-        await logout();
+        // Pass false so logout() doesn't call window.location.reload()
+        await logout(false);
+
         const next = encodeURIComponent(window.location.pathname || '/');
         window.location.href = `${import.meta.env.VITE_API_URL}/saml/login?next=${next}`;
       }

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -119,21 +119,28 @@ export const useApi = (onError?: OnError) => {
           // const result = await method('crossfeed', path, options);
           const response = await method({ apiName: 'crossfeed', path, options })
             .response;
-          const result = await response.body.json();
 
-          // Amplify v6 resolves .response for non-2xx; explicitly throw if >= 400
-          if (response.statusCode >= 400) {
-            if (response.statusCode === 401) {
-              localStorage.removeItem('token');
-            }
+          const statusCode = response.statusCode ?? (response as any).status;
+
+          let result: any;
+          try {
+            result = await response.body.json();
+          } catch {
+            result = undefined;
+          }
+
+          if (statusCode >= 400 || result?.detail === 'Token has expired') {
+            localStorage.removeItem('token');
+
             const error = new Error(
-              `Request failed with status code ${response.statusCode}`
+              result?.detail || `Request failed with status code ${statusCode}`
             );
+
             throw Object.assign(error, {
-              statusCode: response.statusCode,
+              statusCode: statusCode || 401,
               body: result,
               response: {
-                status: response.statusCode,
+                status: statusCode || 401,
                 headers: response.headers
               }
             });
@@ -144,17 +151,38 @@ export const useApi = (onError?: OnError) => {
         } catch (e: any) {
           showLoading && setRequestCount((cnt) => cnt - 1);
 
-          // Standard 401 cleanup fallback if thrown elsewhere
-          if (e?.statusCode === 401 || e?.response?.status === 401) {
+          // 1. Extract status code from various Amplify v6 error formats
+          const status =
+            e?.response?.statusCode ??
+            e?.response?.status ??
+            e?.status ??
+            e?.statusCode ??
+            undefined;
+
+          // 2. Detect if this is an expired token / auth error:
+          //    - Explicit 401/403 status
+          //    - Amplify "UnknownError" while carrying a stored token
+          //    - Error message referencing expired token or unauthorized
+          const isAuthError =
+            status === 401 ||
+            status === 403 ||
+            e?.name === 'UnknownError' ||
+            e?.message?.toLowerCase().includes('token') ||
+            e?.message?.toLowerCase().includes('unauthorized');
+
+          if (isAuthError) {
+            // Clean local storage immediately
             localStorage.removeItem('token');
+
+            // Standardize error shape so AuthContextProvider.handleError receives status 401
+            e.statusCode = status || 401;
+            if (!e.response) {
+              e.response = { status: e.statusCode };
+            }
           }
 
           if (!isLocal) {
-            // Detection of blocks before API Gateway
             try {
-              const status =
-                e?.response?.status ?? e?.status ?? e?.statusCode ?? undefined;
-
               const headersRaw =
                 e?.response?.headers ??
                 e?.headers ??

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -120,10 +120,34 @@ export const useApi = (onError?: OnError) => {
           const response = await method({ apiName: 'crossfeed', path, options })
             .response;
           const result = await response.body.json();
+
+          // Amplify v6 resolves .response for non-2xx; explicitly throw if >= 400
+          if (response.statusCode >= 400) {
+            if (response.statusCode === 401) {
+              localStorage.removeItem('token');
+            }
+            const error = new Error(
+              `Request failed with status code ${response.statusCode}`
+            );
+            throw Object.assign(error, {
+              statusCode: response.statusCode,
+              body: result,
+              response: {
+                status: response.statusCode,
+                headers: response.headers
+              }
+            });
+          }
+
           showLoading && setRequestCount((cnt) => cnt - 1);
           return result as T;
         } catch (e: any) {
           showLoading && setRequestCount((cnt) => cnt - 1);
+
+          // Standard 401 cleanup fallback if thrown elsewhere
+          if (e?.statusCode === 401 || e?.response?.status === 401) {
+            localStorage.removeItem('token');
+          }
 
           if (!isLocal) {
             // Detection of blocks before API Gateway


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

After upgrading to Amplify v6, users with an expired token persisted in localStorage may become stuck in an invalid authenticated state. Amplify v5 handled the backend 401 Token has expired response as an error. As a result, the app treats the error payload as a valid user object, preventing proper logout and leaving the expired token in storage.

This issue appears more likely in normal browser mode where stale site data persists, while InPrivate/Incognito mode works because it starts with clean storage.

CRASM-4074

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Acceptance Criteria

- If /users/me returns 401, the frontend treats it as an error.
- The existing logout/token cleanup logic is triggered.
- Expired token is removed
- User is redirected to the login/sign-in flow.
- Logout button visibility is no longer impacted by invalid error payloads.
- Issue is resolved in normal browser sessions with stale v5 auth/session data.
- Users can sign in successfully after the forced clean sign-out/sign-in cycle.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
To recreate bug:
- Login as normal.
- Grab expired token from google.
- Pass expired token into local storage in dev tools.
- Refresh page.
- Witness broken home page.

To Test:
- 401 Token has expired response is caught as an auth error.
- Existing logout/catch block executes.
- Expired token is removed from localStorage.
- User is redirected to the sign-in page.
- Header/UI does not enter a stuck state.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate) ##
<img width="2032" height="1167" alt="Screenshot 2026-07-31 at 12 15 39 PM" src="https://github.com/user-attachments/assets/1434a5d8-587e-4ecb-94c8-fa1b1b0aa9d7" />


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
