### PR TITLE
Enable ARM64 in PE Docker Build Script (CRASM-4146)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 # repo. Unless a later match takes precedence, these owners will be
 # requested for review when someone opens a pull request.
 
- 
+
 * @cduhn17 @nickviola @rapidray12 @schmelz21 @hawkishpolicy @jayjaybunce @ameliav
 
 # These folks own any files in the .github directory at the root of

--- a/backend/pe/tools/build.sh
+++ b/backend/pe/tools/build.sh
@@ -3,4 +3,16 @@
 set -euo pipefail
 
 PE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-docker build --platform linux/amd64 -t pe-worker -f "${PE_DIR}/Dockerfile" "${PE_DIR}"
+
+# Default to host arch for local dev (avoids QEMU OOM issues on Apple Silicon/arm64)
+# Set PE_WORKER_PLATFORM=linux/amd64 to match Fargate/CI.
+
+if [ -z "${PE_WORKER_PLATFORM:-}" ]; then
+  case "$(uname -m)" in
+  arm64 | aarch64) PE_WORKER_PLATFORM=linux/arm64 ;;
+  *) PE_WORKER_PLATFORM=linux/amd64 ;;
+  esac
+fi
+
+echo "Building PE worker image for platform: ${PE_WORKER_PLATFORM}"
+docker build --platform "${PE_WORKER_PLATFORM}" -t pe-worker -f "${PE_DIR}/Dockerfile" "${PE_DIR}"


### PR DESCRIPTION


<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #
## Enable ARM64 in PE Docker Build Script (CRASM-4146) ##
## 🗣 Description ##
- docker build is now run with platform based on the architecture of the host machine (x86_64 or arm64).
- The build script now checks the architecture of the host machine and sets the appropriate platform for the docker build command.
- prevents arm64 builds emulatting amd64 architecture, which can lead to build failures and performance issues.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
- closes CRASM-4146
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
- tested locally
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


## 📷 Screenshots (if appropriate) ##
Initial problem:
<img width="1019" height="319" alt="Screenshot 2026-08-11 at 11 33 00 AM" src="https://github.com/user-attachments/assets/a97b8366-0c43-4127-b5a2-1e64da179db0" />

Build utilizes system arch for local build:
<img width="1019" height="764" alt="Screenshot 2026-08-11 at 1 10 55 PM" src="https://github.com/user-attachments/assets/8b237b3f-babe-46c3-87a4-1f35cc9778ef" />

Successful build of PE Report
<img width="1019" height="319" alt="Screenshot 2026-08-11 at 11 35 07 AM" src="https://github.com/user-attachments/assets/bee2756e-6e28-4624-92a4-af30860ebe08" />

Ran on amd64 machine to ensure conditional as intended:
<img width="990" height="550" alt="634430419-b6729705-e7e5-4ec5-9d9a-2d837857d8e3" src="https://github.com/user-attachments/assets/7299286d-4300-4ab7-b84e-5cf258b8938a" />


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
