### PR TITLE
CRASM-4179: Disable AWS CLI Auto-Retry to Avoid Container/Task Duplication

### DIFF
--- a/backend/pe/tools/run_asmsync.sh
+++ b/backend/pe/tools/run_asmsync.sh
@@ -3,24 +3,98 @@
 set -euo pipefail
 
 STAGE="${STAGE:-staging-cd}"
+REGION="${AWS_REGION:-us-east-1}"
 FUNCTION="${PE_ASMSYNC_LAMBDA_FUNCTION:-crossfeed-${STAGE}-peAsmSyncController}"
 
 PHASE="${PHASE:?PHASE is required import_s3 or enumerate}"
 ORGS="${ORGS:-all}"
 TASK_COUNT="${TASK_COUNT:-1}"
+OUTPUT_FILE="$(mktemp)"
 
-PAYLOAD=$(jq -n \
+cleanup() {
+  rm -f "$OUTPUT_FILE"
+}
+trap cleanup EXIT
+
+PAYLOAD="$(jq -n \
   --arg phase "$PHASE" \
   --arg orgs "$ORGS" \
   --argjson count "$TASK_COUNT" \
   '{
     phase: $phase,
     orgs: ($orgs | split(",") | map(select(length > 0))),
-    taskCount: $count,
-  }')
+    taskCount: $count
+  }')"
 
-aws lambda invoke \
-  --function-name "$FUNCTION" \
-  --payload "$PAYLOAD" \
-  --cli-binary-format raw-in-base64-out \
-  /dev/stdout
+echo "Invoking ${FUNCTION} in ${REGION}..."
+echo "Payload: ${PAYLOAD}"
+
+# Invoke Lambda once and disable automatic AWS CLI retries
+# AWS CLI auto-retrying can lead to duplicate workers/tasks being spun up.
+if INVOKE_OUTPUT="$(
+  AWS_RETRY_MODE=standard AWS_MAX_ATTEMPTS=1 \
+    aws lambda invoke \
+      --region "$REGION" \
+      --function-name "$FUNCTION" \
+      --cli-binary-format raw-in-base64-out \
+      --output json \
+      --cli-connect-timeout 10 \
+      --cli-read-timeout 900 \
+      --payload "$PAYLOAD" \
+      "$OUTPUT_FILE" \
+      2>&1
+)"
+then
+  :
+else
+  # Capture any invocation errors so they can be written to the output file.
+  INVOKE_EXIT_CODE=$?
+
+  {
+    echo
+    echo "ERROR: Lambda invocation failed with AWS CLI exit code ${INVOKE_EXIT_CODE}."
+    printf '%s\n' "$INVOKE_OUTPUT"
+    echo
+    echo "The AWS CLI attempted the invocation once and did not retry."
+    echo "The Lambda may or may not have performed its intended work."
+    echo "Inspect the Lambda logs and ECS tasks before running this command again to avoid duplication."
+  } >>"$OUTPUT_FILE"
+
+  echo "Lambda invocation error:"
+  cat "$OUTPUT_FILE"
+  exit "$INVOKE_EXIT_CODE"
+fi
+
+echo "Lambda response:"
+cat "$OUTPUT_FILE"
+echo
+
+# Catch any Lambda function errors
+FUNCTION_ERROR="$(
+  printf '%s' "$INVOKE_OUTPUT" |
+    jq -r '.FunctionError // empty'
+)"
+
+if [[ -n "$FUNCTION_ERROR" ]]; then
+  {
+    echo
+    echo "ERROR: Lambda reported a function error: ${FUNCTION_ERROR}"
+    echo "Inspect the Lambda response and logs before running this command again."
+  } >>"$OUTPUT_FILE"
+
+  cat "$OUTPUT_FILE"
+  exit 1
+fi
+
+# Catch any non-200 status codes returned
+STATUS_CODE="$(jq -r '.statusCode // empty' "$OUTPUT_FILE")"
+if [[ -n "$STATUS_CODE" && "$STATUS_CODE" != "200" ]]; then
+  {
+    echo
+    echo "ERROR: Lambda controller returned status code ${STATUS_CODE}."
+    echo "Inspect the response and ECS tasks before running this command again."
+  } >>"$OUTPUT_FILE"
+
+  cat "$OUTPUT_FILE"
+  exit 1
+fi

