### PR TITLE
Update note to use all-orgs instead of all when referencing orgs to scan

### DIFF
--- a/docs/src/documentation-pages/dev/pe.md
+++ b/docs/src/documentation-pages/dev/pe.md
@@ -98,6 +98,11 @@ To rebuild from scratch: `make -C backend/pe syncdb-dangerously-force` then `syn
 
 Use **batch** (`all` / `DEMO`) for a simple single-worker run. Use **parallel** (`all-orgs` / `demo-orgs`) when you want multiple workers draining the queue at once. Do not combine a shortcut with named orgs.
 
+For example, to run Flare Events across all reportable organizations with two
+workers, use `ORGS=all-orgs`. Using `ORGS=all` queues one batch message, so one
+worker processes the organizations sequentially while the other workers remain
+idle.
+
 ```bash
 make -C backend/pe run SCANS=dnstwist ORGS=DHS,DHS_CISA COUNT=2
 make -C backend/pe run SCANS=dnstwist ORGS=all COUNT=1


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Update the P&E documentation to use ORGS=all-orgs when describing scans across all reportable organizations with multiple workers.
The documentation now explains the difference between:
ORGS=all, which queues one batch message for a single worker to process sequentially.
ORGS=all-orgs, which queues individual organization tasks that multiple workers can process in parallel.

## 💭 Motivation and context ##

The previous example could lead users to run multi-worker scans with ORGS=all, causing one worker to process the entire batch while the remaining workers stayed idle.
This change clarifies the correct option for parallel P&E scans and helps users distribute work across multiple worker containers as intended.

## 🧪 Testing ##

Documentation-only change. Reviewed the updated P&E instructions in docs/src/documentation-pages/dev/pe.md. No application code or runtime behavior was changed.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
