### PR TITLE
CRASM-4143: Add WAS report S3 permissions

### DIFF
--- a/infrastructure/was-reporting.tf
+++ b/infrastructure/was-reporting.tf
@@ -54,9 +54,9 @@ resource "aws_iam_role_policy" "was_reporting_s3_reports" {
       {
         Effect = "Allow"
         Action = [
-          "s3:PutObject",
-          "s3:GetObject",
           "s3:DeleteObject",
+          "s3:GetObject",
+          "s3:PutObject",
         ]
         Resource = "${aws_s3_bucket.reports_bucket.arn}/was_reports/*"
       }

--- a/infrastructure/was-reporting.tf
+++ b/infrastructure/was-reporting.tf
@@ -43,6 +43,27 @@ resource "aws_iam_role_policy_attachment" "was_reporting_ssm_core" {
   policy_arn = "arn:${var.aws_partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
+resource "aws_iam_role_policy" "was_reporting_s3_reports" {
+  count = local.create_was_reporting_instance ? 1 : 0
+  name  = "crossfeed-was-reporting-${var.stage}-s3-reports"
+  role  = aws_iam_role.was_reporting[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:PutObject",
+          "s3:GetObject",
+          "s3:DeleteObject",
+        ]
+        Resource = "${aws_s3_bucket.reports_bucket.arn}/was_reports/*"
+      }
+    ]
+  })
+}
+
 # DMZ deployments adopt the same current subnet and security group values as
 # P&E, through independent WAS variables so they can diverge later.
 data "aws_security_group" "was_reporting" {
@@ -106,5 +127,6 @@ resource "aws_instance" "was_reporting" {
     aws_iam_role.was_reporting,
     aws_iam_instance_profile.was_reporting,
     aws_iam_role_policy_attachment.was_reporting_ssm_core,
+    aws_iam_role_policy.was_reporting_s3_reports,
   ]
 }


### PR DESCRIPTION
## Summary

- Add an inline IAM policy to the WAS reporting EC2 role.
- Allow generated WAS reports to be uploaded, retrieved for mailing, and deleted during failed post-upload cleanup.
- Scope access to the `was_reports/*` prefix in the environment-specific Crossfeed reports bucket.

## Purpose

The modernized WAS reporting workflow stores generated encrypted PDF reports in the existing Crossfeed reports bucket. The WAS EC2 instance role currently has Systems Manager permissions only, so the application cannot write or retrieve report artifacts from S3.

## Security

- Grants only `s3:PutObject`, `s3:GetObject`, and `s3:DeleteObject`.
- Restricts access to `${aws_s3_bucket.reports_bucket.arn}/was_reports/*`.
- Does not grant `s3:*`, `s3:ListBucket`, ACL management, or access to unrelated bucket prefixes.
- Uses the EC2 instance role instead of static AWS credentials.

## Deployment Impact

Terraform will add one inline policy to the existing WAS reporting instance role. The policy is included in the EC2 resource dependencies so it is created before the instance is provisioned.

## Validation

- `terraform fmt -check infrastructure/was-reporting.tf`
- `terraform validate`
- `git diff --check -- infrastructure/was-reporting.tf`

All validation commands completed successfully.
