### PR TITLE
3982 - Enable logging in ecs task definition

### DIFF
--- a/backend/pe/peMailerController.py
+++ b/backend/pe/peMailerController.py
@@ -80,10 +80,19 @@ def start_fargate_mailer_task(
     """Start an ECS Fargate task that runs pe-mailer.
 
     Only overrides the env vars specific to this invocation (MAILER_REPORT_DATE/
-    MAILER_ORGS/MAILER_SUMMARY_TO/MAILER_TEST_EMAILS) -- DB credentials,
-    MAILER_ARN, REPORTS_BUCKET_NAME, and PE API creds are expected to already
-    be part of the base task definition, same as peReportController does for
-    pe-reports.
+    MAILER_ORGS/MAILER_SUMMARY_TO/MAILER_TEST_EMAILS/PE_LOG_TO_STDERR) -- DB
+    credentials, MAILER_ARN, REPORTS_BUCKET_NAME, and PE API creds are expected
+    to already be part of the base task definition, same as peReportController
+    does for pe-reports.
+
+    PE_LOG_TO_STDERR is forced on here (rather than added to the shared
+    pe_worker task definition in Terraform) specifically so it only applies to
+    pe-mailer runs -- that task definition is also used by peScanController/
+    peReportController, and this is the one path where email_reports.py's own
+    LOGGER output (its file-only default -- see email_reports.main) needs to
+    reach the awslogs driver/CloudWatch instead of vanishing with the
+    container's ephemeral filesystem when the task stops. See
+    start_local_docker_mailer_task, which already sets this for local runs.
     """
     ecs_client = boto3.client("ecs")
     cluster = os.environ["PE_FARGATE_CLUSTER_NAME"]
@@ -94,6 +103,7 @@ def start_fargate_mailer_task(
     environment = [
         {"name": "MAILER_REPORT_DATE", "value": report_date},
         {"name": "MAILER_ORGS", "value": orgs_arg},
+        {"name": "PE_LOG_TO_STDERR", "value": "true"},
     ]
     if summary_to:
         environment.append({"name": "MAILER_SUMMARY_TO", "value": summary_to})


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This change simply flips a flag in the task definition for the peMailerController. This flag swaps the logging output for the code to allow CloudWatch to pickup and generate log events for code execution.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

For context, the PE Mailer and Encryption code was merged on Friday: https://github.com/cisagov/XFD/pulls?q=is%3Apr+author%3Ajayjaybunce+is%3Aclosed. After successfully deploying the code and testing it via lambda invocation, a few issues were identified. The first issues were resolved, but after resolving those - the worker container was exiting with a 1 and no error logs were making it to CloudWatch. This PR resolves that last issue.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [x] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
