### PR TITLE
Apply organization region filters to list selections

### DIFF
--- a/backend/src/xfd_django/xfd_api/helpers/filter_helpers.py
+++ b/backend/src/xfd_django/xfd_api/helpers/filter_helpers.py
@@ -282,10 +282,10 @@ def apply_organization_filters(base_q, filters: dict):
     if region_id:
         if not isinstance(region_id, list):
             region_id = [region_id]
-            try:
-                region_list = [int(r) for r in region_id if r is not None and r != ""]
-                q &= Q(region_id__in=region_list)
-            except ValueError:
-                # Region Ids must be integers, forcing no results query
-                q &= Q(region_id__in=[-1])
+        try:
+            region_list = [int(r) for r in region_id if r is not None and r != ""]
+            q &= Q(region_id__in=region_list)
+        except ValueError:
+            # Region Ids must be integers, forcing no results query
+            q &= Q(region_id__in=[-1])
     return q

--- a/backend/src/xfd_django/xfd_api/tests/test_filter_helpers.py
+++ b/backend/src/xfd_django/xfd_api/tests/test_filter_helpers.py
@@ -1,0 +1,57 @@
+"""Unit tests for organization search filter construction."""
+
+# Third-Party Libraries
+from django.db.models import Q
+import pytest
+from xfd_api.helpers.filter_helpers import apply_organization_filters
+
+
+@pytest.mark.parametrize(
+    "region_id,expected",
+    [
+        (1, [1]),
+        ("2", [2]),
+        ([1], [1]),
+        ([1, 2], [1, 2]),
+        (["1", "2"], [1, 2]),
+        ([1, "2", None, ""], [1, 2]),
+        ([None, ""], []),
+        ("invalid", [-1]),
+        (["invalid"], [-1]),
+        ([1, "invalid"], [-1]),
+    ],
+)
+def test_organization_region_filters(region_id, expected):
+    """Scalar and list selections must constrain regions, including invalid IDs."""
+    result = apply_organization_filters(Q(), {"region_id": region_id})
+    assert result == Q(retired=False) & Q(region_id__in=expected)
+
+
+@pytest.mark.parametrize(
+    "filters", [{}, {"region_id": None}, {"region_id": ""}, {"region_id": []}]
+)
+def test_empty_region_filters(filters):
+    """Missing or empty selections keep the active-organization filter."""
+    assert apply_organization_filters(Q(), filters) == Q(retired=False)
+
+
+def test_region_list_preserves_other_filters():
+    """Region selections must combine with existing membership and other filters."""
+    base_q = Q(id__in=["member-organization"])
+    filters = {
+        "region_id": [1, "2"],
+        "state": ["va"],
+        "name": " Agency ",
+        "acronym": " TEST ",
+    }
+    result = apply_organization_filters(base_q, filters)
+    assert result == (
+        Q(id__in=["member-organization"])
+        & Q(retired=False)
+        & Q(acronym__icontains="TEST")
+        & Q(name__icontains="Agency")
+        & Q(state__in=["VA"])
+        & Q(region_id__in=[1, 2])
+    )
+    assert base_q == Q(id__in=["member-organization"])
+    assert filters["region_id"] == [1, "2"]


### PR DESCRIPTION
## Summary

Apply the region conversion and query predicate after normalizing scalar input to a list. Previously, list-valued region selections bypassed the filter entirely.

Existing membership, retired-organization and other search filters remain intact. Empty selections and invalid-ID handling retain the existing scalar behavior.

Fixes #1603.

## Testing

- **15 focused tests pass**; eight fail against unchanged develop.
- Exercised actual Django query evaluation against isolated in-memory SQLite: selected regions match, unrelated regions and retired organizations do not, and invalid IDs produce no matches.
- Black, isort, Flake8 and `git diff --check` pass for changed files.

The tests use real Django query construction with isolated settings and no cloud credentials. The full PostgreSQL/API integration suite was not run.