--- a/backend/pe/tools/run_reports.sh
+++ b/backend/pe/tools/run_reports.sh
@@ -3,12 +3,19 @@
 set -euo pipefail
 
 STAGE="${STAGE:-staging-cd}"
+REGION="${AWS_REGION:-us-east-1}"
 FUNCTION="${PE_REPORT_LAMBDA_FUNCTION:-crossfeed-${STAGE}-peReportController}"
 
 REPORT_DATE="${REPORT_DATE:?REPORT_DATE required (YYYY-MM-DD)}"
 ORGS="${ORGS:-all}"
 TASK_COUNT="${TASK_COUNT:-1}"
 SOC_MED="${SOC_MED:-false}"
+OUTPUT_FILE="$(mktemp)"
+
+cleanup() {
+  rm -f "$OUTPUT_FILE"
+}
+trap cleanup EXIT
 
 PAYLOAD=$(jq -n \
   --arg date "$REPORT_DATE" \
@@ -22,8 +29,75 @@ PAYLOAD=$(jq -n \
     socMedIncluded: $soc
   }')
 
-aws lambda invoke \
-  --function-name "$FUNCTION" \
-  --payload "$PAYLOAD" \
-  --cli-binary-format raw-in-base64-out \
-  /dev/stdout
+echo "Invoking ${FUNCTION} in ${REGION}..."
+echo "Payload: ${PAYLOAD}"
+
+# Invoke Lambda once and disable automatic AWS CLI retries
+# AWS CLI auto-retrying can lead to duplicate workers/tasks being spun up.
+if INVOKE_OUTPUT="$(
+  AWS_RETRY_MODE=standard AWS_MAX_ATTEMPTS=1 \
+    aws lambda invoke \
+      --region "$REGION" \
+      --function-name "$FUNCTION" \
+      --cli-binary-format raw-in-base64-out \
+      --output json \
+      --cli-connect-timeout 10 \
+      --cli-read-timeout 900 \
+      --payload "$PAYLOAD" \
+      "$OUTPUT_FILE" \
+      2>&1
+)"
+then
+  :
+else
+  # Capture any invocation errors so they can be written to the output file.
+  INVOKE_EXIT_CODE=$?
+
+  {
+    echo
+    echo "ERROR: Lambda invocation failed with AWS CLI exit code ${INVOKE_EXIT_CODE}."
+    printf '%s\n' "$INVOKE_OUTPUT"
+    echo
+    echo "The AWS CLI attempted the invocation once and did not retry."
+    echo "The Lambda may or may not have performed its intended work."
+    echo "Inspect the Lambda logs and ECS tasks before running this command again to avoid duplication."
+  } >>"$OUTPUT_FILE"
+
+  echo "Lambda invocation error:"
+  cat "$OUTPUT_FILE"
+  exit "$INVOKE_EXIT_CODE"
+fi
+
+echo "Lambda response:"
+cat "$OUTPUT_FILE"
+echo
+
+# Catch any Lambda function errors
+FUNCTION_ERROR="$(
+  printf '%s' "$INVOKE_OUTPUT" |
+    jq -r '.FunctionError // empty'
+)"
+
+if [[ -n "$FUNCTION_ERROR" ]]; then
+  {
+    echo
+    echo "ERROR: Lambda reported a function error: ${FUNCTION_ERROR}"
+    echo "Inspect the Lambda response and logs before running this command again."
+  } >>"$OUTPUT_FILE"
+
+  cat "$OUTPUT_FILE"
+  exit 1
+fi
+
+# Catch any non-200 status codes returned
+STATUS_CODE="$(jq -r '.statusCode // empty' "$OUTPUT_FILE")"
+if [[ -n "$STATUS_CODE" && "$STATUS_CODE" != "200" ]]; then
+  {
+    echo
+    echo "ERROR: Lambda controller returned status code ${STATUS_CODE}."
+    echo "Inspect the response and ECS tasks before running this command again."
+  } >>"$OUTPUT_FILE"
+
+  cat "$OUTPUT_FILE"
+  exit 1
+fi

--- a/backend/pe/tools/run_scans.sh
+++ b/backend/pe/tools/run_scans.sh
@@ -112,20 +112,73 @@ PAYLOAD="$(jq -n \
 echo "Invoking ${FUNCTION} in ${REGION}..."
 echo "Payload: ${PAYLOAD}"
 
