### PR TITLE
4039 - Update ad-hoc OpenCTI workflow to only run apply and validate

### DIFF
--- a/.github/workflows/import-open-cti.yml
+++ b/.github/workflows/import-open-cti.yml
@@ -1,32 +1,25 @@
 ---
-# One-off, manually-triggered workflow to bring the already-existing OpenCTI EC2
-# instance (i-033771e2a6a9a26ca) into Terraform state. Run this exactly once,
-# BEFORE merging infrastructure/open_cti.tf et al. into develop -- the regular
-# Infrastructure Pipeline workflow auto-applies on push to develop with no manual
-# approval gate.
+# One-off, manually-triggered workflow to inspect a `terraform plan` against the
+# staging-cd remote state with real CI credentials, without mutating anything.
 #
-# NOTE: this instance was never actually unmanaged -- it's the same instance
-# `aws_instance.pe` has managed all along (someone repurposed the running "pe" box
-# to also host OpenCTI, out-of-band). The original version of this workflow ran
-# `terraform import aws_instance.open_cti i-033771e2a6a9a26ca` while `aws_instance.pe`
-# was still in state pointing at the same ID, leaving two state entries bound to one
-# real resource -- which corrupted the plan (spurious destroy/recreate churn). The
-# steps below correct that: drop the bad import, then rename the existing
-# `aws_instance.pe` state entry to `aws_instance.open_cti` (a state-only operation,
-# no AWS API calls against the real instance). This addressing ([0], via `count`)
-# matches PR #1530's `aws_instance.open_cti` definition.
+# This file originally performed one-time state surgery to adopt the existing
+# OpenCTI EC2 instance (i-033771e2a6a9a26ca) into Terraform state as
+# `aws_instance.open_cti` (see git history for that version, and PR discussion
+# for the corrupted-plan issue it fixed). That surgery is already complete --
+# `aws_instance.pe[0]` has been removed from state and `aws_instance.open_cti[0]`
+# is now the sole tracked address for that instance.
 #
-# Preconditions -- enforced by the pre-flight step below, noted here for a human
-# reader too:
-#   - infrastructure/pe_worker.tf's old `aws_instance.pe` block must already be
-#     removed, and infrastructure/open_cti.tf's `aws_instance.open_cti` (with
-#     `count`) must already be present, on whatever ref this is dispatched against.
-#   - `aws_instance.pe[0]` and `aws_instance.open_cti[0]` must both currently exist
-#     in remote state (the former from history, the latter from the earlier bad
-#     import).
+# This version is read-only: init + validate + plan, nothing else. No `-out` is
+# written, so there's no plan artifact anything could later `apply` -- that's
+# deliberate, not an oversight. Use this to inspect what a real plan looks like
+# with proper CI credentials before deciding whether/what to merge.
 #
-# Delete this file once the corrected plan step below shows no destructive diff.
-name: Import OpenCTI EC2 into Terraform State
+# Dispatch this from any branch that has this file -- no need to merge to
+# develop/integration first. Merging to develop triggers the regular
+# Infrastructure Pipeline (.github/workflows/infrastructure.yml), which DOES
+# auto-apply on push with no approval gate; this workflow exists specifically
+# so you can inspect a plan before that happens.
+name: Inspect OpenCTI Terraform Plan
 
 on:
   workflow_dispatch: {}
@@ -39,15 +32,12 @@ defaults:
     working-directory: ./infrastructure
 
 jobs:
-  import:
+  plan:
     runs-on: ubuntu-latest
     environment: staging
-    # Reuses the exact same group name as the `staging` job's concurrency
-    # lock in infrastructure.yml -- concurrency groups are matched repo-wide,
-    # not per-workflow, so this queues (rather than races) against both other
-    # dispatches of this workflow and the regular Infrastructure Pipeline's
-    # staging apply, which would otherwise be free to mutate the same remote
-    # state concurrently with the state rm/mv/push below.
+    # Same literal group as infrastructure.yml's staging job -- concurrency
+    # groups are matched repo-wide, not per-workflow, so this queues behind
+    # (rather than races) a real apply run instead of reading state mid-mutation.
     concurrency: '1'
     steps:
       - uses: actions/checkout@v3
@@ -65,171 +55,12 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: "us-east-1"
 
-      # Fail before mutating anything if the checked-out ref or the remote state
-      # don't match what the state surgery below assumes.
-      - name: Pre-flight checks (config + state preconditions)
-        run: |
-          set -euo pipefail
+      - name: Terraform validate
+        run: terraform validate
 
