### PR TITLE
Use scalar term queries for all-region filters

### DIFF
--- a/backend/src/xfd_django/xfd_api/helpers/elastic_search.py
+++ b/backend/src/xfd_django/xfd_api/helpers/elastic_search.py
@@ -102,7 +102,10 @@ def get_term_filter(term_filter):
         search_type = "wildcard"
     elif term_filter["field"] == "services.port":
         search_type = "match"
-    elif term_filter["field"] == "organization.region_id":
+    elif (
+        term_filter["field"] == "organization.region_id"
+        and term_filter["type"] == "any"
+    ):
         search_type = "terms"
 
     # --- Special handling for vulnerabilities.severity in post_filter ---

--- a/backend/src/xfd_django/xfd_api/tests/test_elastic_search_regions.py
+++ b/backend/src/xfd_django/xfd_api/tests/test_elastic_search_regions.py
@@ -1,0 +1,106 @@
+"""Regression tests for region filters in Elasticsearch domain searches."""
+
+# Standard Python Libraries
+import unittest
+
+# Third-Party Libraries
+from xfd_api.helpers.elastic_search import (
+    build_request,
+    build_request_filter,
+    get_term_filter,
+)
+from xfd_api.schema_models.search import DomainSearchBody
+
+
+class TestRegionFilters(unittest.TestCase):
+    """Keep region conjunctions valid without changing union or access filters."""
+
+    def test_all_uses_scalar_term_queries(self):
+        """Each conjunct must be a term query, not a terms query with a scalar."""
+        for values in ([1], [1, 2], [1, 1], ["1", "2"]):
+            with self.subTest(values=values):
+                result = get_term_filter(
+                    {"field": "organization.region_id", "type": "all", "values": values}
+                )
+                self.assertEqual(
+                    result,
+                    {
+                        "bool": {
+                            "filter": [
+                                {"term": {"organization.region_id": value}}
+                                for value in values
+                            ]
+                        }
+                    },
+                )
+
+    def test_any_keeps_one_terms_query(self):
+        """Union selections still pass the complete array to a terms query."""
+        for values in ([1], [1, 2], ["1", "2"]):
+            with self.subTest(values=values):
+                result = get_term_filter(
+                    {"field": "organization.region_id", "type": "any", "values": values}
+                )
+                self.assertEqual(
+                    result,
+                    {
+                        "bool": {
+                            "should": [{"terms": {"organization.region_id": values}}],
+                            "minimum_should_match": 1,
+                        }
+                    },
+                )
+
+    def test_empty_all_is_unchanged(self):
+        """An empty conjunction retains the existing no-op representation."""
+        self.assertEqual(
+            get_term_filter(
+                {"field": "organization.region_id", "type": "all", "values": []}
+            ),
+            {"bool": {"filter": []}},
+        )
+
+    def test_region_and_other_filters_are_combined(self):
+        """The fix must preserve sibling filters and the post-filter boundary."""
+        filters, post_filter = build_request_filter(
+            [
+                {"field": "organization.region_id", "type": "all", "values": [1]},
+                {"field": "from_root_domain", "type": "all", "values": [True]},
+            ],
+            False,
+        )
+        self.assertEqual(
+            filters,
+            [
+                {"bool": {"filter": [{"term": {"organization.region_id": 1}}]}},
+                {"bool": {"filter": [{"term": {"from_root_domain": True}}]}},
+            ],
+        )
+        self.assertIsNone(post_filter)
+
+    def test_domain_request_retains_organization_scope(self):
+        """The complete request keeps its organization restriction intact."""
+        request = build_request(
+            DomainSearchBody(
+                filters=[
+                    {
+                        "field": "organization_id",
+                        "type": "any",
+                        "values": [{"id": "visible-org"}],
+                    },
+                    {"field": "organization.region_id", "type": "all", "values": [1]},
+                ]
+            )
+        )
+        scoped_query = request["query"]["bool"]["must"]
+        self.assertEqual(
+            scoped_query[0], {"terms": {"organization.id.keyword": ["visible-org"]}}
+        )
+        self.assertEqual(
+            scoped_query[1]["bool"]["filter"],
+            [{"bool": {"filter": [{"term": {"organization.region_id": 1}}]}}],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fix region filters with type "all" in Elasticsearch domain searches. The existing code sends a scalar to a terms query for each selected region, which Elasticsearch rejects with HTTP 400 even for a single selection.

Use scalar term clauses for conjunctions while retaining the existing terms array for "any". Organization scope and other filters remain unchanged. This is separate from #1604.

## Testing

- Five regression test methods pass, covering numeric/string IDs, duplicates, empty selections, sibling filters and organization scoping. Six subcases fail on unchanged develop.
- Ten result checks pass against an isolated Elasticsearch 8.19.21 instance. The original single-region "all" query reproduces HTTP 400.
- Black 23.9.1, test import formatting, Python compilation and git diff --check pass.
- Validation: https://github.com/sylvesterkaczmarek/XFD/actions/runs/34514021322

The full Django/PostgreSQL/API suite was not run. Only synthetic local test data was used. The validation workflow remains on a separate fork branch and is excluded from this PR.