-aws lambda invoke \
-  --region "$REGION" \
-  --function-name "$FUNCTION" \
-  --cli-binary-format raw-in-base64-out \
-  --payload "$PAYLOAD" \
-  "$OUTPUT_FILE" \
-  >/dev/null
+# Invoke Lambda once and disable automatic AWS CLI retries
+# AWS CLI auto-retrying can lead to duplicate workers/tasks being spun up.
+if INVOKE_OUTPUT="$(
+  AWS_RETRY_MODE=standard AWS_MAX_ATTEMPTS=1 \
+    aws lambda invoke \
+      --region "$REGION" \
+      --function-name "$FUNCTION" \
+      --cli-binary-format raw-in-base64-out \
+      --output json \
+      --cli-connect-timeout 10 \
+      --cli-read-timeout 900 \
+      --payload "$PAYLOAD" \
+      "$OUTPUT_FILE" \
+      2>&1
+)"
+then
+  :
+else
+  # Capture any invocation errors so they can be written to the output file.
+  INVOKE_EXIT_CODE=$?
+
+  {
+    echo
+    echo "ERROR: Lambda invocation failed with AWS CLI exit code ${INVOKE_EXIT_CODE}."
+    printf '%s\n' "$INVOKE_OUTPUT"
+    echo
+    echo "The AWS CLI attempted the invocation once and did not retry"
+    echo "The Lambda may or may not have performed its intended work."
+    echo "Inspect the SQS queue, Lambda logs, and ECS tasks before running this command again to avoid duplication."
+  } >>"$OUTPUT_FILE"
+
+  echo "Lambda invocation error:"
+  cat "$OUTPUT_FILE"
+  exit "$INVOKE_EXIT_CODE"
+fi
 
 echo "Lambda response:"
 cat "$OUTPUT_FILE"
 echo
 
+# Catch any Lambda function errors
+FUNCTION_ERROR="$(
+  printf '%s' "$INVOKE_OUTPUT" |
+    jq -r '.FunctionError // empty'
+)"
+
+if [[ -n "$FUNCTION_ERROR" ]]; then
+  {
+    echo
+    echo "ERROR: Lambda reported a function error: ${FUNCTION_ERROR}"
+    echo "Inspect the Lambda response and logs before running this command again."
+  } >>"$OUTPUT_FILE"
+
+  cat "$OUTPUT_FILE"
+  exit 1
+fi
+
+# Catch any non-200 status codes returned
 STATUS_CODE="$(jq -r '.statusCode // empty' "$OUTPUT_FILE")"
 if [[ -n "$STATUS_CODE" && "$STATUS_CODE" != "200" ]]; then
+  {
+    echo
+    echo "ERROR: Lambda controller returned status code ${STATUS_CODE}."
+    echo "Inspect the response and AWS resources before running this command again."
+  } >>"$OUTPUT_FILE"
+
+  cat "$OUTPUT_FILE"
   exit 1
 fi
 

--- a/backend/src/tasks/functions.yml
+++ b/backend/src/tasks/functions.yml
@@ -186,6 +186,7 @@ queryDailyCustomerMetrics:
 peScanController:
   <<: *adot
   timeout: 900
+  maximumRetryAttempts: 0
   memorySize: 512
   handler: pe.peScanController.handler
   environment:


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Update Lambda invoke bash scripts and functions.yml so that AWS CLI doesn't automatically retry. Also increase the amount of time before AWS CLI considers an invoke to be timed out. Finally, improve error logging for Lambda invoke issues.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

P&E has been encountering problems when launching its data collection scripts using the bash scripts in backed/pe/tools/. When launching a data collection script like Flare leaked credentials with "orgs=all-orgs" and 1 worker container, it would unexpectedly launch 2-3 containers and >142 tasks in queue. For reference, a command like that should only launch 1 container and queue up 142 tasks.

After some troubleshooting, we determined the source of the issue was AWS CLI automatic retries. Essentially, when the lambda is invoked it takes >60s to queue up all 142 tasks. AWS CLI was misinterpreting this long delay as a failure, and was going off by itself to retry the command - effectively running the same invoke command 2-3 times.

We need to fix this because duplicate containers and tasks creates unnecessary duplicate script runs and drastically increases execution times

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Tested these bash script updates with the lambdas that are currently deployed in staging-cd. Confirmed that using the updated bash scripts results in the correct number of containers being spun up and 142 tasks in queue.

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
