### PR TITLE
 Fix 401 Token Removal Bug (CRASM-4092)

### DIFF
--- a/frontend/src/context/AuthContextProvider.tsx
+++ b/frontend/src/context/AuthContextProvider.tsx
@@ -100,6 +100,7 @@ export const AuthContextProvider: React.FC<AuthContextProviderProps> = ({
 
       if (status === 401) {
         // Pass false so logout() doesn't call window.location.reload()
+        logger.debug('handleError status:', status, 'error:', in_error);
         await logout(false);
 
         const next = encodeURIComponent(window.location.pathname || '/');

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -170,6 +170,8 @@ export const useApi = (onError?: OnError) => {
             e?.statusCode ??
             undefined;
 
+          // TODO: CRASM-4093 Add more robust checks for expired tokens and other error codes; current implementation may not cover all cases.
+
           // 2. Detect if this is an expired token:
           //    - Explicit 401 status
           //    - Error message referencing "jwt", "token", and "expired"

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -129,7 +129,18 @@ export const useApi = (onError?: OnError) => {
             result = undefined;
           }
 
-          if (statusCode >= 400 || result?.detail === 'Token has expired') {
+          const tokenDetail =
+            typeof result?.detail === 'string'
+              ? result.detail.toLowerCase()
+              : '';
+
+          if (
+            typeof statusCode === 'number' &&
+            statusCode === 401 &&
+            (tokenDetail.includes('jwt') ||
+              (tokenDetail.includes('token') &&
+                tokenDetail.includes('expired')))
+          ) {
             localStorage.removeItem('token');
 
             const error = new Error(
@@ -159,18 +170,16 @@ export const useApi = (onError?: OnError) => {
             e?.statusCode ??
             undefined;
 
-          // 2. Detect if this is an expired token / auth error:
-          //    - Explicit 401/403 status
-          //    - Amplify "UnknownError" while carrying a stored token
-          //    - Error message referencing expired token or unauthorized
-          const isAuthError =
-            status === 401 ||
-            status === 403 ||
-            e?.name === 'UnknownError' ||
-            e?.message?.toLowerCase().includes('token') ||
-            e?.message?.toLowerCase().includes('unauthorized');
+          // 2. Detect if this is an expired token:
+          //    - Explicit 401 status
+          //    - Error message referencing "jwt", "token", and "expired"
+          const isTokenExpired =
+            status === 401 &&
+            (e?.message?.toLowerCase().includes('token') ||
+              e?.message?.toLowerCase().includes('jwt')) &&
+            e?.message?.toLowerCase().includes('expired');
 
-          if (isAuthError) {
+          if (isTokenExpired) {
             // Clean local storage immediately
             localStorage.removeItem('token');
 


### PR DESCRIPTION


<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #
## Fix 401 Token Removal Bug (CRASM-4092) ##

## 🗣 Description ##
- tightened the logic for handling expired tokens in the useApi.ts hook. Now, when a request fails due to an expired token, it will automatically attempt to refresh the token and retry the request. If the refresh fails, it will log the user out and redirect them to the login page.
- made it more explicit that it checks for a 401 response and include "jwt" or "token" plus "expired" in the response.
- applied same logic if normal request fails with 401 and the caught error includes "jwt" or "token" plus "expired".
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
- closes CRASM-4092
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
- Bug is not present in local, only in Cloudfare based environments.
- Needs to be tested in staging-cd.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
