### PR TITLE
Adjust Payload Parameter for DNSMonitor API Call

### DIFF
--- a/backend/pe/src/pe_source/dnsmonitor/dnsmonitor_helpers.py
+++ b/backend/pe/src/pe_source/dnsmonitor/dnsmonitor_helpers.py
@@ -97,7 +97,7 @@ def get_domain_alerts(token, domain_ids, from_date, to_date):
     }
     # Make API Call
     try:
-        resp = session.get(url, headers=headers, json=payload, timeout=60)
+        resp = session.get(url, headers=headers, data=payload, timeout=60)
         resp.raise_for_status()
         resp = resp.json()
         return pd.DataFrame(resp)

--- a/backend/pe/tests/test_dnsmonitor_scan.py
+++ b/backend/pe/tests/test_dnsmonitor_scan.py
@@ -172,7 +172,7 @@ class DnsmonitorHelperTests(unittest.TestCase):
                 "authorization": f"Bearer {mock_token}",
                 "Content-Type": "application/json",
             },
-            json=mock_payload,
+            data=mock_payload,
             timeout=60,
         )
 


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

Update the get_domain_alerts() function to pass the payload as "data" instead of "json" in the API call to DNSMonitor.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

Further inspection and testing of the serverless DNSMonitor script has shown that passing the payload as "json" results in different findings be returned  than if the payload is passed as "data". After testing and comparing to the EC2 version of the DNSMonitor script, it was confirmed that "data" was the correct way to pass the payload data in the API call.

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

- Compared to EC2 version of the DNSMonitor script, the EC2 version uses "data" instead of "json"
- Imported real PE DB data into local database copy and re-compared output of EC2 and serverless DNSMonitor script to ensure the outputs of the two are exactly the same

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
