### PR TITLE
Update authentication to prevent expired token crash (CRASM-4100)

### DIFF
--- a/frontend/src/context/AuthContextProvider.tsx
+++ b/frontend/src/context/AuthContextProvider.tsx
@@ -63,18 +63,28 @@ export const AuthContextProvider: React.FC<AuthContextProviderProps> = ({
       setIsLoggingOut(true);
 
       try {
-        // 1. Clear local storage
-        localStorage.clear();
-
-        // 2. Clear token from persistent state hook
+        // 1. Clear state first so usePersistentState flushes state cleanly
         setToken(null);
         setAuthUser(null);
 
-        // 3. Force-remove cookies across all path/domain combinations
+        // 2. Clear storage explicitly
+        localStorage.clear();
+
+        // 3. Force-remove cookies across all variations
         cookies.remove('token', cookieOpts);
         cookies.remove('crossfeed-token', cookieOpts);
         cookies.remove('token', { path: '/' });
         cookies.remove('crossfeed-token', { path: '/' });
+
+        // Extra safeguard: clear on window domain explicitly
+        cookies.remove('token', {
+          domain: window.location.hostname,
+          path: '/'
+        });
+        cookies.remove('crossfeed-token', {
+          domain: window.location.hostname,
+          path: '/'
+        });
       } catch (error) {
         logger.error(error);
       } finally {
@@ -114,27 +124,37 @@ export const AuthContextProvider: React.FC<AuthContextProviderProps> = ({
   const { apiGet } = api;
 
   const getProfile = useCallback(async () => {
-    const user: User = await apiGet<User>(ENDPOINTS.USERS_ME);
+    try {
+      const user: User = await apiGet<User>(ENDPOINTS.USERS_ME);
 
-    // TODO: Uncomment this if we want to fully disable logins during maintenance windows.
-    // Currently commented to meet "waiting room" needs and allow login for state selection
-    // and user terms acceptance for new users.
-    //
-    // This acts as a backup safeguard to alert users login is unavailable and log them out.
-    // If user is blocked due to maintenance, show alert and logout.
-    //
-    // if (user.login_blocked_by_maintenance) {
-    //   alert(
-    //     'Product has not officially been launched. Please check back again.'
-    //   );
-    //   await logout();
-    //   return;
-    // }
+      // TODO: Uncomment this if we want to fully disable logins during maintenance windows.
+      // Currently commented to meet "waiting room" needs and allow login for state selection
+      // and user terms acceptance for new users.
+      //
+      // This acts as a backup safeguard to alert users login is unavailable and log them out.
+      // If user is blocked due to maintenance, show alert and logout.
+      //
+      // if (user.login_blocked_by_maintenance) {
+      //   alert(
+      //     'Product has not officially been launched. Please check back again.'
+      //   );
+      //   await logout();
+      //   return;
+      // }
 
-    setAuthUser({
-      ...user,
-      isRegistered: user.first_name !== ''
-    });
+      // Guard against non-error 401 payloads ({ detail: "Token has expired" })
+      if (!user || !user.id) {
+        throw new Error('401 Token has expired');
+      }
+
+      setAuthUser({
+        ...user,
+        isRegistered: user.first_name !== ''
+      });
+    } catch (err) {
+      // Allow handleError to catch and perform cleanup
+      setAuthUser(null);
+    }
   }, [apiGet]);
 
   const setProfile = useCallback(
@@ -153,33 +173,25 @@ export const AuthContextProvider: React.FC<AuthContextProviderProps> = ({
     await getProfile();
   }, [token, getProfile]);
 
-  // SPA token update from cookies after SAML ACS redirect
+  // Guard cookie sync against active logout cycles
   useEffect(() => {
-    if (!token) {
+    if (!token && !isLoggingOut) {
       const cookieToken =
         cookies.get('token') || cookies.get('crossfeed-token');
       if (cookieToken) {
-        // Set token from cookie if we don't have one yet
         setToken(cookieToken);
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [token, cookies]);
+  }, [token, cookies, isLoggingOut, setToken]);
 
-  // On first mount, try Cognito refresh (if enabled)
-  useEffect(() => {
-    refreshUser();
-    // eslint-disable-next-line
-  }, []);
-
-  // When token changes, either clear user or fetch profile
+  // Single effect for profile fetching when token changes
   useEffect(() => {
     if (!token) {
       setAuthUser(null);
-    } else {
+    } else if (!authUser) {
       getProfile();
     }
-  }, [token, getProfile]);
+  }, [token]); // Clean dependencies prevent infinite re-fetches
 
   const extendedOrg = useMemo(
     () => getExtendedOrg(org, authUser),

--- a/frontend/src/context/AuthContextProvider.tsx
+++ b/frontend/src/context/AuthContextProvider.tsx
@@ -191,6 +191,7 @@ export const AuthContextProvider: React.FC<AuthContextProviderProps> = ({
     } else if (!authUser) {
       getProfile();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [token]); // Clean dependencies prevent infinite re-fetches
 
   const extendedOrg = useMemo(

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -91,20 +91,28 @@ export const useApi = (onError?: OnError) => {
   const getToken = () => {
     const token = localStorage.getItem('token');
     try {
-      return token ? JSON.parse(token) : '';
+      return token ? JSON.parse(token) : token || '';
     } catch {
-      return '';
+      return token || '';
     }
   };
 
   const prepareInit = useCallback(async (init: any) => {
     const { headers, ...rest } = init;
+    const token = getToken();
+
     return {
       ...rest,
       headers: {
         ...baseHeaders, // put base first
         ...headers, // allow caller to override (e.g., Accept: text/csv)
-        Authorization: getToken()
+        ...(token
+          ? {
+              Authorization: token.startsWith('Bearer ')
+                ? token
+                : `Bearer ${token}`
+            }
+          : {})
       }
     };
   }, []);
@@ -116,7 +124,6 @@ export const useApi = (onError?: OnError) => {
         try {
           showLoading && setRequestCount((cnt) => cnt + 1);
           const options = await prepareInit(rest);
-          // const result = await method('crossfeed', path, options);
           const response = await method({ apiName: 'crossfeed', path, options })
             .response;
 
@@ -129,29 +136,19 @@ export const useApi = (onError?: OnError) => {
             result = undefined;
           }
 
-          const tokenDetail =
-            typeof result?.detail === 'string'
-              ? result.detail.toLowerCase()
-              : '';
-
-          if (
-            typeof statusCode === 'number' &&
-            statusCode === 401 &&
-            (tokenDetail.includes('jwt') ||
-              (tokenDetail.includes('token') &&
-                tokenDetail.includes('expired')))
-          ) {
-            localStorage.removeItem('token');
-
+          // If status is 401, immediately throw standardized error
+          if (statusCode === 401) {
             const error = new Error(
-              result?.detail || `Request failed with status code ${statusCode}`
+              result?.detail ||
+                result?.message ||
+                `Request failed with status code 401`
             );
 
             throw Object.assign(error, {
-              statusCode: statusCode || 401,
+              statusCode: 401,
               body: result,
               response: {
-                status: statusCode || 401,
+                status: 401,
                 headers: response.headers
               }
             });
@@ -168,27 +165,32 @@ export const useApi = (onError?: OnError) => {
             e?.response?.status ??
             e?.status ??
             e?.statusCode ??
-            undefined;
+            (e?.message?.includes('401') ? 401 : undefined);
+
+          const errorDetail = (
+            e?.message ||
+            e?.body?.detail ||
+            e?.response?.data?.detail ||
+            ''
+          ).toLowerCase();
 
           // TODO: CRASM-4093 Add more robust checks for expired tokens and other error codes; current implementation may not cover all cases.
 
           // 2. Detect if this is an expired token:
           //    - Explicit 401 status
-          //    - Error message referencing "jwt", "token", and "expired"
-          const isTokenExpired =
-            status === 401 &&
-            (e?.message?.toLowerCase().includes('token') ||
-              e?.message?.toLowerCase().includes('jwt')) &&
-            e?.message?.toLowerCase().includes('expired');
+          //    - Error message referencing explicit token expiration or invalidity
+          const isAuthError =
+            status === 401 ||
+            errorDetail.includes('token has expired') ||
+            errorDetail.includes('jwt expired') ||
+            errorDetail.includes('invalid token') ||
+            errorDetail.includes('not authenticated');
 
-          if (isTokenExpired) {
-            // Clean local storage immediately
-            localStorage.removeItem('token');
-
+          if (isAuthError) {
             // Standardize error shape so AuthContextProvider.handleError receives status 401
-            e.statusCode = status || 401;
+            e.statusCode = 401;
             if (!e.response) {
-              e.response = { status: e.statusCode };
+              e.response = { status: 401 };
             }
           }
 
@@ -223,7 +225,10 @@ export const useApi = (onError?: OnError) => {
             }
           }
 
-          onError && onError(e);
+          // Pass standardized error to AuthContextProvider
+          if (onError) {
+            await onError(e);
+          }
           throw e;
         }
       },


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
Continued: Expired token in localStorage causes user to become stuck after Amplify v6 upgrade

After upgrading to Amplify v6, users with an expired token persisted in localStorage may become stuck in an invalid authenticated state. Amplify v5 handled the backend 401 Token has expired response as an error. As a result, the app treats the error payload as a valid user object, preventing proper logout and leaving the expired token in storage.

This issue appears more likely in normal browser mode where stale site data persists, while InPrivate/Incognito mode works because it starts with clean storage.

Acceptance Criteria
- If /users/me returns 401, the frontend treats it as an error.
- The existing logout/token cleanup logic is triggered.
- Expired token is removed
- User is redirected to the login/sign-in flow.
- Logout button visibility is no longer impacted by invalid error payloads.
- Issue is resolved in normal browser sessions with stale v5 auth/session data.
- Users can sign in successfully after the forced clean sign-out/sign-in cycle.
(CRASM-4100)
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

As soon as a token expires, the app cleanly wipes all stored credentials in the background and smoothly redirects the user back to the login page—matching the clean experience users see in Incognito mode.

**Smarter Session Detection (useApi):**
Updated the app to immediately recognize any expired session or "Unauthorized" response from the server, rather than relying on strict, specific error text formats.

**Clean Logout & Storage Reset (AuthContextProvider):**
Fixed an issue where the app's internal memory was accidentally restoring expired tokens back into browser storage right after they were deleted.

**Eliminated the "White Screen" Crash:**
Ensured that when a user's session ends, the app redirects gracefully to the login page instead of attempting to load profile data on a dead session.

## 🧪 Testing ##

Steps to test:

- Log in to the application using a valid account
- Allow the authentication token to expire
- Refresh or reopen the application in a normal browser session
- Observe that apiGet('/users/me') sends the expired token.
- Confirm the backend returns a 401 response
- Observe that Amplify v6/client logic treats the response as successful instead of throwing/catching an error.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