-          if grep -qE '^resource\s+"aws_instance"\s+"pe"' pe_worker.tf 2>/dev/null; then
-            echo "::error::aws_instance.pe is still declared in pe_worker.tf."
-            echo "::error::Remove it before running this workflow."
-            exit 1
-          fi
-
-          if ! grep -qE '^resource\s+"aws_instance"\s+"open_cti"' \
-            open_cti.tf 2>/dev/null; then
-            echo "::error::aws_instance.open_cti is not declared in open_cti.tf."
-            echo "::error::Nothing to adopt into."
-            exit 1
-          fi
-
-          if ! terraform state list | grep -qxF 'aws_instance.pe[0]'; then
-            echo "::error::aws_instance.pe[0] not found in remote state."
-            echo "::error::Nothing to rename -- aborting before any mutation."
-            exit 1
-          fi
-
-          if ! terraform state list | grep -qxF 'aws_instance.open_cti[0]'; then
-            echo "::error::aws_instance.open_cti[0] not found in remote state."
-            echo "::error::Expected the earlier bad import to be present."
-            echo "::error::Aborting before any mutation."
-            exit 1
-          fi
-
-          # Confirm both addresses are the SAME real instance before renaming
-          # one over the other. If the earlier import pointed at a different
-          # instance ID, rm+mv would silently orphan whichever one isn't kept.
-          state_json=$(terraform state pull)
-
-          pe_id=$(jq -r '
-            .resources[]?
-            | select(.type == "aws_instance" and .name == "pe")
-            | .instances[]?
-            | select(.index_key == 0)
-            | .attributes.id // empty
-          ' <<<"$state_json")
-
-          open_cti_id=$(jq -r '
-            .resources[]?
-            | select(.type == "aws_instance" and .name == "open_cti")
-            | .instances[]?
-            | select(.index_key == 0)
-            | .attributes.id // empty
-          ' <<<"$state_json")
-
-          if [ -z "$pe_id" ] || [ -z "$open_cti_id" ]; then
-            echo "::error::Could not read an instance ID for pe[0] or"
-            echo "::error::open_cti[0] from state -- aborting before mutation."
-            exit 1
-          fi
-
-          if [ "$pe_id" != "$open_cti_id" ]; then
-            echo "::error::aws_instance.pe[0] is $pe_id but"
-            echo "::error::aws_instance.open_cti[0] is $open_cti_id --"
-            echo "::error::these are different real instances. Renaming would"
-            echo "::error::orphan whichever one isn't kept. Aborting."
-            exit 1
-          fi
-
-          echo "Confirmed pe[0] and open_cti[0] both reference $pe_id."
-          echo "Pre-flight checks passed."
+      - name: Terraform plan (read-only -- no -out, nothing to apply)
+        run: terraform plan -no-color -var-file=stage-cd.tfvars
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: "us-east-1"
-
-      # Local-only snapshot so a partial failure below can be undone within this
-      # same job. Deliberately not uploaded as an artifact -- state can contain
-      # secrets, and this runner is torn down at the end of the job regardless.
-      - name: Back up state before mutating
-        run: terraform state pull > pre-surgery-backup.tfstate
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: "us-east-1"
-
-      - name: Terraform state surgery (undo bad import, adopt pe as open_cti)
-        id: surgery
-        run: |
-          set -euo pipefail
-
-          terraform state rm 'aws_instance.open_cti[0]'
-          if terraform state list | grep -qxF 'aws_instance.open_cti[0]'; then
-            echo "::error::aws_instance.open_cti[0] still present after rm."
-            echo "::error::Aborting before rename."
-            exit 1
-          fi
-
-          terraform state mv 'aws_instance.pe[0]' 'aws_instance.open_cti[0]'
-          if terraform state list | grep -qxF 'aws_instance.pe[0]'; then
-            echo "::error::aws_instance.pe[0] still present after state mv."
-            exit 1
-          fi
-          if ! terraform state list | grep -qxF 'aws_instance.open_cti[0]'; then
-            echo "::error::aws_instance.open_cti[0] missing after state mv."
-            exit 1
-          fi
-
-          echo "State surgery complete: pe[0] -> open_cti[0]"
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: "us-east-1"
-
-      # If either mutation above failed partway, the real instance could be left
-      # with no state address at all (rm succeeded, mv didn't). Restore the
-      # pre-surgery snapshot immediately, in the same job, rather than leaving that
-      # for a human to notice and fix by hand later.
-      - name: Roll back state if surgery failed
-        if: failure() && steps.surgery.outcome == 'failure'
-        run: |
-          set -euo pipefail
-          echo "::error::State surgery failed partway through."
-          echo "::error::Restoring pre-surgery snapshot."
-          terraform state push -force pre-surgery-backup.tfstate
-          echo "::error::State restored to its pre-surgery snapshot."
-          echo "::error::aws_instance.pe[0] is intact; aws_instance.open_cti[0]"
-          echo "::error::is back to how it was before this run. Investigate the"
-          echo "::error::surgery step's log before retrying this workflow."
-          exit 1
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: "us-east-1"
-
-      # Fails closed if aws_instance.open_cti[0] itself would be destroyed or
-      # replaced -- the actual guarantee this workflow needs to make. Scoped to
-      # that one resource rather than the whole plan: this same plan is expected
-      # to show unrelated destroys elsewhere (email_sender, elk_stack, the old pe
-      # IAM role/profile) as part of retiring those alongside this rename, and a
-      # blanket "no deletes anywhere" check would fail on those every time.
-      - name: Terraform plan (fails on destroy/replace of open_cti instance)
-        run: |
-          set -euo pipefail
-          terraform plan -no-color -var-file=stage-cd.tfvars -out=surgery-verify.plan
-          terraform show -no-color surgery-verify.plan
-          terraform show -json surgery-verify.plan > surgery-verify.json
-
-          destructive=$(jq -r '
-            .resource_changes[]?
-            | select(.address == "aws_instance.open_cti[0]")
-            | select(.change.actions | index("delete"))
-            | .address
-          ' surgery-verify.json)
-
-          if [ -n "$destructive" ]; then
-            echo "::error::aws_instance.open_cti[0] shows a destroy/replace action."
-            echo "::error::An attribute in open_cti.tf doesn't match reality."
-            echo "::error::Do not apply. Fix the mismatch and re-run this workflow."
-            exit 1
-          fi
-
-          echo "No destructive change on aws_instance.open_cti[0]."
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: "us-east-1"
-
-      - if: ${{ always() }}
-        run: rm -f surgery-verify.plan surgery-verify.json pre-surgery-backup.tfstate


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
These updates are intended to allow a one-time execution of the import-open-cti workflow to be able to run terraform plan and validate. Due to being run within actions, the AWS account will have access to perform a realist plan run which will then be cross-checked with other developers for safety.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
