### PR TITLE
CRASM-3981 Fix Serverless Report Gen Script Staging-CD Issues

### DIFF
--- a/backend/pe/pe_reports_django_project/dataAPI/report_schemas.py
+++ b/backend/pe/pe_reports_django_project/dataAPI/report_schemas.py
@@ -12,7 +12,7 @@ class DomainAlertsTable(BaseModel):
     domain_alert_uid: str
     sub_domain_uid_id: Optional[str] = None
     data_source_uid_id: Optional[str] = None
-    organizations_uid: Optional[str] = None
+    organizations_uid_id: Optional[str] = None
     alert_type: Optional[str] = None
     message: Optional[str] = None
     previous_value: Optional[str] = None
@@ -73,7 +73,7 @@ class RSSTable(BaseModel):
     ports_count: Optional[int]
     creds_count: Optional[int]
     breach_count: Optional[int]
-    creds_password_count: Optional[int]
+    cred_password_count: Optional[int]
     domain_alert_count: Optional[int]
     suspected_domain_count: Optional[int]
     insecure_port_count: Optional[int]

--- a/backend/pe/pe_reports_django_project/dataAPI/report_views.py
+++ b/backend/pe/pe_reports_django_project/dataAPI/report_views.py
@@ -71,7 +71,9 @@ def domain_alerts_by_org_date(
             row["data_source_uid_id"] = convert_uuid_to_string(
                 row["data_source_uid_id"]
             )
-            row["organizations_uid"] = convert_uuid_to_string(row["organizations_uid"])
+            row["organizations_uid_id"] = convert_uuid_to_string(
+                row["organizations_uid_id"]
+            )
             row["date"] = convert_date_to_string(row["date"])
         return domain_alerts_by_org_date_data
     except ObjectDoesNotExist:
@@ -128,9 +130,7 @@ def domain_permu_by_org_date(
 # --- get_org_assets_count_past(), Issue 603 ---
 @report_router.post(
     "/past_asset_counts_by_org",
-    dependencies=[
-        Depends(verify_api_key)
-    ],  # Depends(RateLimiter(times=200, seconds=60))],
+    dependencies=[Depends(verify_api_key)],
     response_model=List[schemas.RSSTable],
     tags=["Get all RSS data for the specified org_uid and date."],
 )

--- a/backend/pe/pe_reports_django_project/home/tasks/helpers/create_sample_data.py
+++ b/backend/pe/pe_reports_django_project/home/tasks/helpers/create_sample_data.py
@@ -11,11 +11,14 @@ from django.db import IntegrityError, transaction
 from home.models import (
     Cidrs,
     DataSource,
+    DomainAlerts,
     Executives,
+    FlareEvents,
     FlareEventTypes,
     Ips,
     IpsSubs,
     Organizations,
+    ReportSummaryStats,
     RootDomains,
     SubDomains,
     TopCves,
@@ -476,6 +479,86 @@ def populate_sample_data():
                 "sixgill_id": "",
             },
         )
+
+    # Create domain alert sample data
+    org_inst = Organizations.objects.get(cyhy_db_name="DHS")
+    root_inst = RootDomains.objects.get(
+        root_domain="google.com", organizations_uid=org_inst.organizations_uid
+    )
+    sub_inst = SubDomains.objects.get(
+        sub_domain="dns.google", root_domain_uid=root_inst.root_domain_uid
+    )
+    data_src_inst = DataSource.objects.get(name="DNSMonitor")
+    dom_alert_obj, created = DomainAlerts.objects.update_or_create(
+        organizations_uid=org_inst,
+        message="The tracked domain dhs.gov has a new dnsA record, 12.345.678.910",
+        date="2026-07-12",
+        defaults={
+            "sub_domain_uid": sub_inst,
+            "data_source_uid": data_src_inst,
+            "alert_type": "New Variant Record",
+            "previous_value": "",
+            "new_value": "12.345.678.910",
+        },
+    )
+
+    # Create report summary stats table data
+    rss_obj, created = ReportSummaryStats.objects.update_or_create(
+        organizations_uid=org_inst,
+        start_date="2026-06-01",
+        end_date="2026-06-15",
+        defaults={
+            "ip_count": 0,
+            "root_count": 0,
+            "sub_count": 0,
+            "ports_count": 0,
+            "creds_count": 0,
+            "breach_count": 0,
+            "cred_password_count": 0,
+            "domain_alert_count": 0,
+            "suspected_domain_count": 0,
+            "insecure_port_count": 0,
+            "verified_vuln_count": 0,
+            "suspected_vuln_count": 0,
+            "suspected_vuln_addrs_count": 0,
+            "threat_actor_count": 0,
+            "dark_web_alerts_count": 0,
+            "dark_web_mentions_count": 0,
+            "dark_web_executive_alerts_count": 0,
+            "pe_number_score": "NA",
+            "pe_letter_grade": "NA",
+            "pe_percent_score": 0.5,
+            "cidr_count": 0,
+            "port_protocol_count": 0,
+            "software_count": 0,
+            "foreign_ips_count": 0,
+        },
+    )
+
+    # Create Flare alert (event) data
+    flare_src_inst = DataSource.objects.get(name="Flare")
+    long_content = "This is a really long content field... " + ("blah " * 6560)
+    flare_event_obj, created = FlareEvents.objects.update_or_create(
+        organizations_uid=org_inst,
+        flare_uid="service/driller_shodan/www.v-consultancy.com/cloudfront/443",
+        defaults={
+            "event_type": "service",
+            "event_date": "2026-07-12",
+            "collection_date": "2026-07-14",
+            "title": "sample title service event",
+            "content": long_content,
+            "content_hash": "a33be926d6508158b62aaf126aec1f87b4671462",
+            "actor": "test_actor",
+            "category": "HTTPS Service",
+            "source": "driller_shodan",
+            "url": "test_url.com",
+            "risk_scores": "{'score': 2}",
+            "related_identifiers": ["12345678"],
+            "data_source_uid": flare_src_inst,
+            "severity": "low",
+            "related_identifiers_txt": ["test_ident"],
+        },
+    )
 
     return {
         "data_sources": [

--- a/backend/pe/src/pe_reports/data/db_query.py
+++ b/backend/pe/src/pe_reports/data/db_query.py
@@ -131,6 +131,7 @@ def query_domMasq_alerts(org_uid, start_date, end_date):
             columns={
                 "sub_domain_uid_id": "sub_domain_uid",
                 "data_source_uid_id": "data_source_uid",
+                "organizations_uid_id": "organizations_uid",
             },
             inplace=True,
         )

--- a/backend/pe/src/pe_reports/pages.py
+++ b/backend/pe/src/pe_reports/pages.py
@@ -448,6 +448,7 @@ def dark_web_flare(
         lambda x: list(set(x))
     )
     alerts_df.drop(columns=["related_identifiers_txt"], inplace=True)
+    alerts_df["content"] = alerts_df["content"].str.slice(0, 32000)
     # Prep top 10 cves raw data
     top_cves_df = FlareObj.top_cves
     top_cves_df.drop(columns=["summary_short"], inplace=True, errors="ignore")


### PR DESCRIPTION

## 🗣 Description ##

Several issues were found when running the serverless report generation script in staging-cd. These issues were not found when originally PR'd (#1532) b/c 1532 was only tested using narrow, manually created sample data. Once running in staging-cd with real PE data, the issues became apparent. Here are the issues:

Problem 1:
- Line 472 in pe_reports/pages.py was throwing a warning due to needing to truncate excessively long "content" fields when converting Flare events dataframe to xlsx. The max number of characters allowed in an xlsx cell is 32,767 .
-  Solution: Added line of code to cap the max length of that content field to 32,000

Problem 2:
-  domain_alerts_by_org_date() in report_views.py was throwing an error because the data it was trying to return did not match the set response schema. This is a known issue where the Django ORM will take "field_uid" fields and automatically rename them "field_uid_id".
- Solution: Similar to other endpoints, code has added to account for this renaming and convert the field name back to its orignally intended name

Problem 3:
- past_asset_counts_by_org() in report_views.py was throwing an error because one of the fields it was returning did not match its set response schema. Turned out to be a typo in report_schemas.py where "creds_password_count" should've been "cred_password_count"
- Solution: corrected response schema to fix typo


## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

Need to correct these serverless report gen issues discovered in staging-cd so we can do a real-world run of the serverless code

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
