### PR TITLE
PE Serverless Auto Schedule (CRASM-4070 the fifth)

### DIFF
--- a/backend/src/tasks/functions.yml
+++ b/backend/src/tasks/functions.yml
@@ -201,10 +201,13 @@ peScanController:
       # EventBridge evaluates in UTC by default.
 
       # Have adjusted the cron expressions below to run at the
-      # desired local time (EST/EDT).
+      # desired local time in EDT.
 
-      # Will base cron jobs on eastern time zone in the future
-      # once IAM policy issue is resolved.
+      # Cron jobs running after 1:59 AM will vary by 1 hour
+      # depending on whether DST is in effect.
+
+      # EST = UTC-5
+      # EDT = UTC-4
 
     # ORGS:
       # "all" - load is handled by one container.
@@ -239,7 +242,7 @@ peScanController:
     - schedule:
         name: pe-flare-events-semi-monthly
         description: "Semi-monthly flare events scan"
-        # Runs the 1st and 16th of every month at 4:00 AM EST/EDT
+        # Runs the 1st and 16th of every month at 12:00 AM EST/EDT
         rate: cron(0 4 1,16 * ? *)
         enabled: true
         input:
@@ -249,7 +252,7 @@ peScanController:
     - schedule:
         name: pe-flare-leaked-credentials-semi-monthly
         description: "Semi-monthly flare leaked credentials scan"
-        # Runs the 1st and 16th of every month at 10:00 AM EST/EDT
+        # Runs the 1st and 16th of every month at 5:00 AM EST/6:00 AM EDT
         rate: cron(0 10 1,16 * ? *)
         enabled: true
         input:
@@ -269,10 +272,8 @@ peScanController:
     - schedule:
         name: pe-shodan-top-cves-semi-monthly
         description: "Semi-monthly shodan top CVEs scan"
-        # Runs the 1st and 20th of every month at 1:00 PM EST/EDT
-        # Revert back to 1st and 16th of every month at 8:00 AM EST/EDT
-        # after the first run of this task on 2024-08-20.
-        rate: cron(0 17 1,20 * ? *)
+        # Runs the 1st and 16th of every month at 5:00 AM EST/6:00 AM EDT
+        rate: cron(0 10 1,16 * ? *)
         enabled: true
         input:
           scans: ["shodan_top_cves"]


### PR DESCRIPTION


<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## PE Serverless Auto Schedule (CRASM-4070 the fourth) ##
## 🗣 Description ##
Restore PE test cron job:
- restored Shodan Top CVEs semi-monthly cron job to run on the 1st and 16th of every month at 5:00 AM EST/6:00 AM EDT (cron(0 10 1,16 * ? *)).
- Updated comments to reflect the correct time for the cron job and removed outdated comments.
- Cron jobs running after 1:59 AM will vary by 1 hour depending on whether DST is in effect.
- So 10:00 AM UTC = 5:00 AM EST/6:00 AM EDT.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
- Close CRASM-4070
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
- tested in staging-cd.
- Shodan Top CVEs ran as expected.
- Confirmed in logs
- Confirmed additions to DB.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
