### PR TITLE
PE Serverless Auto Schedule (CRASM-4070 contd)

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -65,7 +65,8 @@ pe-requirements-audit:
 		--ignore-vuln CVE-2026-8404 \
 		--ignore-vuln CVE-2026-48588 \
 		--ignore-vuln CVE-2026-53877 \
-		--ignore-vuln CVE-2026-53878
+		--ignore-vuln CVE-2026-53878 \
+		--ignore-vuln PYSEC-2026-3717
 
 # Verify the pe-worker image built from backend/pe/Dockerfile
 PE_SMOKE_ENV = \

--- a/backend/src/tasks/functions.yml
+++ b/backend/src/tasks/functions.yml
@@ -276,10 +276,10 @@ peScanController:
     - schedule:
         name: pe-shodan-top-cves-semi-monthly
         description: "Semi-monthly shodan top CVEs scan"
-        # Runs the 1st and 19th of every month at 2:00 PM EST/EDT
+        # Runs the 1st and 19th of every month at 3:30 PM EST/EDT
         # Revert back to 1st and 16th of every month at 8:00 AM EST/EDT
         # after the first run of this task on 2024-08-19.
-        rate: cron(0 14 1,19 * ? *)
+        rate: cron(30 15 1,19 * ? *)
         method: scheduler
         timezone: America/New_York
         enabled: true

--- a/backend/src/tasks/functions.yml
+++ b/backend/src/tasks/functions.yml
@@ -276,10 +276,10 @@ peScanController:
     - schedule:
         name: pe-shodan-top-cves-semi-monthly
         description: "Semi-monthly shodan top CVEs scan"
-        # Runs the 1st and 19th of every month at 8:00 AM EST/EDT
+        # Runs the 1st and 19th of every month at 2:00 PM EST/EDT
         # Revert back to 1st and 16th of every month at 8:00 AM EST/EDT
-        # after the first run of this task on 2024-06-19.
-        rate: cron(0 8 1,19 * ? *)
+        # after the first run of this task on 2024-08-19.
+        rate: cron(0 14 1,19 * ? *)
         method: scheduler
         timezone: America/New_York
         enabled: true

--- a/infrastructure/pe_scheduler_deploy.tf
+++ b/infrastructure/pe_scheduler_deploy.tf
@@ -1,0 +1,28 @@
+# Purpose: Add permissions to the IAM Role that controlls the scheduler in AWS
+resource "aws_iam_policy" "scheduler_deploy_policy" {
+  count       = var.is_dmz ? 1 : 0
+  name        = "crossfeed-${var.stage}-scheduler-deploy-policy"
+  description = "Allow deployment of EventBridge Scheduler schedules"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "scheduler:CreateSchedule",
+          "scheduler:DeleteSchedule",
+          "scheduler:GetSchedule",
+          "scheduler:UpdateSchedule",
+        ]
+        Resource = "arn:${var.aws_partition}:scheduler:${var.aws_region}:${data.aws_caller_identity.current.account_id}:schedule/default/pe-*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_user_policy_attachment" "scheduler_deploy_user_attach" {
+  count      = var.is_dmz ? 1 : 0
+  user       = "crossfeed-deploy-staging"
+  policy_arn = aws_iam_policy.scheduler_deploy_policy[0].arn
+}


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #
## PE Serverless Auto Schedule (CRASM-4070 contd) ##
## 🗣 Description ##
- Adds permissions to the scheduler lambda function to allow it to be invoked by EventBridge.
- Temporarily change top cves cron job to today at 2pm for dry run.
 <!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
- removes deployment blocker for PE auto schedule
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
- testing in staging-cd following deployment
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
