### PR TITLE
CRASM-4262: Update ASM Sync to Log to Stderr

### DIFF
--- a/backend/pe/src/pe_asm/asm_sync.py
+++ b/backend/pe/src/pe_asm/asm_sync.py
@@ -39,6 +39,29 @@ from schema import And, Schema, SchemaError, Use
 LOGGER = logging.getLogger(__name__)
 
 
+def _configure_console_logging(log_level: str) -> None:
+    """Mirror logs to stderr for cloudwatch."""
+    level = getattr(logging, log_level.upper())
+    root = logging.getLogger()
+    root.setLevel(level)
+
+    formatter = logging.Formatter(
+        "%(asctime)s %(levelname)s %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+    for handler in root.handlers:
+        if isinstance(handler, logging.StreamHandler) and handler.stream is sys.stderr:
+            handler.setLevel(level)
+            handler.setFormatter(formatter)
+            return
+
+    console = logging.StreamHandler(sys.stderr)
+    console.setLevel(level)
+    console.setFormatter(formatter)
+    root.addHandler(console)
+
+
 def run_asm_sync(phase, orgs_list):
     """Run either the ASM Sync local or remote scripts."""
     if phase == "import_s3":
@@ -85,6 +108,8 @@ def main():
         datefmt="%m/%d/%Y %I:%M:%S",
         level=log_level.upper(),
     )
+    # Mirror logs to stderr for Cloudwatch
+    _configure_console_logging(log_level)
     # Run ASM Sync
     run_asm_sync(
         validated_args["PHASE"],


### PR DESCRIPTION

<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

Updates P&E's ASM Sync scripts to log to stderr so they can be viewed in Cloudwatch

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

Currently, P&E's ASM Sync scripts are the only P&E scripts that do not log to stderr/stdout in some form (they only log to a central logging file inside the worker), resulting in difficulty gauging ASM Sync worker progress when viewing them in Cloudwatch. 

## 🧪 Testing ##

Ran the updated ASM Sync scripts locally and confirmed expected logging statements are now visible 

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
